### PR TITLE
Correzioni urgenti audit: USR (rimozione falsa validazione) + PCTO (monte ore) + mappa-sito + box anti-paura

### DIFF
--- a/content/formazione/educazione-civica/_index.md
+++ b/content/formazione/educazione-civica/_index.md
@@ -157,7 +157,13 @@ Per organizzare un incontro: scrivere a **[segreteria@protezionecivilegenzano.it
 
 ## Disponibilità PCTO {#disponibilita-pcto}
 
-Il Gruppo è disponibile a **ospitare studenti delle scuole superiori** per percorsi PCTO (Percorsi per le Competenze Trasversali e l'Orientamento) — minimo 30 ore per i licei, fino a 150 per i tecnici.
+Il Gruppo è disponibile a **ospitare studenti delle scuole superiori** per percorsi PCTO (Percorsi per le Competenze Trasversali e l'Orientamento) con **moduli da 30 a 50 ore**, adattabili all'indirizzo e **riconoscibili all'interno del monte ore PCTO complessivo previsto dall'Istituto**:
+
+- almeno **90 ore** nei Licei,
+- almeno **150 ore** negli Istituti Tecnici,
+- almeno **210 ore** negli Istituti Professionali
+
+(monte ore minimo triennale ridefinito dall'**art. 1, comma 785 della L. 145/2018** e specificato dal **D.M. 774/2019** sulle linee guida PCTO).
 
 **Aree possibili**:
 - Mappatura del territorio e cartografia operativa
@@ -166,11 +172,31 @@ Il Gruppo è disponibile a **ospitare studenti delle scuole superiori** per perc
 - Documentazione fotografica e video di eventi formativi
 - Manutenzione mezzi e attrezzature (sotto supervisione)
 
-**Procedura**: contattare la segreteria del Gruppo per l'avvio della convenzione attuativa con l'Istituto. La convenzione viene formalizzata con il Dirigente scolastico, validata dall'Ufficio Scolastico Regionale, e prevede tutoraggio interno + esterno.
+**Sicurezza degli studenti in PCTO**: prima dell'avvio è prevista la **formazione generale sulla sicurezza** (almeno 4 ore, art. 37 D.Lgs. 81/2008 e Accordo Stato-Regioni 21/12/2011) e, quando l'attività lo richiede, una **formazione specifica** sui rischi del contesto. La copertura assicurativa, la valutazione dei rischi e l'individuazione delle misure di prevenzione restano in capo all'Istituto scolastico (datore di lavoro di fatto degli studenti in PCTO).
+
+**Procedura**: contattare la segreteria del Gruppo per la stipula di una **convenzione attuativa** con il Dirigente scolastico, secondo le procedure interne dell'Istituto. La convenzione regola tutoraggio interno + esterno, monte ore, copertura assicurativa, modalità di valutazione.
 
 > ⚠️ **L'ammissione al programma PCTO è soggetta all'incondizionabile giudizio del Coordinatore e del Consiglio Direttivo del Gruppo Comunale**, che valutano caso per caso la coerenza del percorso con la disponibilità operativa del Gruppo, le esigenze formative dello studente e le necessità del territorio. Il giudizio è insindacabile e non rilascia alcun automatismo all'attivazione della convenzione.
 
 ---
 
+## Stato dei materiali — coerenza con la normativa scolastica {#stato-materiali}
+
+I materiali del Gruppo sono **prodotti volontariamente** dal Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma e sono **liberamente utilizzabili dalle scuole**. La citazione del Gruppo nelle programmazioni è gradita.
+
+**Cosa NON sono i nostri materiali:**
+
+- Non sono **approvati**, **validati**, **adottati** o **certificati** da Ministero dell'Istruzione e del Merito (MIM), Ufficio Scolastico Regionale (USR) del Lazio, Ufficio Scolastico Provinciale, Comune di Genzano di Roma, ASL Roma 6, Dipartimento Nazionale di Protezione Civile.
+- Non costituiscono **testi scolastici** ai sensi del D.Lgs. 297/1994 né rientrano in elenchi ministeriali di materiali ufficialmente validati.
+- Non sostituiscono i **libri di testo** adottati dal collegio dei docenti né i materiali del **piano dell'offerta formativa** dell'Istituto.
+
+**Cosa sono i nostri materiali:**
+
+I materiali sono **progettati per tendere agli obiettivi formativi definiti dalla normativa scolastica vigente** — Indicazioni Nazionali per il Curricolo, Linee Guida del D.M. 183/2024 sull'Educazione Civica (3 Nuclei Concettuali: Costituzione, Sostenibilità, Cittadinanza Digitale), competenze chiave europee per l'apprendimento permanente (Raccomandazione UE 22 maggio 2018), Goal dell'Agenda 2030 ONU. La coerenza con questi riferimenti è dichiarata in modo trasparente nelle sezioni "Per il/la docente" e nei riferimenti normativi a piè di pagina.
+
+La **valutazione finale** di idoneità all'uso in classe e di adeguatezza al gruppo classe specifico spetta al **docente**, in autonomia professionale e in coerenza con la programmazione del consiglio di classe e con il piano dell'offerta formativa dell'Istituto.
+
+---
+
 **Ultimo aggiornamento**: 1 maggio 2026.
-**Riferimenti normativi**: L. 92/2019 (art. 3 lett. h sulla protezione civile, lett. h-ter sulla sicurezza nei luoghi di lavoro come modificata dalla L. 21/2025) · D.M. 7 settembre 2024 n. 183 (a.s. 2024/2025) · L. 17 febbraio 2025 n. 21 · D.Lgs. 1/2018 · D.Lgs. 66/2017 · D.Lgs. 81/2008 · Raccomandazione UE 22 maggio 2018 sulle competenze chiave per l'apprendimento permanente · Agenda 2030 ONU.
+**Riferimenti normativi**: L. 92/2019 (art. 3 lett. h sulla protezione civile, lett. h-ter sulla sicurezza nei luoghi di lavoro come modificata dalla L. 21/2025) · D.M. 7 settembre 2024 n. 183 (a.s. 2024/2025) · L. 17 febbraio 2025 n. 21 · D.Lgs. 1/2018 · D.Lgs. 66/2017 · D.Lgs. 81/2008 · L. 145/2018 (art. 1 c. 785 sul monte ore PCTO) · D.M. 774/2019 (Linee guida PCTO) · D.Lgs. 77/2005 · D.Lgs. 62/2017 · Raccomandazione UE 22 maggio 2018 sulle competenze chiave per l'apprendimento permanente · Agenda 2030 ONU.

--- a/content/formazione/kit-scuola-infanzia.md
+++ b/content/formazione/kit-scuola-infanzia.md
@@ -9,6 +9,8 @@ Questo kit è pensato per gli insegnanti della **scuola dell'infanzia** che desi
 
 I contenuti sono stati sviluppati dal Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma per le attività di divulgazione nelle scuole del territorio.
 
+> ⚠️ **Avvertenza pedagogica — non spaventare i bambini.** Le attività di questo kit **non devono mai generare paura**. I bambini di 3-6 anni hanno una percezione del rischio molto diversa da quella dell'adulto: parlare di terremoti, incendi o allagamenti in modo enfatico o con immagini drammatiche può produrre **ansia, incubi, regressioni**. La regola è opposta: presentare i comportamenti corretti come **un gioco rassicurante** (la tartaruga che si ripara, il numero 112 come "amico che arriva"), proporzionato all'età, sempre concluso con la rassicurazione che **gli adulti sono lì per proteggerli**. Niente video reali di disastri, niente cronaca, niente racconto di vittime. Per la dimensione emotiva si rimanda alla pagina [Psicologia dell'emergenza](/formazione/psicologia-emergenza/).
+
 ---
 
 ## Guida per il docente

--- a/content/formazione/kit-scuola-primaria.md
+++ b/content/formazione/kit-scuola-primaria.md
@@ -9,6 +9,8 @@ Questo kit è pensato per gli insegnanti della **scuola primaria** che desideran
 
 I contenuti sono stati sviluppati dal Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma e sono adatti a bambini dai 6 agli 11 anni, con attività differenziate per le classi iniziali (I-II) e per le classi finali (III-IV-V).
 
+> ⚠️ **Avvertenza pedagogica — proporzionare l'argomento all'età.** Le attività di questo kit affrontano rischi reali (terremoto, alluvione, incendio, blackout, eventi storici) ma **non devono generare paura o ansia**. Il docente è chiamato a presentare i fenomeni in modo **concreto, rassicurante, agentivo**: l'attenzione è sui *comportamenti corretti che il bambino può fare* (preparare lo zaino, conoscere il punto di raccolta, chiamare il 112), non sull'enfasi del danno. Le case study delle maxi-emergenze italiane sono adattate per la fascia 9-11 anni con focus su lieto fine, ricostruzione, solidarietà — **mai con immagini di vittime o cronaca cruda**. Se nella classe ci sono bambini reduci da eventi traumatici familiari (lutti, evacuazioni, terremoti recenti), valutare con cautela e raccordarsi con il dirigente scolastico, lo psicologo scolastico e con la pagina [Psicologia dell'emergenza](/formazione/psicologia-emergenza/).
+
 ---
 
 ## Guida per il docente

--- a/content/formazione/percorsi-didattici/_index.md
+++ b/content/formazione/percorsi-didattici/_index.md
@@ -253,9 +253,9 @@ Rubrica fascia, indicatori 2 (comunicazione del rischio), 6 (cittadinanza attiva
 | 5 (PCTO) | Testimonianza diretta di un volontario PC su un infortunio reale evitato grazie alla formazione | Visita al Gruppo o intervento di un volontario in classe |
 | 6 (PCTO) | Stesura di una **Procedura Operativa Standard** sintetica per un'attività della propria scuola | Lavoro di gruppo, restituzione in plenaria |
 
-### Connessione con il PCTO (D.Lgs. 77/2005)
+### Connessione con il PCTO (D.Lgs. 77/2005, L. 145/2018, D.M. 774/2019)
 
-Il percorso può essere riconosciuto come parte delle ore di sicurezza obbligatorie nei PCTO. Il Gruppo Comunale è disponibile a **ospitare studenti** per percorsi PCTO sui temi di **mappatura del territorio, comunicazione del rischio, supporto a esercitazioni**. Procedura e condizioni nella [pagina docenti — sezione PCTO](/formazione/educazione-civica/#disponibilita-pcto).
+Il percorso può essere riconosciuto come parte delle ore di sicurezza obbligatorie nei PCTO, all'interno del **monte ore minimo triennale** previsto dall'art. 1 comma 785 della **L. 145/2018**: almeno **90 ore nei Licei**, **150 nei Tecnici**, **210 nei Professionali**. Il Gruppo Comunale è disponibile a **ospitare studenti** per moduli da 30-50 ore sui temi di **mappatura del territorio, comunicazione del rischio, supporto a esercitazioni**. Procedura, sicurezza e condizioni nella [pagina docenti — sezione PCTO](/formazione/educazione-civica/#disponibilita-pcto).
 
 ### Competenze chiave europee mobilitate
 
@@ -300,4 +300,4 @@ Scrivere a **[segreteria@protezionecivilegenzano.it](mailto:segreteria@protezion
 ---
 
 **Ultimo aggiornamento**: 1 maggio 2026.
-**Riferimenti normativi**: L. 92/2019 (art. 3 lett. h e h-ter) · D.M. 7 settembre 2024 n. 183 (a.s. 2024/2025) · L. 17 febbraio 2025 n. 21 · D.Lgs. 1/2018 · D.Lgs. 81/2008 · D.Lgs. 77/2005 (PCTO) · D.M. 26/08/1992 (prevenzione incendi nelle scuole) · Raccomandazione UE 22 maggio 2018.
+**Riferimenti normativi**: L. 92/2019 (art. 3 lett. h e h-ter) · D.M. 7 settembre 2024 n. 183 (a.s. 2024/2025) · L. 17 febbraio 2025 n. 21 · D.Lgs. 1/2018 · D.Lgs. 81/2008 · D.Lgs. 77/2005 (PCTO) · L. 145/2018 (art. 1 c. 785 monte ore PCTO) · D.M. 774/2019 (Linee guida PCTO) · D.Lgs. 62/2017 · D.M. 26/08/1992 (prevenzione incendi nelle scuole) · Raccomandazione UE 22 maggio 2018.

--- a/content/mappa-sito/_index.md
+++ b/content/mappa-sito/_index.md
@@ -180,6 +180,11 @@ In questa pagina trovi **tutte le sezioni del sito** organizzate per tema. Se no
   <p class="ms-card-title">Terremoto</p>
   <p class="ms-card-desc">Comportamenti prima/durante/dopo, mappa terremoti recenti INGV, Genzano in zona sismica 2B.</p>
 </a>
+<a class="ms-card ms-emerg" href="/rischi-prevenzione/rischio-vulcanico/">
+  <div class="ms-card-icon"><i class="bi bi-droplet-half"></i></div>
+  <p class="ms-card-title">Rischio vulcanico (Colli Albani)</p>
+  <p class="ms-card-desc">Vulcano Laziale quiescente, sismicità di bassa magnitudo, emissioni di CO₂ in spazi confinati (cantine, pozzi, scantinati). Fonti INGV e ISPRA.</p>
+</a>
 <a class="ms-card ms-emerg" href="/rischi-prevenzione/rischio-idrogeologico/">
   <div class="ms-card-icon"><i class="bi bi-water"></i></div>
   <p class="ms-card-title">Frane e alluvioni</p>
@@ -230,6 +235,16 @@ In questa pagina trovi **tutte le sezioni del sito** organizzate per tema. Se no
   <p class="ms-card-title">Hub Formazione</p>
   <p class="ms-card-desc">Punto centrale della formazione: kit didattici, schede, giochi, primo soccorso.</p>
 </a>
+<a class="ms-card ms-edu" href="/formazione/percorsi-didattici/">
+  <div class="ms-card-icon"><i class="bi bi-rocket-takeoff-fill"></i></div>
+  <p class="ms-card-title">Percorsi didattici pronti</p>
+  <p class="ms-card-desc">6 percorsi pronti all'uso per docenti con poco tempo: PC base, rischio meteo, terremoto, piano familiare, fake news, sicurezza nei luoghi di lavoro/PCTO. Ognuno con destinatari, durata, obiettivi e materiali linkati.</p>
+</a>
+<a class="ms-card ms-edu" href="/formazione/educazione-civica/">
+  <div class="ms-card-icon"><i class="bi bi-mortarboard-fill"></i></div>
+  <p class="ms-card-title">Per i docenti — Ed. Civica</p>
+  <p class="ms-card-desc">Mappa dei materiali sui 3 Nuclei Concettuali del D.M. 183/2024 (a.s. 2024/2025), Goal Agenda 2030, calendario delle 33 ore, rubriche di valutazione, sezione PCTO e disponibilità del Gruppo nelle scuole.</p>
+</a>
 <a class="ms-card ms-edu" href="/formazione/schede-stampabili/">
   <div class="ms-card-icon"><i class="bi bi-printer-fill"></i></div>
   <p class="ms-card-title">Schede stampabili</p>
@@ -269,6 +284,16 @@ In questa pagina trovi **tutte le sezioni del sito** organizzate per tema. Se no
   <div class="ms-card-icon"><i class="bi bi-heart-fill"></i></div>
   <p class="ms-card-title">Abili a Proteggere</p>
   <p class="ms-card-desc">32 attività accessibili per persone con difficoltà cognitive o motorie, anziani e bambini fragili: pulsanti grandi, testi semplici, nessun timer.</p>
+</a>
+<a class="ms-card ms-edu" href="/formazione/easy-to-read-scuola/">
+  <div class="ms-card-icon"><i class="bi bi-bookmark-heart-fill"></i></div>
+  <p class="ms-card-title">Easy-to-Read per le scuole</p>
+  <p class="ms-card-desc">4 schede semplificate (112, terremoto, evacuazione, zaino) con frasi corte e pittogrammi ARASAAC. Per alunni con disabilità intellettiva, BES/DSA, italiano L2.</p>
+</a>
+<a class="ms-card ms-edu" href="/formazione/psicologia-emergenza/">
+  <div class="ms-card-icon"><i class="bi bi-emoji-smile"></i></div>
+  <p class="ms-card-title">Psicologia dell'emergenza</p>
+  <p class="ms-card-desc">Reazioni emotive normali e segnali di attenzione, modello OMS Psychological First Aid (Look · Listen · Link), indicazioni per fascia d'età e per la scuola dopo un evento avverso. Pagina divulgativa: non sostituisce lo psicologo.</p>
 </a>
 <a class="ms-card ms-edu" href="/glossario/">
   <div class="ms-card-icon"><i class="bi bi-book"></i></div>


### PR DESCRIPTION
## Sommario

Correzioni urgenti emerse dall'audit dell'utente in data 2026-05-01, dopo il merge di PR #33.

## Correzioni applicate

### 🔴 CRITICA — Rimozione falsa validazione USR
La pagina `/formazione/educazione-civica/` affermava che "la convenzione PCTO è validata dall'Ufficio Scolastico Regionale". **Era falso**: nessun USR ha mai validato né approvato i materiali del Gruppo. Sostituito con:
- nuova sezione **"Stato dei materiali — coerenza con la normativa scolastica"** che dichiara in modo trasparente:
  - cosa NON sono i materiali: **NON approvati/validati/adottati/certificati** da MIM, USR del Lazio, USP, Comune di Genzano, ASL Roma 6, DPC; non sono testi scolastici ai sensi del D.Lgs. 297/1994;
  - cosa **SONO**: materiali volontari, liberamente utilizzabili dalle scuole, progettati per **tendere agli obiettivi formativi definiti dalla normativa scolastica vigente** (Indicazioni Nazionali, D.M. 183/2024, competenze chiave UE, Agenda 2030);
  - la valutazione finale di idoneità in classe spetta al **docente** in autonomia professionale.
- procedura PCTO riformulata: "stipula di convenzione attuativa con il Dirigente scolastico, secondo le procedure interne dell'Istituto" (niente più "validazione USR").

### 🔴 ALTA — PCTO monte ore minimo triennale
Riferimenti pre-esistenti errati: "minimo 30 ore per i licei, fino a 150 per i tecnici". Sostituiti con:
- **moduli del Gruppo da 30-50 ore**, riconoscibili all'interno del monte ore PCTO complessivo previsto dall'Istituto;
- monte ore minimo: **90 ore Licei · 150 Tecnici · 210 Professionali** (L. 145/2018 art. 1 c. 785; D.M. 774/2019);
- aggiunta sezione esplicita sulla **sicurezza in PCTO**: 4 ore di formazione generale ex art. 37 D.Lgs. 81/2008 + Accordo Stato-Regioni 21/12/2011 + formazione specifica quando l'attività lo richiede;
- riferimenti normativi completati (L. 145/2018, D.M. 774/2019, D.Lgs. 62/2017) sia in `/formazione/educazione-civica/` sia in `/formazione/percorsi-didattici/`.

### 🟡 ALTA — Mappa del sito allineata alla nuova architettura
Aggiunte 5 card mancanti dopo il merge di PR #33:
- "Rischio vulcanico (Colli Albani)" (sezione Cosa fare in caso di…);
- "Percorsi didattici pronti" + "Per i docenti — Ed. Civica" (sezione Formazione e didattica);
- "Easy-to-Read per le scuole" + "Psicologia dell'emergenza" (sezione Formazione e didattica).
Tutti i 5 link verificati: pagine target esistenti.

### 🟡 ALTA — Box anti-paura su kit infanzia + primaria
Avvertenza pedagogica esplicita all'inizio dei due kit: "le attività **non devono mai generare paura** o ansia". Niente video reali di disastri, niente cronaca cruda, focus su **comportamenti agentivi** e rassicurazione. Per la dimensione emotiva, cross-link alla nuova `/formazione/psicologia-emergenza/`.

## File toccati

```
content/formazione/educazione-civica/_index.md
content/formazione/kit-scuola-infanzia.md
content/formazione/kit-scuola-primaria.md
content/formazione/percorsi-didattici/_index.md
content/mappa-sito/_index.md
```

## Cosa NON è in questa PR (rimandato a follow-up dopo confronto con l'utente)

L'audit dell'utente segnalava anche queste richieste, di portata maggiore e che richiedono nuove pagine ex novo o ridisegno UX:

- **Pagina "Scuole: scegli il tuo percorso"** (cruscotto unico per docenti)
- **Pagina "Quadro normativo scuola"** (riassunto unico delle norme)
- **Pacchetti PDF scaricabili** per fascia (PDF docente, PDF alunni, griglia, verifica, soluzioni, attestato, liberatoria, modulo richiesta)
- **Pagina dedicata Dirigente scolastico / RSPP** (ruoli, limiti di responsabilità del Gruppo)
- **Liberatorie immagini per minori** (privacy GDPR)
- **Rinforzo box "non sostituisce RSPP / scuola / ASL / psicologo"** dove serve
- **Indici e download sintetici** sulle pagine lunghe

Questi blocchi saranno proposti separatamente dopo allineamento sul perimetro con l'utente.

## Test plan

- [ ] Verifica deploy.yml verde
- [ ] Verifica live `/formazione/educazione-civica/` — sezione "Stato dei materiali" e nuova sezione PCTO con monte ore corretto
- [ ] Verifica live `/mappa-sito/` con le 5 nuove card
- [ ] Verifica live kit infanzia + primaria con box anti-paura visibile
- [ ] Workflow `audit-sito.yml` resta verde


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q23fQbZ1BjsLo4x8dASmBi)_