### PR TITLE
Coach Layer 3: hint contestuale su errore in 4 giochi domanda/risposta

### DIFF
--- a/static/giochi/primaria/cosa-faccio-se/js/script.js
+++ b/static/giochi/primaria/cosa-faccio-se/js/script.js
@@ -325,6 +325,7 @@ document.addEventListener('DOMContentLoaded', () => {
         storyCard.style.animation = '';
         storyFeedback.classList.add('hide');
         choicesContainer.innerHTML = '';
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
         step.choices.forEach(ch => {
             const btn = document.createElement('button');
             btn.className = 'choice-btn';
@@ -334,6 +335,18 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    // Mappa scenario → pagina teoria del sito
+    const TEORIA_SCENARIO = {
+        'terremoto':       { url: '/rischi-prevenzione/rischio-sismico/',       titolo: 'rischio sismico' },
+        'temporale':       { url: '/rischi-prevenzione/temporali-intensi/',     titolo: 'temporali intensi' },
+        'fumo':            { url: '/rischi-prevenzione/rischio-incendio/',      titolo: 'rischio incendio' },
+        'alluvione':       { url: '/rischi-prevenzione/rischio-idrogeologico/', titolo: 'rischio idrogeologico' },
+        'incendio-bosco':  { url: '/rischi-prevenzione/rischio-incendio/',      titolo: 'rischio incendio' },
+        'blackout':        { url: '/rischi-prevenzione/blackout/',              titolo: 'blackout' },
+        'neve-ghiaccio':   { url: '/rischi-prevenzione/',                       titolo: 'rischi e prevenzione' },
+        'persona-smarrita':{ url: '/numeri-utili/',                             titolo: 'numeri di emergenza' }
+    };
+
     function handleChoice(btn, choice, step) {
         const allBtns = choicesContainer.querySelectorAll('.choice-btn');
         allBtns.forEach(b => { b.disabled = true; });
@@ -342,6 +355,7 @@ document.addEventListener('DOMContentLoaded', () => {
             storyFeedback.className = 'story-feedback correct';
             storyFeedback.innerHTML = '<strong><i class="bi bi-check-circle-fill me-1"></i> Giusto!</strong> ' + choice.tip;
             storyFeedback.classList.remove('hide');
+            if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
             setTimeout(() => {
                 stepIndex++;
                 if (stepIndex < currentScenario.steps.length) { showStep(); }
@@ -353,6 +367,11 @@ document.addEventListener('DOMContentLoaded', () => {
             storyFeedback.className = 'story-feedback wrong';
             storyFeedback.innerHTML = '<strong><i class="bi bi-x-circle-fill me-1"></i> Non proprio...</strong> ' + choice.tip;
             storyFeedback.classList.remove('hide');
+            // Layer 3: hint contestuale con link teoria in base allo scenario
+            if (window.GameCoach && window.GameCoach.hint) {
+                const t = TEORIA_SCENARIO[currentScenario.id] || { url: '/rischi-prevenzione/', titolo: 'rischi e prevenzione' };
+                window.GameCoach.hint('Vuoi capire il perché? Leggi la pagina ' + t.titolo + ' del sito.', t.url);
+            }
             setTimeout(() => {
                 allBtns.forEach(b => {
                     if (!b.classList.contains('wrong-choice')) { b.disabled = false; }

--- a/static/giochi/primaria/quiz/js/script.js
+++ b/static/giochi/primaria/quiz/js/script.js
@@ -1219,9 +1219,25 @@ document.addEventListener('DOMContentLoaded', () => {
         if (correct) {
             feedbackBox.classList.add('correct');
             feedbackBox.innerHTML = '<div class="feedback-title">Risposta esatta!</div>' + currentQ.explanation;
+            if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
         } else {
             feedbackBox.classList.add('wrong');
             feedbackBox.innerHTML = '<div class="feedback-title">Risposta sbagliata</div>' + currentQ.explanation;
+            // Layer 3: hint contestuale con link teoria in base alla categoria della domanda
+            if (window.GameCoach && window.GameCoach.hint) {
+                const TEORIA = {
+                    'terremoto': { url: '/rischi-prevenzione/rischio-sismico/', titolo: 'rischio sismico' },
+                    'incendio': { url: '/rischi-prevenzione/rischio-incendio/', titolo: 'rischio incendio' },
+                    'alluvione': { url: '/rischi-prevenzione/rischio-idrogeologico/', titolo: 'rischio idrogeologico' },
+                    'numeri': { url: '/numeri-utili/', titolo: 'numeri di emergenza' },
+                    'zaino': { url: '/rischi-prevenzione/kit-emergenza/', titolo: 'kit di emergenza' },
+                    'evacuazione': { url: '/piano-familiare/', titolo: 'piano familiare' },
+                    'protezione-civile': { url: '/chi-siamo/', titolo: 'chi siamo' },
+                    'sicurezza': { url: '/cosa-fare-adesso/', titolo: 'cosa fare in emergenza' }
+                };
+                const t = TEORIA[currentQ.category] || { url: '/rischi-prevenzione/', titolo: 'rischi e prevenzione' };
+                window.GameCoach.hint('Vuoi capire il perché? Leggi la pagina ' + t.titolo + ' del sito.', t.url);
+            }
         }
 
         scoreLive.textContent = score + ' corrette';
@@ -1285,6 +1301,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function resetState() {
         feedbackBox.classList.add('hide');
         while (answerButtonsElement.firstChild) { answerButtonsElement.removeChild(answerButtonsElement.firstChild); }
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
     }
 
     function setStatusClass(element, correct) {

--- a/static/giochi/ragazzi/triage-start/index.html
+++ b/static/giochi/ragazzi/triage-start/index.html
@@ -380,6 +380,7 @@
       esito.classList.add('hide'); esito.classList.remove('ok','ko'); esito.innerHTML = '';
       nextWrap.classList.add('hide');
       btnCods.forEach(function(b){ b.disabled = false; });
+      if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
       idxCur.textContent = idx + 1;
       progressBar.style.width = ((idx / queue.length) * 100) + '%';
     }
@@ -393,10 +394,21 @@
         if (p.cod === 'rosso') rossiOk++;
         esito.classList.remove('ko'); esito.classList.add('ok');
         esito.innerHTML = '<strong><i class="bi bi-check-circle-fill me-1"></i>Corretto: ' + CODNAMES[p.cod] + '.</strong> ' + p.spiega;
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
       } else {
         if (p.cod === 'rosso' && (cod === 'verde' || cod === 'giallo')) erroriCritici++;
         esito.classList.remove('ok'); esito.classList.add('ko');
         esito.innerHTML = '<strong><i class="bi bi-x-circle-fill me-1"></i>Sbagliato.</strong> Tu hai scelto <strong>' + CODNAMES[cod] + '</strong>, il codice corretto era <strong>' + CODNAMES[p.cod] + '</strong>. ' + p.spiega;
+        // Layer 3: hint contestuale con criterio START
+        if (window.GameCoach && window.GameCoach.hint) {
+          var TIPS = {
+            'rosso':  'ROSSO = pericolo di vita immediato (respira male, polso radiale assente, non risponde). Sul campo si tratta per primo.',
+            'giallo': 'GIALLO = grave ma stabile, può aspettare 30-60 minuti. Parametri compensati ma lesione importante.',
+            'verde':  'VERDE = lieve, cammina e parla. Può aspettare ore, ma va comunque registrato.',
+            'nero':   'NERO = deceduto o non recuperabile sul campo. Si annota e si passa al prossimo paziente.'
+          };
+          window.GameCoach.hint(TIPS[p.cod] || 'Rivedi il metodo START sui Consigli (bottone sopra).', '/cosa-fare-adesso/');
+        }
       }
       esito.classList.remove('hide');
       nextWrap.classList.remove('hide');

--- a/static/giochi/ragazzi/vero-o-bufala/index.html
+++ b/static/giochi/ragazzi/vero-o-bufala/index.html
@@ -309,6 +309,7 @@
       btnUff.disabled = false; btnBuf.disabled = false;
       idxCur.textContent = (idx + 1);
       progressBar.style.width = ((idx / queue.length) * 100) + '%';
+      if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
     }
 
     function rispondi(scelta){
@@ -322,11 +323,19 @@
         esito.classList.remove('sbagliato');
         esito.classList.add('corretto');
         esito.innerHTML = '<strong><i class="bi bi-check-circle-fill me-1"></i>Corretto.</strong> ' + n.spiega;
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
       } else {
         esito.classList.remove('corretto');
         esito.classList.add('sbagliato');
         var eraRisp = n.ufficiale ? 'fonte ufficiale' : 'bufala';
         esito.innerHTML = '<strong><i class="bi bi-x-circle-fill me-1"></i>Sbagliato.</strong> Era una <strong>' + eraRisp + '</strong>. ' + n.spiega;
+        // Layer 3: hint con criteri per riconoscere fonti
+        if (window.GameCoach && window.GameCoach.hint) {
+          var tip = n.ufficiale
+            ? 'Le fonti ufficiali (DPC, Regione, Comune, INGV, ARPA, ISS, EENA) hanno: dato preciso, periodo definito, rimando al sito istituzionale, nessun appello emotivo.'
+            : 'Le bufale hanno: appelli urgenti a "condividere", "fonti interne anonime", numeri allarmanti senza fonte, link abbreviati o mittente non istituzionale (gmail, gruppi anonimi, video virali).';
+          window.GameCoach.hint(tip, '/social-media-policy/');
+        }
       }
       esito.classList.remove('hide');
       nextWrap.classList.remove('hide');


### PR DESCRIPTION
## Sommario

Aggancia l'API `window.GameCoach.hint(testo, url)` introdotta nella PR #40 ai 4 giochi domanda/risposta più frustranti per i bambini che giocano senza nozioni di base. Quando il bambino sbaglia, accanto al bottone "Consigli per giocare" appare un riquadro giallo con un suggerimento contestuale e un link "Scopri perché →" alla pagina teoria pertinente.

Pattern: il fallimento diventa apprendimento contestuale, senza richiedere al bambino di cliccare proattivamente sul bottone "Consigli".

## Giochi modificati (4)

| Gioco | Logica del hint |
|---|---|
| `primaria/quiz` | Mappa la `category` della domanda (terremoto, incendio, alluvione, numeri, zaino, evacuazione, protezione-civile, sicurezza) all'URL della pagina teoria. Es. domanda su terremoto sbagliata → hint che linka `/rischi-prevenzione/rischio-sismico/`. |
| `primaria/cosa-faccio-se` | Mappa l'`id` dello scenario (8 scenari) alla teoria. Es. scenario "blackout" → `/rischi-prevenzione/blackout/`, "temporale" → `/rischi-prevenzione/temporali-intensi/`. |
| `ragazzi/triage-start` | Hint con il **criterio START** del codice corretto: rosso = pericolo immediato (>30 respiri/min, polso radiale assente), giallo = grave-stabile, verde = lieve, nero = deceduto. Il ragazzo impara il metodo nel momento dell'errore. Linka a `/cosa-fare-adesso/`. |
| `ragazzi/vero-o-bufala` | Hint con i criteri di riconoscimento: fonte ufficiale (DPC/INGV/ARPA/ISS = dato preciso + sito istituzionale + nessun appello emotivo) vs bufala (appello a condividere, mittente anonimo, link abbreviati, finti esperti). Linka a `/social-media-policy/`. |

## Pattern uniforme nei 4 giochi

- **Risposta corretta** → `window.GameCoach.clearHint()` (pulisce hint precedenti).
- **Risposta sbagliata** → `window.GameCoach.hint(testo, url)` (riquadro giallo a fianco del bottone Consigli).
- **Passaggio a domanda/step successivo** → `clearHint()` per partire pulito.

Tutti i fallback usano `if (window.GameCoach && window.GameCoach.hint) { … }` — il gioco continua a funzionare anche se coach.js fallisce a caricare.

## Verifiche pre-commit

- ✅ `node -c` su `quiz/script.js` e `cosa-faccio-se/script.js`: OK.
- ✅ `new Function(code)` sui due script inline (`triage-start`, `vero-o-bufala`): OK.
- ✅ Le 2 nuove URL teoria aggiunte (`/rischi-prevenzione/blackout/`, `/rischi-prevenzione/temporali-intensi/`) mappano a `content/rischi-prevenzione/<slug>.md` esistenti.

## Test plan

- [ ] Quiz primaria: rispondi sbagliato a una domanda terremoto → controlla che il riquadro giallo appaia con link a "rischio sismico" del sito.
- [ ] Cosa faccio se → scenario blackout → risposta sbagliata → hint linka a `/rischi-prevenzione/blackout/`.
- [ ] Triage START: classifica un paziente "rosso" come "verde" → hint mostra il criterio START rosso.
- [ ] Vero o bufala: classifica una bufala come fonte ufficiale → hint elenca i segnali tipici di una bufala.
- [ ] Verifica che cliccando "Scopri perché →" si apre la pagina teoria corretta.
- [ ] Verifica che il hint si pulisce passando alla domanda successiva.

https://claude.ai/code/session_01UrYc3nirvW2CVu1ZUpB2T2

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrYc3nirvW2CVu1ZUpB2T2)_