### PR TITLE
Giochi responsive su tutti i viewport + icone vettoriali in trova-cartello

### DIFF
--- a/static/giochi/assets/css/giochi.css
+++ b/static/giochi/assets/css/giochi.css
@@ -240,3 +240,51 @@
   body { background: #fff; }
   .gioco-fine { break-inside: avoid; }
 }
+
+/* ── Guardrail responsive globale per i giochi ─────────────── */
+/* Evita overflow orizzontale su mobile <360px e su tutte le pagine
+   gioco statiche (fuori da Hugo): immagini, video, canvas e svg
+   non superano mai la larghezza del contenitore. */
+.giochi-section img,
+.giochi-section svg,
+.giochi-section video,
+.giochi-section canvas,
+.giochi-section iframe {
+  max-width: 100%;
+  height: auto;
+}
+.giochi-section .container,
+.giochi-section .container-fluid {
+  overflow-x: clip;
+}
+/* Tabelle non native si reflowano automaticamente */
+.giochi-section table {
+  width: 100%;
+  table-layout: auto;
+}
+/* Pulsanti non eccedono mai il viewport */
+.giochi-section .btn {
+  max-width: 100%;
+  white-space: normal;
+}
+/* Focus visibile minimo */
+.giochi-section button:focus-visible,
+.giochi-section [role="button"]:focus-visible {
+  outline: 3px solid #ffbe2e;
+  outline-offset: 2px;
+}
+
+/* Stat-box flessibili: su mobile <360px non eccedono il viewport.
+   Il valore min-width definito nei singoli giochi era 110-140px:
+   con clamp() scala fino a 88px su tiny phones senza perdere leggibilità. */
+.stat-box,
+.stat-row > * {
+  min-width: clamp(88px, 28vw, 140px) !important;
+}
+/* Stat-row: gestisce wrapping pulito su tutti i viewport */
+.stat-row {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  justify-content: center !important;
+  gap: .5rem;
+}

--- a/static/giochi/infanzia/assets/infanzia.css
+++ b/static/giochi/infanzia/assets/infanzia.css
@@ -66,10 +66,10 @@ body.inf-body {
   align-items: center;
   justify-content: center;
   gap: .5rem;
-  min-width: 140px;
-  min-height: 90px;
-  padding: 1rem 1.5rem;
-  font-size: 1.25rem;
+  min-width: clamp(120px, 38vw, 140px);
+  min-height: clamp(72px, 22vw, 90px);
+  padding: clamp(.7rem, 3vw, 1rem) clamp(1rem, 4vw, 1.5rem);
+  font-size: clamp(1rem, 4vw, 1.25rem);
   font-weight: 800;
   border-radius: 20px;
   border: 3px solid transparent;
@@ -78,6 +78,7 @@ body.inf-body {
   color: #fff;
   box-shadow: 0 6px 0 rgba(0,0,0,.15);
   transition: transform .15s;
+  max-width: 100%;
 }
 .inf-big-btn:hover, .inf-big-btn:focus {
   transform: translateY(-3px);

--- a/static/giochi/infanzia/trova-cartello/index.html
+++ b/static/giochi/infanzia/trova-cartello/index.html
@@ -44,28 +44,35 @@
       z-index: 1;
     }
     .cartelli {
-      display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem;
-      max-width: 520px; margin: 0 auto;
+      display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: clamp(.6rem, 3vw, 1rem);
+      width: 100%; max-width: 520px; margin: 0 auto;
     }
     .cartello-btn {
-      aspect-ratio: 1; min-height: 120px;
+      aspect-ratio: 1; width: 100%;
       border-radius: 20px; border: 4px solid transparent;
       background: #fff;
       display: flex; align-items: center; justify-content: center;
-      font-size: 4.5rem; line-height: 1;
+      padding: clamp(.5rem, 3vw, 1rem);
       box-shadow: 0 6px 0 rgba(0,0,0,.15);
       cursor: pointer; user-select: none;
       transition: transform .15s;
       position: relative;
+    }
+    .cartello-btn img.cartello-img {
+      width: 100%; height: 100%;
+      max-width: 140px; max-height: 140px;
+      object-fit: contain;
+      pointer-events: none;
+      display: block;
     }
     .cartello-btn:focus { outline: 4px solid var(--inf-blu, #003366); outline-offset: 4px; }
     .cartello-btn:hover { transform: translateY(-2px); }
     .cartello-btn:active { transform: translateY(2px); box-shadow: 0 2px 0 rgba(0,0,0,.15); }
     .cartello-btn.sfondo-giallo  { background: #fff3cd; border-color: #b45309; }
     .cartello-btn.sfondo-rosso   { background: #fff;    border-color: #dc3545; }
-    .cartello-btn.sfondo-blu     { background: #cfe2ff; border-color: #0d6efd; border-radius: 50%; }
+    .cartello-btn.sfondo-blu     { background: #cfe2ff; border-color: #0d6efd; }
     .cartello-btn.sfondo-verde   { background: #d1e7dd; border-color: #198754; }
-    .cartello-btn.sfondo-uscita  { background: #198754; color: #fff; border-color: #0f5132; }
+    .cartello-btn.sfondo-uscita  { background: #d1e7dd; border-color: #0f5132; }
     .cartello-btn.sfondo-vvf     { background: #f8d7da; border-color: #dc3545; }
     .cartello-btn.correct { animation: inf-pulse-green .6s ease; box-shadow: 0 0 0 6px #198754; }
     .cartello-btn.wrong   { animation: inf-shake .4s ease; box-shadow: 0 0 0 6px #dc3545; }
@@ -73,16 +80,13 @@
 
     .progress-dots {
       display: flex; justify-content: center; gap: .4rem; margin-bottom: .8rem;
+      flex-wrap: wrap;
     }
     .progress-dots .dot {
       width: 14px; height: 14px; border-radius: 50%; background: #cfd6df;
     }
     .progress-dots .dot.done { background: var(--inf-verde, #198754); }
     .progress-dots .dot.now  { background: var(--inf-blu, #003366); }
-
-    @media (max-width: 400px) {
-      .cartello-btn { font-size: 3.4rem; }
-    }
   </style>
 </head>
 <body class="inf-body">
@@ -140,24 +144,28 @@
   (function () {
     'use strict';
 
-    // Catalogo cartelli: 16 opzioni (4 nuove)
+    // Catalogo cartelli: 16 opzioni con pittogrammi ISO 7010 ufficiali
+    // (static/pittogrammi/iso7010/, PD-shape/CC0 da Wikimedia) e ARASAAC
+    // (CC BY-NC-SA 4.0) per i concetti che ISO non copre direttamente.
+    var ISO  = '/pittogrammi/iso7010/';
+    var ARAS = '/pittogrammi/arasaac/';
     var CATALOGO = {
-      fuoco:     { glyph: '\uD83D\uDD25', sfondo: 'sfondo-giallo', nome: 'il fuoco' },
-      alta:      { glyph: '\u26A1',         sfondo: 'sfondo-giallo', nome: 'l\'alta tensione (la corrente elettrica)' },
-      scivolo:   { glyph: '\u26A0\uFE0F',   sfondo: 'sfondo-giallo', nome: 'attenzione: pavimento scivoloso' },
-      caduta:    { glyph: '\u2757',         sfondo: 'sfondo-giallo', nome: 'attenzione al rischio di caduta' },
-      fumo:      { glyph: '\uD83D\uDEAD', sfondo: 'sfondo-rosso',  nome: 'vietato fumare' },
-      entrare:   { glyph: '\uD83D\uDEAB', sfondo: 'sfondo-rosso',  nome: 'vietato entrare' },
-      ascensore: { glyph: '\uD83D\uDEC8', sfondo: 'sfondo-rosso',  nome: 'vietato usare l\'ascensore' },
-      mangiare:  { glyph: '\uD83C\uDF54', sfondo: 'sfondo-rosso',  nome: 'vietato mangiare e bere' },
-      casco:     { glyph: '\u26D1\uFE0F', sfondo: 'sfondo-blu',    nome: 'mettere il casco' },
-      guanti:    { glyph: '\uD83E\uDDE4', sfondo: 'sfondo-blu',    nome: 'mettere i guanti' },
-      mascherina:{ glyph: '\uD83D\uDE37', sfondo: 'sfondo-blu',    nome: 'mettere la mascherina' },
-      croce:     { glyph: '\u2795',         sfondo: 'sfondo-verde',  nome: 'il primo soccorso' },
-      raccolta:  { glyph: '\uD83D\uDC65', sfondo: 'sfondo-verde',  nome: 'il punto di raccolta' },
-      uscita:    { glyph: '\uD83D\uDEAA', sfondo: 'sfondo-uscita', nome: 'l\'uscita di emergenza' },
-      estintore: { glyph: '\uD83E\uDDEF', sfondo: 'sfondo-vvf',    nome: 'l\'estintore per spegnere il fuoco' },
-      vvf:       { glyph: '\uD83D\uDE92', sfondo: 'sfondo-vvf',    nome: 'i vigili del fuoco' }
+      fuoco:     { img: ISO  + 'materiale-infiammabile.svg',  sfondo: 'sfondo-giallo', nome: 'il fuoco' },
+      alta:      { img: ISO  + 'pericolo-elettrico.svg',      sfondo: 'sfondo-giallo', nome: 'l\'alta tensione (la corrente elettrica)' },
+      scivolo:   { img: ISO  + 'pavimento-scivoloso.svg',     sfondo: 'sfondo-giallo', nome: 'attenzione: pavimento scivoloso' },
+      caduta:    { img: ISO  + 'pericolo-generico.svg',       sfondo: 'sfondo-giallo', nome: 'attenzione al rischio di caduta' },
+      fumo:      { img: ISO  + 'vietato-fumare.svg',          sfondo: 'sfondo-rosso',  nome: 'vietato fumare' },
+      entrare:   { img: ISO  + 'vietato-pedoni.svg',          sfondo: 'sfondo-rosso',  nome: 'vietato entrare' },
+      ascensore: { img: ARAS + 'ascensore.png',               sfondo: 'sfondo-rosso',  nome: 'vietato usare l\'ascensore' },
+      mangiare:  { img: ARAS + 'cibo.png',                    sfondo: 'sfondo-rosso',  nome: 'vietato mangiare e bere' },
+      casco:     { img: ISO  + 'casco-protettivo.svg',        sfondo: 'sfondo-blu',    nome: 'mettere il casco' },
+      guanti:    { img: ISO  + 'guanti-protettivi.svg',       sfondo: 'sfondo-blu',    nome: 'mettere i guanti' },
+      mascherina:{ img: ISO  + 'maschera-protettiva.svg',     sfondo: 'sfondo-blu',    nome: 'mettere la mascherina' },
+      croce:     { img: ISO  + 'cassetta-primo-soccorso.svg', sfondo: 'sfondo-verde',  nome: 'il primo soccorso' },
+      raccolta:  { img: ISO  + 'punto-raccolta.svg',          sfondo: 'sfondo-verde',  nome: 'il punto di raccolta' },
+      uscita:    { img: ISO  + 'uscita-emergenza-destra.svg', sfondo: 'sfondo-uscita', nome: 'l\'uscita di emergenza' },
+      estintore: { img: ISO  + 'estintore.svg',               sfondo: 'sfondo-vvf',    nome: 'l\'estintore per spegnere il fuoco' },
+      vvf:       { img: ISO  + 'telefono-antincendio.svg',    sfondo: 'sfondo-vvf',    nome: 'i vigili del fuoco' }
     };
 
     // 12 domande in 2 round — round 1 piu' facile, round 2 piu' difficile
@@ -248,7 +256,13 @@
         btn.type = 'button';
         btn.className = 'cartello-btn ' + c.sfondo;
         btn.setAttribute('aria-label', 'Cartello ' + c.nome);
-        btn.textContent = c.glyph;
+        var img = document.createElement('img');
+        img.src = c.img;
+        img.alt = '';
+        img.setAttribute('aria-hidden', 'true');
+        img.className = 'cartello-img';
+        img.loading = 'lazy';
+        btn.appendChild(img);
         btn.addEventListener('click', function () { scegli(id, btn); });
         cartelliEl.appendChild(btn);
       });

--- a/static/giochi/primaria/cruciverba/css/style.css
+++ b/static/giochi/primaria/cruciverba/css/style.css
@@ -56,11 +56,11 @@
   width: fit-content;
 }
 
-/* ogni cella */
+/* ogni cella — la dimensione si adatta al viewport */
 .cell {
   position: relative;
-  width: 40px;
-  height: 40px;
+  width: clamp(24px, 7.5vw, 40px);
+  height: clamp(24px, 7.5vw, 40px);
   background: #fff;
   display: flex;
   align-items: center;
@@ -75,7 +75,7 @@
   height: 100%;
   border: 0;
   text-align: center;
-  font-size: 1.1rem;
+  font-size: clamp(.85rem, 3vw, 1.1rem);
   font-weight: 700;
   color: #003366;
   text-transform: uppercase;
@@ -192,8 +192,5 @@
   border: 1px solid #ffe69c;
 }
 
-@media (max-width: 520px) {
-  .cell { width: 32px; height: 32px; }
-  .cell input { font-size: .95rem; }
-  .cell-number { font-size: .52rem; }
-}
+/* Sizing su mobile gestito direttamente da clamp() su .cell e .cell input */
+.cell-number { font-size: clamp(.5rem, 1.7vw, .6rem); }

--- a/static/giochi/primaria/labirinto-evacuazione/index.html
+++ b/static/giochi/primaria/labirinto-evacuazione/index.html
@@ -47,20 +47,32 @@
 
     .mappa-wrap {
       display: flex; justify-content: center; margin-bottom: 1rem;
-      overflow-x: auto;
+      padding: 0 .25rem;
     }
     .mappa {
+      --mappa-cols: 10;
+      --mappa-gap: 3px;
+      --mappa-pad: 3px;
+      --mappa-max-cell: 44px;
+      --mappa-min-cell: 22px;
+      --mappa-max-w: min(560px, calc(100vw - 1.5rem));
+      --mappa-cell: clamp(
+        var(--mappa-min-cell),
+        calc((var(--mappa-max-w) - 2 * var(--mappa-pad) - (var(--mappa-cols) - 1) * var(--mappa-gap)) / var(--mappa-cols)),
+        var(--mappa-max-cell)
+      );
       display: grid;
-      gap: 3px;
+      grid-template-columns: repeat(var(--mappa-cols), var(--mappa-cell));
+      gap: var(--mappa-gap);
       background: #dee2e6;
-      padding: 3px;
+      padding: var(--mappa-pad);
       border-radius: 8px;
       box-shadow: inset 0 0 0 2px #003366;
     }
     .cell {
-      width: 44px; height: 44px;
+      width: var(--mappa-cell); height: var(--mappa-cell);
       display: flex; align-items: center; justify-content: center;
-      font-size: 1.4rem; line-height: 1;
+      font-size: calc(var(--mappa-cell) * 0.6); line-height: 1;
       border-radius: 4px; background: #fff;
       position: relative;
       user-select: none;
@@ -69,7 +81,7 @@
     .cell.empty { background: #f8f9fa; }
     .cell.corridor { background: #e7f1ff; }
     .cell.start { background: #cfe2ff; }
-    .cell.exit { background: #d1e7dd; font-size: 1.6rem; }
+    .cell.exit { background: #d1e7dd; font-size: calc(var(--mappa-cell) * 0.7); }
     .cell.elevator { background: #fff3cd; color: #664d03; }
     .cell.fire { background: #f8d7da; color: #dc3545; }
     .cell.obstacle { background: #fff3cd; color: #b45309; }
@@ -81,7 +93,7 @@
       content: "🧒";
       position: absolute; inset: 0;
       display: flex; align-items: center; justify-content: center;
-      font-size: 1.6rem;
+      font-size: calc(var(--mappa-cell) * 0.7);
       animation: pulse 1.2s ease-in-out infinite;
     }
     @keyframes pulse {
@@ -92,14 +104,15 @@
 
     .comandi {
       display: grid;
-      grid-template-columns: 60px 60px 60px;
-      grid-template-rows: 60px 60px;
+      --cmd-size: clamp(48px, 14vw, 60px);
+      grid-template-columns: repeat(3, var(--cmd-size));
+      grid-template-rows: repeat(2, var(--cmd-size));
       gap: .4rem;
       justify-content: center;
       margin: 1rem auto;
     }
     .comandi button {
-      font-size: 1.8rem; line-height: 1;
+      font-size: clamp(1.4rem, 5vw, 1.8rem); line-height: 1;
       border: 2px solid #003366; background: #fff; color: #003366;
       border-radius: 10px; cursor: pointer;
       transition: transform .08s, background .15s;
@@ -130,12 +143,7 @@
     .alert-msg.danger { background: #f8d7da; color: #842029; border: 1px solid #f5c2c7; animation: shake .3s; }
     @keyframes shake { 0%,100%{transform:translateX(0)} 25%{transform:translateX(-6px)} 75%{transform:translateX(6px)} }
 
-    @media (max-width: 575.98px) {
-      .cell { width: 36px; height: 36px; font-size: 1.1rem; }
-      .cell.player::after { font-size: 1.3rem; }
-      .comandi { grid-template-columns: 54px 54px 54px; grid-template-rows: 54px 54px; }
-      .comandi button { font-size: 1.6rem; }
-    }
+    /* Sizing su mobile gestito direttamente da clamp() su .cell e .comandi */
   </style>
 </head>
 <body>
@@ -441,7 +449,7 @@
 
     function disegna(){
       var cols = mappa[0].length;
-      mappaEl.style.gridTemplateColumns = 'repeat(' + cols + ', auto)';
+      mappaEl.style.setProperty('--mappa-cols', cols);
       mappaEl.innerHTML = '';
       for (var r = 0; r < mappa.length; r++){
         for (var c = 0; c < mappa[r].length; c++){

--- a/static/giochi/primaria/memory/css/style.css
+++ b/static/giochi/primaria/memory/css/style.css
@@ -1,6 +1,7 @@
 /* Memory dei Rischi — stili specifici (il grosso è in /app-shared/app-common.css) */
 :root {
-    --card-size: 120px;
+    --card-size: clamp(64px, 21vw, 120px);
+    --card-gap: clamp(6px, 2vw, 15px);
 }
 .game-container {
     max-width: 800px;
@@ -10,7 +11,7 @@
 .memory-grid {
     display: grid;
     grid-template-columns: repeat(4, var(--card-size));
-    gap: 15px;
+    gap: var(--card-gap);
     justify-content: center;
     perspective: 1000px;
 }
@@ -132,11 +133,4 @@
     0%   { opacity: 1; transform: translateX(-50%) translateY(0); }
     100% { opacity: 0; transform: translateX(-50%) translateY(-40px); }
 }
-@media (max-width: 600px) {
-    :root {
-        --card-size: 75px;
-    }
-    .memory-grid {
-        gap: 8px;
-    }
-}
+/* Sizing su mobile gestito direttamente da clamp() su --card-size e --card-gap */

--- a/static/giochi/ragazzi/cartelli-pericolo/index.html
+++ b/static/giochi/ragazzi/cartelli-pericolo/index.html
@@ -24,11 +24,17 @@
     .regole-box h2 { color: #003366; font-size: 1.05rem; margin-top: 0; margin-bottom: .5rem; }
     .regole-box ul { margin: 0; padding-left: 1.2rem; }
 
-    .chapter-grid { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; }
+    .chapter-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(min(240px, 100%), 1fr));
+      gap: 1rem;
+      max-width: 760px;
+      margin: 0 auto;
+    }
     .chapter-card {
       background: #fff; border-radius: 14px; padding: 1.2rem; text-align: center;
       box-shadow: 0 2px 10px rgba(0,0,0,.08); border: 3px solid transparent;
-      cursor: pointer; width: 240px; transition: all .2s;
+      cursor: pointer; width: 100%; transition: all .2s;
     }
     .chapter-card:hover, .chapter-card:focus {
       border-color: #003366; transform: translateY(-3px);
@@ -58,31 +64,31 @@
 
     /* Pittogrammi CLP — diamante bianco con bordo rosso */
     .clp {
-      width: 130px; height: 130px;
+      width: clamp(96px, 32vw, 130px); height: clamp(96px, 32vw, 130px);
       position: relative; margin: 0 auto 1rem;
       transform: rotate(45deg);
       background: #fff; border: 5px solid #d91e18;
       display: flex; align-items: center; justify-content: center;
     }
     .clp-inner {
-      transform: rotate(-45deg); font-size: 3rem; color: #000;
+      transform: rotate(-45deg); font-size: clamp(2rem, 8vw, 3rem); color: #000;
       display: flex; align-items: center; justify-content: center;
     }
 
     /* ADR — diamante colorato con numero in basso */
     .adr {
-      width: 130px; height: 130px;
+      width: clamp(96px, 32vw, 130px); height: clamp(96px, 32vw, 130px);
       position: relative; margin: 0 auto 1rem;
       transform: rotate(45deg);
       border: 3px solid #000;
       display: flex; align-items: center; justify-content: center;
     }
     .adr-inner {
-      transform: rotate(-45deg); font-size: 2.6rem; color: #000;
+      transform: rotate(-45deg); font-size: clamp(1.6rem, 6vw, 2.6rem); color: #000;
       display: flex; flex-direction: column; align-items: center;
       line-height: 1;
     }
-    .adr-inner .sym { font-size: 2.6rem; }
+    .adr-inner .sym { font-size: clamp(1.6rem, 6vw, 2.6rem); }
     .adr-inner .cls { font-size: 1rem; font-weight: 800; border-top: 2px solid currentColor; padding-top: 4px; margin-top: 4px; min-width: 20px; }
     /* Colori ADR per classe */
     .adr-1 { background: #ff9900; } /* esplosivi */
@@ -104,13 +110,13 @@
 
     /* UNI EN ISO 7010 — forme/colori */
     .uni7010 {
-      width: 120px; height: 120px; margin: 0 auto 1rem;
+      width: clamp(88px, 30vw, 120px); height: clamp(88px, 30vw, 120px); margin: 0 auto 1rem;
       display: flex; align-items: center; justify-content: center;
-      font-size: 3.5rem; line-height: 1;
+      font-size: clamp(2.4rem, 9vw, 3.5rem); line-height: 1;
     }
     .uni7010.pericolo { background: #ffcc00; border: 5px solid #000; color: #000;
       clip-path: polygon(50% 0, 100% 100%, 0 100%); padding-top: 30px; align-items: flex-end;
-      width: 140px; height: 130px; font-size: 3rem;
+      width: clamp(100px, 34vw, 140px); height: clamp(92px, 31vw, 130px); font-size: clamp(2rem, 8vw, 3rem);
     }
     .uni7010.divieto { background: #fff; border: 8px solid #cc0000; border-radius: 50%; color: #000;
       position: relative;


### PR DESCRIPTION
## Sommario

Fix di responsiveness su tutti i giochi statici della sezione Giochi della Sicurezza + sostituzione degli emoji nel gioco "Trova il Cartello" con i pittogrammi vettoriali ufficiali ISO 7010 e ARASAAC già presenti nel repo.

Origine: segnalazione utente che alcuni cartelli risultavano vuoti (in particolare l'ascensore: emoji `U+1F6C8` non reso su Android) e che il labirinto di evacuazione produceva scroll orizzontale su smartphone.

## Sostituzione emoji → icone vettoriali (regola `02-content-design-pa.md`)

In `static/giochi/infanzia/trova-cartello/index.html`:

- 16 cartelli ora caricano pittogrammi da `static/pittogrammi/`:
  - **14 ISO 7010** (PD-shape/CC0 da Wikimedia): `materiale-infiammabile`, `pericolo-elettrico`, `pavimento-scivoloso`, `pericolo-generico`, `vietato-fumare`, `vietato-pedoni`, `casco-protettivo`, `guanti-protettivi`, `maschera-protettiva`, `cassetta-primo-soccorso`, `punto-raccolta`, `uscita-emergenza-destra`, `estintore`, `telefono-antincendio`.
  - **2 ARASAAC** (CC BY-NC-SA 4.0) per i concetti che ISO 7010 non copre direttamente: `ascensore.png` e `cibo.png`. La semantica "vietato" è data dal bordo rosso istituzionale `sfondo-rosso` della carta.
- Render: `<img class="cartello-img" alt="" aria-hidden="true" loading="lazy">` con il bottone esterno che porta l'`aria-label` descrittivo (es. *"Cartello vietato usare l'ascensore"*).
- Rimozione del bordo rotondo accidentale sui cartelli `sfondo-blu` (era `border-radius: 50%`, schiacciava il pittogramma quadrato ISO).

## Responsive: clamp() basato sul viewport sostituisce le dimensioni in px

7 file modificati, tutti dentro `static/giochi/`:

| File | Cosa cambia |
|---|---|
| `primaria/labirinto-evacuazione/index.html` | Celle e pulsanti freccia ora scalano via variabile CSS `--mappa-cols` (impostata in JS al numero reale di colonne dello scenario) + `clamp(22-44px)`. Le mappe a 12 colonne non hanno più scroll orizzontale su 360px. |
| `ragazzi/cartelli-pericolo/index.html` | Chapter card da `width:240px` fissa a `grid-template-columns: repeat(auto-fit, minmax(min(240px,100%), 1fr))`. Diamanti CLP, ADR e segnali UNI EN ISO 7010 con `clamp(88-140px)`. |
| `primaria/cruciverba/css/style.css` | Celle da `width:40px` fisse a `clamp(24px, 7.5vw, 40px)` + font-size scalato. Niente scroll orizzontale anche sui cruciverba più larghi. |
| `primaria/memory/css/style.css` | `--card-size` da `120px` fisso a `clamp(64px, 21vw, 120px)`, gap proporzionale `clamp(6-15px)`. |
| `infanzia/assets/infanzia.css` | `inf-big-btn` (usato da 10 giochi infanzia): `min-width`, `min-height`, padding e font-size tutti con `clamp()`. |
| `assets/css/giochi.css` | Guardrail globale: `img/svg/canvas/iframe { max-width: 100% }` dentro `.giochi-section`, `overflow-x: clip` sui container, `.stat-box` con `min-width: clamp(88px, 28vw, 140px)` (era 110-140px fisso in 5 giochi ragazzi), `.btn { max-width: 100%; white-space: normal }`. |

## Audit completo

Tutti i 33 giochi sono stati auditati (10 infanzia + 13 primaria + 10 ragazzi):
- 7 hanno richiesto fix (sopra elencati).
- 26 erano già responsive grazie a `grid-template-columns: 1fr`, `auto-fit minmax`, `flex-wrap: wrap` o `aspect-ratio: 1` con max-width sul wrapper.

## Verifiche pre-commit

- Tutti i 16 path dei pittogrammi puntano a file esistenti in `static/pittogrammi/iso7010/` e `static/pittogrammi/arasaac/`.
- Sintassi JS valida sia in `trova-cartello` che in `labirinto-evacuazione` (`new Function(code)` non solleva eccezioni).
- Parentesi e graffe bilanciate nei 4 file CSS modificati.
- Nessun residuo `glyph` / `c.glyph` / `btn.textContent` rimasto in `trova-cartello`.

## Test plan

- [ ] Verificare su smartphone con viewport 360px che il labirinto scenario 6 (12 colonne) non produca scroll orizzontale.
- [ ] Verificare che il cartello "ascensore" sia ora visibile in `Trova il Cartello` round 2.
- [ ] Verificare cruciverba a difficoltà "difficile" (griglia più grande) su mobile.
- [ ] Test di base sul memory primaria con 4 colonne su viewport stretto.

https://claude.ai/code/session_01UrYc3nirvW2CVu1ZUpB2T2

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrYc3nirvW2CVu1ZUpB2T2)_