### PR TITLE
Coach Layer 3 esteso + TTS audio su giochi/pagine/fiabe + manualistica

### DIFF
--- a/.claude/rules/03-accessibility.md
+++ b/.claude/rules/03-accessibility.md
@@ -97,23 +97,70 @@ Per la struttura dei file, le regole di estensione e i divieti operativi vedi `0
 
 ## TTS "Leggi ad alta voce" (Web Speech API)
 
-Pulsante che usa `window.speechSynthesis` per leggere il contenuto della pagina in italiano. Componente in `themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html`. Opt-in via frontmatter `tts: true`. Attivo su 12 pagine essenziali (cosa-fare-adesso, numeri-utili, facile-da-leggere, allerte-meteo, piano-familiare + 7 sotto-pagine rischi-prevenzione).
+Il sito usa la **Web Speech API browser-native** in tre contesti distinti, tutti basati sullo stesso paradigma (`window.speechSynthesis` + `SpeechSynthesisUtterance`, voce italiana, niente file MP3, niente API key esterne, niente costi). Il W3C-WAI raccomanda questa scelta per la PA al posto degli overlay commerciali (AccessiBe, UserWay, Equally AI), che mascherano problemi invece di risolverli.
 
-**Caratteristiche accessibilità:**
-- ARIA: `role=button`, `aria-pressed` dinamico, `aria-label` che cambia con lo stato (idle/reading/paused), `aria-live=polite` per stato annunciato a screen reader
-- Tastiera: bottone nativo, attivabile con Enter/Space, focus visibile (`outline 3px #ffbe2e`)
-- Voce italiana: priorità `it-IT`, fallback qualsiasi voce italiana, fallback voce default browser
-- Velocità: 0.95x default per chiarezza (più lento del default)
-- Stati visivi distinti: idle (outline blu), reading (riempito blu + animazione pulse rispettosa di `prefers-reduced-motion`), paused (outline blu + icona play)
-- Esclude da lettura: script, style, code blocks, elementi `aria-hidden`, pittogrammi (sostituiti dalla `caption`)
-- Fallback graceful: se browser senza Web Speech API, bottone nascosto via JS
+### 1. TTS pagine Hugo (partial `leggi-ad-alta-voce.html`)
+
+Pulsante grande "Leggi ad alta voce" inserito automaticamente all'inizio del corpo articolo nelle pagine con frontmatter `tts: true`. Componente in `themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html`.
+
+**Pagine attive (21):**
+- 12 pagine storiche: cosa-fare-adesso, numeri-utili, facile-da-leggere, allerte-meteo, piano-familiare + 7 sotto-pagine rischi-prevenzione (sismico, idrogeologico, incendio, vento, temporali, blackout, ondate-calore).
+- 9 pagine aggiunte (PR coach + TTS): assistente, faq, piano-emergenza, contatti, chi-siamo, diventa-volontario, glossario, rischi-prevenzione/{kit-emergenza, persone-necessita-specifiche}.
+
+### 2. TTS dentro il "Coach" dei giochi (`giochi/assets/js/coach.js`)
+
+Bottone "🔊 Ascolta i consigli" dentro il dialog del bottone "Consigli per giocare" (presente su tutti i 33 giochi statici di `static/giochi/`). Legge ad alta voce: titolo dialog + regola del gioco + bullet "Come si gioca". Variante mini "🔊 Ascolta" anche nei suggerimenti contestuali sull'errore (Layer 3). API esposta: `window.GameCoach.{speak, stopSpeaking, ttsSupported}`.
+
+### 3. TTS sulle fiabe e storie (`formazione/storie-e-racconti/assets/tts-storia.js`)
+
+Bottone "🔊 Ascolta" nella `.storia-toolbar` di tutte le 18 fiabe in `static/formazione/storie-e-racconti/`. Modulo standalone auto-iniettato (basta includere il `<script>` nell'index.html della storia). Legge `.storia-titolo-principale` + `.storia-corpo`, spezzando il testo in chunk di ~200 caratteri per evitare cut-off su fiabe lunghe (lettura ~4 minuti).
+
+### Caratteristiche accessibilità (comuni ai tre contesti)
+
+- ARIA: `role=button` o `<button>` nativo, `aria-pressed` o `aria-label` dinamico (idle/speaking), `aria-live=polite` per stato annunciato a screen reader.
+- Tastiera: bottone nativo, attivabile con Enter/Space, focus visibile (`outline 3px #ffbe2e`).
+- Voce italiana: priorità `it-IT`, fallback qualsiasi voce con `lang.startsWith("it")`, fallback voce default browser.
+- Velocità: 0.9-0.95x default per chiarezza (più lento del default).
+- Stati visivi distinti: idle (outline), speaking (riempito + animazione pulse, rispetta `prefers-reduced-motion`).
+- Stop automatico su: page unload, dialog close, ESC, click su altro bottone TTS.
+- Fallback graceful: se browser senza Web Speech API, bottone nascosto via `ttsSupported()`.
 
 **Caso d'uso target:** anziani con vista debole, persone in stress/emergenza, parlanti italiano L2, bambini che leggono lentamente, utenti con dislessia.
 
 **Regole operative:**
-- Per attivare TTS su una nuova pagina: aggiungere `tts: true` nel frontmatter (opt-in esplicito, non automatico)
-- Non attivare TTS su pagine legali (privacy, note legali, accessibilità) o tecniche (mappa sito, attribuzioni) — non utili da leggere ad alta voce
-- Non aggiungere altri TTS provider (es. Google Cloud TTS, AWS Polly) che richiedono API key/costo: Web Speech API browser è gratuita e sufficiente
+- Per attivare TTS su una **nuova pagina Hugo**: aggiungere `tts: true` nel frontmatter (opt-in esplicito, non automatico).
+- Per **giochi statici**: il TTS dentro il coach è già attivo via `coach.js` su tutti i giochi con `data-coach-game` sul `<body>` — niente da fare manualmente.
+- Per **nuove storie/racconti**: includere `<script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>` prima di `</body>` nell'index.html della storia. Il modulo trova `.storia-toolbar` e inietta il bottone.
+- **Non attivare TTS** su pagine legali (privacy, note legali, accessibilità, social-media-policy) o tecniche (mappa sito, attribuzioni-pittogrammi) — non utili da leggere ad alta voce.
+- **Non aggiungere altri TTS provider** (es. Google Cloud TTS, AWS Polly) che richiedono API key/costo: Web Speech API browser è gratuita, sempre aggiornata col testo, e raccomandata da W3C-WAI per PA.
+
+## Coach dei giochi — onboarding e teoria di rinforzo
+
+Tutti i 33 giochi statici in `static/giochi/{infanzia,primaria,ragazzi}/` hanno un sistema condiviso di **onboarding** + **teoria di rinforzo** che riduce l'abbandono dei bambini che non hanno nozioni di base e rispondono a caso. Ispirato a "Io non rischio" del DPC e alla regola AGID di accessibilità cognitiva.
+
+**Architettura:**
+- `static/giochi/assets/css/coach.css` — styling (bottone trigger inline, dialog modale accessibile, suggerimento contestuale, bottone TTS).
+- `static/giochi/assets/js/coach.js` — modulo IIFE con manifest dei 33 giochi + dialog accessibile (`role=dialog`, `aria-modal`, focus trap, ESC, click-outside) + hint contestuale + TTS Web Speech API. Auto-init via attributo `data-coach-game="<id>"` sul `<body>` di ogni gioco.
+
+**Tre layer:**
+
+1. **Bottone "💡 Consigli per giocare"** sotto il titolo di ogni gioco. Click → dialog con: regola in 1 frase, "Come si gioca" in bullet, link "Approfondisci sul sito" alla teoria. Tre varianti visive per fascia (rosso infanzia, verde primaria, blu ragazzi).
+2. **TTS audio** nel dialog ("🔊 Ascolta i consigli") — vedi sezione TTS sopra.
+3. **Hint contestuale su errore**: quando il bambino sbaglia, accanto al bottone "Consigli" appare un riquadro giallo con suggerimento mirato + link "Scopri perché →". API: `window.GameCoach.hint(testo, urlOpz)` chiamata dai singoli giochi nel callback wrong-answer; `clearHint()` su risposta corretta o passaggio a domanda successiva.
+
+**Manifest dei contenuti** in `coach.js` (~33 voci, 1 per gioco). Ogni voce ha:
+- `fascia: 'infanzia' | 'primaria' | 'ragazzi'`
+- `titolo`, `regola` (1 frase, italiano AGID)
+- `come` (3-6 bullet operativi, voce attiva, frasi <20 parole)
+- `teoria` (array di `{titolo, url}` che puntano a pagine già pubblicate sul sito — niente nuova teoria scritta)
+
+**Regole operative:**
+- Per **aggiungere un nuovo gioco**: includere `<link rel="stylesheet" href="/giochi/assets/css/coach.css">` + `<script src="/giochi/assets/js/coach.js" defer></script>` + `<body data-coach-game="<id-univoco>">` + voce nel manifest `CONTENUTI` di `coach.js`.
+- Per **modificare i consigli** di un gioco esistente: editare la voce nel manifest. Niente cambi al gioco.
+- Per **agganciare hint contestuale Layer 3** in un gioco: nel callback wrong-answer, chiamare `if (window.GameCoach && window.GameCoach.hint) { window.GameCoach.hint('testo breve', '/url-teoria/'); }`. Su risposta corretta o nuovo turno, chiamare `clearHint()`.
+- I link teoria devono **sempre** puntare a pagine già pubblicate (`content/<slug>/_index.md` o `content/<slug>.md` esistente) — verificato pre-commit.
+
+Specifiche complete di implementazione e mapping per fascia in `MANUALE-SITO.md` Parte 16.
 
 ## Accessibilità dei post sui social media
 

--- a/.claude/rules/04b-hugo-template-css.md
+++ b/.claude/rules/04b-hugo-template-css.md
@@ -216,6 +216,29 @@ Sistema completo per generare bozze post social (X, Facebook, Instagram, Telegra
 
 **Documentazione operativa completa** in `scripts/README-social.md`. **Workflow mobile-first** in `MANUALE-MOBILE.md` (root).
 
+## Coach + TTS sui giochi statici (`giochi/assets/`)
+
+I giochi statici della sezione Giochi della Sicurezza vivono in `static/giochi/{infanzia,primaria,ragazzi}/` (33 giochi totali) e usano un sistema condiviso di onboarding e teoria di rinforzo.
+
+**Asset condivisi** in `static/giochi/assets/`:
+- `css/giochi.css` — palette, card hub, badge, focus visibile, guardrail responsive globale.
+- `css/coach.css` — bottone trigger inline, dialog modale, hint contestuale, bottone TTS. Tre varianti per fascia (rosso/verde/blu).
+- `js/coach.js` — modulo IIFE: manifest dei 33 giochi, dialog accessibile (`role=dialog`, focus trap, ESC), hint contestuale, TTS via Web Speech API. Auto-init via `data-coach-game="<id>"` sul `<body>` di ogni gioco.
+- `js/progressione.js`, `js/attestato.js`, `js/audio-sintetico.js`, `js/comune.js`, `js/attestato-inclusivo.js` — utilities di gameplay condivise.
+
+**Per ogni nuovo gioco** servono 3 righe HTML:
+1. `<link rel="stylesheet" href="/giochi/assets/css/coach.css">` in `<head>` (dopo `giochi.css`).
+2. `<body data-coach-game="<id-univoco>">` (l'attributo aggiunto al tag esistente).
+3. `<script src="/giochi/assets/js/coach.js" defer></script>` prima di `</body>`.
+
+E **una voce nel manifest `CONTENUTI`** dentro `coach.js` con titolo, regola, come si gioca, link teoria. Specifiche di accessibilità e contenuto in `03-accessibility.md` § "Coach dei giochi".
+
+## TTS sulle storie e fiabe (`storie-e-racconti/assets/tts-storia.js`)
+
+Le 18 fiabe in `static/formazione/storie-e-racconti/*/` hanno un bottone "🔊 Ascolta" via Web Speech API. Modulo standalone in `static/formazione/storie-e-racconti/assets/tts-storia.js`, auto-init via `DOMContentLoaded`, inietta il bottone nella `.storia-toolbar` di ogni storia. Legge `.storia-titolo-principale` + `.storia-corpo` spezzando in chunk di ~200 caratteri per fiabe lunghe.
+
+**Per nuove storie:** includere il `<script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>` prima di `</body>`. Il bottone si aggiunge automaticamente. Stile in `assets/storia-libro.css` sezione "Bottone TTS".
+
 ## Pagina 404 istituzionale
 
 `themes/flavour-pcgenzano/layouts/404.html` è una **pagina di atterraggio del recupero**, non un vicolo cieco. Contiene:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,8 @@ bash scripts/genera-social.sh --dry-run <file>.md              # solo anteprima
 | Cartelle `static/` canoniche e cartella `riferimenti-interni/` non deployata | `04c-hugo-static-cartelle.md` |
 | Assistente guidato `/assistente/` (albero decisionale JS) | `04a-hugo-shortcode-partial.md` § "Assistente guidato" |
 | Pagina lite `/emergenza/` (44 KB) | `04a-hugo-shortcode-partial.md` § "Shortcode pagina-emergenza-lite" |
+| Coach dei giochi (bottone "Consigli per giocare" + hint contestuale + TTS) su 33 giochi statici | `03-accessibility.md` § "Coach dei giochi" + `04b-hugo-template-css.md` § "Coach + TTS sui giochi" |
+| TTS Web Speech API: 21 pagine Hugo (`tts: true`), coach giochi, 18 fiabe `storie-e-racconti/` | `03-accessibility.md` § "TTS Leggi ad alta voce" |
 
 ## Regole contenuti e qualità
 

--- a/MANUALE-SITO.md
+++ b/MANUALE-SITO.md
@@ -5352,5 +5352,129 @@ dalla quota Gemini.
 
 ---
 
+## Parte 17 — Coach didattico nei giochi e TTS esteso (maggio 2026)
+
+### 17.1 Perché esiste il "Coach"
+
+Ad aprile 2026 abbiamo notato che molti bambini, soprattutto della fascia 3-8 anni,
+abbandonavano i giochi della sezione "Giochi della Sicurezza" dopo i primi errori:
+non avendo studiato i temi, rispondevano a caso e perdevano la motivazione. Il
+sistema di feedback esistente (testo "risposta sbagliata") era sufficiente a
+registrare l'errore ma non a far imparare.
+
+La soluzione è un sistema **a tre layer** ispirato alla campagna DPC "Io non rischio"
+e alle linee guida AGID per accessibilità cognitiva:
+
+1. **Onboarding pre-gioco**: bottone "💡 Consigli per giocare" sotto il titolo di
+   ogni gioco. Click → dialog con regola in 1 frase + bullet "Come si gioca" +
+   link alle pagine teoria del sito.
+2. **TTS audio**: dentro il dialog, bottone "🔊 Ascolta i consigli" che legge
+   regola + bullet via Web Speech API browser-native. Stessa cosa nei suggerimenti
+   contestuali.
+3. **Suggerimento contestuale su errore**: quando il bambino sbaglia, accanto al
+   bottone Consigli appare un riquadro giallo con suggerimento mirato + link
+   "Scopri perché →" alla teoria pertinente. Trasforma il fallimento in
+   apprendimento senza richiedere proattività al bambino.
+
+### 17.2 Architettura del Coach
+
+Tutto in 2 file condivisi sotto `static/giochi/assets/`:
+
+- **`css/coach.css`** — bottone trigger, dialog modale, hint contestuale, bottone
+  TTS. Tre varianti per fascia (rosso infanzia, verde primaria, blu ragazzi).
+  Rispetta `prefers-reduced-motion`. Nascosto in stampa.
+- **`js/coach.js`** — modulo IIFE con: manifest dei 33 giochi, dialog accessibile
+  (`role=dialog`, focus trap, ESC), hint contestuale, TTS Web Speech API.
+  Auto-init via `data-coach-game="<id>"` sul `<body>` di ogni gioco.
+
+Per **aggiungere un nuovo gioco** servono 3 righe HTML + 1 voce nel manifest:
+
+```html
+<head>
+  ...
+  <link rel="stylesheet" href="/giochi/assets/css/coach.css">
+</head>
+<body class="..." data-coach-game="nuovo-gioco-id">
+  ...
+  <script src="/giochi/assets/js/coach.js" defer></script>
+</body>
+```
+
+E nel manifest dentro `coach.js`:
+
+```js
+'nuovo-gioco-id': {
+  fascia: 'primaria',
+  titolo: 'Consigli per il Nuovo Gioco',
+  regola: 'Una frase chiara di cosa si fa.',
+  come: ['Punto 1.', 'Punto 2.', 'Punto 3.'],
+  teoria: [
+    { titolo: 'Pagina teoria', url: '/percorso-pagina/' }
+  ]
+}
+```
+
+### 17.3 Layer 3: agganciare hint contestuale a un gioco
+
+Per un gioco con feedback wrong/correct discreto, basta aggiungere 2 righe nel
+callback wrong-answer e 1 nel callback correct-answer:
+
+```js
+// Su risposta sbagliata:
+if (window.GameCoach && window.GameCoach.hint) {
+  window.GameCoach.hint('Suggerimento mirato di 1-2 frasi.', '/percorso/teoria/');
+}
+
+// Su risposta corretta o passaggio a nuova domanda:
+if (window.GameCoach && window.GameCoach.clearHint) {
+  window.GameCoach.clearHint();
+}
+```
+
+Il `if (window.GameCoach && ...)` garantisce **fallback graceful**: il gioco
+continua a funzionare anche se `coach.js` non è caricato.
+
+### 17.4 TTS esteso al sito
+
+Lo stesso paradigma Web Speech API alimenta tre contesti distinti:
+
+| Contesto | Componente | Quanti |
+|---|---|---|
+| Pagine Hugo | `partials/leggi-ad-alta-voce.html` (opt-in `tts: true` nel frontmatter) | 21 pagine |
+| Coach giochi | `js/coach.js` (auto su tutti i giochi con `data-coach-game`) | 33 giochi |
+| Storie e fiabe | `formazione/storie-e-racconti/assets/tts-storia.js` | 18 storie |
+
+Le 21 pagine Hugo con `tts: true`:
+- 12 storiche: cosa-fare-adesso, numeri-utili, facile-da-leggere, allerte-meteo,
+  piano-familiare, 7 sotto-pagine rischi-prevenzione.
+- 9 aggiunte (maggio 2026): assistente, faq, piano-emergenza, contatti, chi-siamo,
+  diventa-volontario, glossario, rischi-prevenzione/{kit-emergenza,
+  persone-necessita-specifiche}.
+
+Per **attivare TTS su una nuova pagina Hugo**: aggiungere `tts: true` al frontmatter.
+
+Per **attivare TTS su una nuova storia/racconto**: includere
+`<script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>`
+prima di `</body>`. Il bottone si aggiunge automaticamente nella `.storia-toolbar`.
+
+### 17.5 Conformità AGID + WCAG 2.2
+
+La scelta della **Web Speech API browser-native** è raccomandata da W3C-WAI per la
+PA italiana al posto degli **overlay commerciali** (AccessiBe, UserWay, Equally AI),
+sconsigliati perché mascherano problemi di accessibilità invece di risolverli.
+
+Vantaggi:
+- **Zero costi**: nessuna API key, nessun servizio cloud, nessun fee per parola.
+- **Zero file da mantenere**: niente MP3 da rigenerare quando cambi il testo. La
+  sintesi è al volo, sempre coerente col testo.
+- **WCAG 2.2 compliant**: `aria-pressed` dinamico, focus visibile, gestione tastiera,
+  fallback graceful se browser senza Speech API.
+- **GDPR safe**: nessun dato esce dal browser, nessun tracker.
+
+Specifiche tecniche complete in `.claude/rules/03-accessibility.md` § "TTS Leggi ad
+alta voce" e § "Coach dei giochi".
+
+---
+
 *Fine del manuale. Per domande non coperte qui, apri un'Issue sul repository o contatta
 il Chief Digital Officer del Gruppo.*

--- a/README.md
+++ b/README.md
@@ -54,8 +54,19 @@ Ogni storia ha:
 - **Box "Cosa abbiamo imparato"** con 2-3 consigli pratici
 - **"Per parlarne insieme"** (domande di comprensione)
 - **"Per il/la docente — valore pedagogico"**: obiettivi di apprendimento, discipline coinvolte, competenze chiave europee, attività in classe, riferimenti curricolari (Indicazioni Nazionali 2012, L. 92/2019, D.Lgs. 1/2018, campagne DPC *Io non rischio* / *Attimo Decisivo*)
+- **Bottone "🔊 Ascolta la storia"** che legge la fiaba ad alta voce in italiano via Web Speech API (browser-native, gratis, niente file MP3). Fondamentale per bambini che non leggono ancora bene, anziani che leggono con un nipote, persone con dislessia.
 
 Le storie sono usabili come materiale didattico per l'educazione civica nelle scuole; il Gruppo apprezza la citazione nelle programmazioni.
+
+### Coach didattico nei giochi (`/giochi/`)
+
+Tutti i 33 giochi della sezione **Giochi della Sicurezza** hanno un sistema di onboarding e teoria di rinforzo:
+
+- **Bottone "💡 Consigli per giocare"** sotto il titolo: apre un dialog con la regola del gioco, "Come si gioca" e link alle pagine teoria del sito (rischi-prevenzione, numeri-utili, pittogrammi, ecc.).
+- **Bottone "🔊 Ascolta i consigli"** dentro il dialog (Web Speech API).
+- **Suggerimento contestuale su errore**: quando un bambino sbaglia, appare un riquadro con un suggerimento mirato e un link "Scopri perché →" alla teoria pertinente.
+
+Pattern ispirato a campagna DPC "Io non rischio" e linee guida AGID per accessibilità cognitiva. Riduce l'abbandono dei bambini che giocano senza nozioni di base.
 
 ### File in `archetypes/` (template Hugo)
 

--- a/content/assistente/_index.md
+++ b/content/assistente/_index.md
@@ -6,4 +6,5 @@ layout: "list"
 sitemap:
   priority: 0.8
   changefreq: monthly
+tts: true
 ---

--- a/content/chi-siamo/_index.md
+++ b/content/chi-siamo/_index.md
@@ -6,6 +6,7 @@ toc: true
 aliases:
   - /chisiamo.html
   - /chisiamo/
+tts: true
 ---
 
 <div class="card border-primary mb-5">

--- a/content/contatti/_index.md
+++ b/content/contatti/_index.md
@@ -4,6 +4,7 @@ description: "Recapiti, mappa e modalità di attivazione in emergenza."
 layout: "single"
 aliases:
   - /contatti.html
+tts: true
 ---
 
 <div class="card border-danger mb-4">

--- a/content/diventa-volontario/_index.md
+++ b/content/diventa-volontario/_index.md
@@ -6,6 +6,7 @@ toc: true
 aliases:
   - /diventavolontario.html
   - /diventavolontario/
+tts: true
 ---
 
 <div class="card border-primary mb-4">

--- a/content/faq/_index.md
+++ b/content/faq/_index.md
@@ -8,6 +8,7 @@ sitemap:
   priority: 0.7
   changefreq: monthly
 toc: true
+tts: true
 ---
 
 ## Allerte Meteo

--- a/content/glossario/_index.md
+++ b/content/glossario/_index.md
@@ -7,6 +7,7 @@ sitemap:
   priority: 0.7
   changefreq: monthly
 toc: true
+tts: true
 ---
 Le sigle e i termini tecnici della Protezione Civile possono sembrare complicati. Questa pagina li spiega in **parole semplici**, con un esempio concreto dove utile. Se cerchi un termine che non trovi, scrivici a [segreteria@protezionecivilegenzano.it](mailto:segreteria@protezionecivilegenzano.it): lo aggiungiamo.
 

--- a/content/piano-emergenza/_index.md
+++ b/content/piano-emergenza/_index.md
@@ -10,6 +10,7 @@ sitemap:
   priority: 0.8
   changefreq: monthly
 toc: true
+tts: true
 ---
 Il Piano di Emergenza Comunale è lo strumento fondamentale che stabilisce le procedure operative per affrontare qualsiasi calamità in modo organizzato ed efficace. È un documento predisposto dal Comune per la tutela della popolazione e del territorio.
 

--- a/content/rischi-prevenzione/kit-emergenza.md
+++ b/content/rischi-prevenzione/kit-emergenza.md
@@ -4,6 +4,7 @@ title: "Kit di Emergenza"
 description: "Cosa mettere nello zaino di emergenza per la tua famiglia: la lista completa degli oggetti essenziali."
 weight: 8
 toc: true
+tts: true
 ---
 Il kit di emergenza è uno zaino o una borsa sempre pronta, conservata in un luogo facilmente raggiungibile, che contiene tutto il necessario per affrontare le prime ore dopo un'evacuazione. Preparalo con calma quando non c'è emergenza: in un momento di crisi non avrai il tempo di pensare a cosa portare.
 

--- a/content/rischi-prevenzione/persone-necessita-specifiche.md
+++ b/content/rischi-prevenzione/persone-necessita-specifiche.md
@@ -4,6 +4,7 @@ title: "Persone con Necessità Specifiche"
 description: "Indicazioni per la sicurezza di anziani, persone con disabilità, bambini e altre persone in condizioni di fragilità durante le emergenze."
 weight: 9
 toc: true
+tts: true
 ---
 In ogni emergenza, le persone con necessità specifiche sono le più vulnerabili. Pianificare in anticipo le loro esigenze è fondamentale per garantirne la sicurezza. Questa pagina raccoglie indicazioni pratiche per chi si prende cura di persone fragili e per le persone stesse.
 

--- a/static/formazione/storie-e-racconti/amica-cielo/index.html
+++ b/static/formazione/storie-e-racconti/amica-cielo/index.html
@@ -161,5 +161,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/assets/storia-libro.css
+++ b/static/formazione/storie-e-racconti/assets/storia-libro.css
@@ -299,3 +299,48 @@ html, body {
 @media (prefers-reduced-motion: reduce) {
   * { transition: none !important; }
 }
+
+/* ── Bottone TTS "Ascolta la storia" (Web Speech API) ─────── */
+.tts-storia-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border: 2px solid #003366;
+  background: #fff;
+  color: #003366;
+  font-weight: 700;
+  font-size: 0.95rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background .15s, color .15s, transform .12s;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  font-family: inherit;
+}
+.tts-storia-btn:hover,
+.tts-storia-btn:focus-visible {
+  background: #003366;
+  color: #fff;
+  outline: 3px solid #ffbe2e;
+  outline-offset: 2px;
+}
+.tts-storia-btn .tts-storia-icon { font-size: 1.1rem; line-height: 1; }
+.tts-storia-btn.speaking {
+  background: #198754;
+  color: #fff;
+  border-color: #198754;
+  animation: tts-storia-pulse 1.4s ease-in-out infinite;
+}
+@keyframes tts-storia-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(25, 135, 84, .4); }
+  50%      { box-shadow: 0 0 0 8px rgba(25, 135, 84, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tts-storia-btn,
+  .tts-storia-btn.speaking { animation: none !important; transition: none !important; }
+}
+
+@media print {
+  .tts-storia-btn { display: none !important; }
+}

--- a/static/formazione/storie-e-racconti/assets/tts-storia.js
+++ b/static/formazione/storie-e-racconti/assets/tts-storia.js
@@ -1,0 +1,148 @@
+/* ============================================================
+   TTS Storia — bottone "Ascolta la storia" via Web Speech API
+   Auto-inietta nella .storia-toolbar di ogni storia/racconto.
+   ============================================================ */
+(function () {
+  'use strict';
+
+  function ttsSupported() {
+    return typeof window.speechSynthesis !== 'undefined' &&
+           typeof window.SpeechSynthesisUtterance !== 'undefined';
+  }
+
+  function pickItalianVoice() {
+    if (!ttsSupported()) return null;
+    var voices = window.speechSynthesis.getVoices() || [];
+    return voices.find(function (v) { return v.lang === 'it-IT'; }) ||
+           voices.find(function (v) { return v.lang && v.lang.indexOf('it') === 0; }) ||
+           null;
+  }
+
+  // Estrae il testo leggibile dalla pagina storia
+  function buildStoryText() {
+    var parts = [];
+    var titolo = document.querySelector('.storia-titolo-principale');
+    if (titolo) parts.push(titolo.textContent.trim() + '.');
+    var sotto = document.querySelector('.storia-sottotitolo');
+    if (sotto) parts.push(sotto.textContent.trim() + '.');
+    var corpo = document.querySelector('.storia-corpo');
+    if (corpo) {
+      // Solo i paragrafi <p>, ignora separatori decorativi
+      corpo.querySelectorAll('p, h2, h3').forEach(function (el) {
+        var t = el.textContent.trim();
+        if (t) parts.push(t);
+      });
+    }
+    return parts.join(' ');
+  }
+
+  // Spezza il testo in frasi per evitare cut-off su utterance lunghe
+  function splitIntoChunks(text, maxLen) {
+    if (!text) return [];
+    var max = maxLen || 200;
+    var result = [];
+    var sentences = text.split(/(?<=[.!?])\s+/);
+    var buf = '';
+    sentences.forEach(function (s) {
+      if ((buf + ' ' + s).length > max && buf) {
+        result.push(buf.trim());
+        buf = s;
+      } else {
+        buf = buf ? (buf + ' ' + s) : s;
+      }
+    });
+    if (buf) result.push(buf.trim());
+    return result;
+  }
+
+  var queue = [];
+  var queueIdx = 0;
+  var btnEl = null;
+  var voiceCache = null;
+
+  function setBtnState(state) {
+    if (!btnEl) return;
+    var icon = btnEl.querySelector('.tts-storia-icon');
+    var label = btnEl.querySelector('.tts-storia-label');
+    if (state === 'speaking') {
+      btnEl.classList.add('speaking');
+      btnEl.setAttribute('aria-label', 'Ferma la lettura');
+      if (label) label.textContent = 'Ferma';
+      if (icon) icon.textContent = '⏸';
+    } else {
+      btnEl.classList.remove('speaking');
+      btnEl.setAttribute('aria-label', 'Ascolta la storia ad alta voce');
+      if (label) label.textContent = 'Ascolta';
+      if (icon) icon.textContent = '🔊';
+    }
+  }
+
+  function stop() {
+    if (!ttsSupported()) return;
+    try { window.speechSynthesis.cancel(); } catch (e) { /* noop */ }
+    queue = []; queueIdx = 0;
+    setBtnState('idle');
+  }
+
+  function speakNext() {
+    if (queueIdx >= queue.length) { stop(); return; }
+    var u = new SpeechSynthesisUtterance(queue[queueIdx]);
+    u.lang = 'it-IT';
+    u.rate = 0.9;
+    u.pitch = 1;
+    if (voiceCache) u.voice = voiceCache;
+    u.onend = function () {
+      queueIdx++;
+      if (queueIdx < queue.length) speakNext();
+      else stop();
+    };
+    u.onerror = function () { stop(); };
+    window.speechSynthesis.speak(u);
+  }
+
+  function start() {
+    if (!ttsSupported()) return;
+    if (window.speechSynthesis.speaking) { stop(); return; }
+    var text = buildStoryText();
+    if (!text) return;
+    voiceCache = pickItalianVoice();
+    queue = splitIntoChunks(text, 200);
+    queueIdx = 0;
+    setBtnState('speaking');
+    speakNext();
+  }
+
+  function injectButton() {
+    if (!ttsSupported()) return;
+    var toolbar = document.querySelector('.storia-toolbar');
+    if (!toolbar) return;
+
+    btnEl = document.createElement('button');
+    btnEl.type = 'button';
+    btnEl.className = 'tts-storia-btn';
+    btnEl.setAttribute('aria-label', 'Ascolta la storia ad alta voce');
+    btnEl.innerHTML = '<span class="tts-storia-icon" aria-hidden="true">🔊</span><span class="tts-storia-label">Ascolta</span>';
+    btnEl.addEventListener('click', start);
+
+    // Inserisci il bottone come secondo elemento (dopo "Torna alle storie")
+    var first = toolbar.firstElementChild;
+    if (first && first.nextSibling) {
+      toolbar.insertBefore(btnEl, first.nextSibling);
+    } else {
+      toolbar.appendChild(btnEl);
+    }
+  }
+
+  // Stop TTS quando si lascia la pagina
+  if (typeof window !== 'undefined' && window.addEventListener) {
+    window.addEventListener('pagehide', stop);
+    window.addEventListener('beforeunload', stop);
+  }
+
+  // Auto-init
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', injectButton);
+  } else {
+    injectButton();
+  }
+})();

--- a/static/formazione/storie-e-racconti/bosco-parlava/index.html
+++ b/static/formazione/storie-e-racconti/bosco-parlava/index.html
@@ -156,5 +156,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/casa-che-balla/index.html
+++ b/static/formazione/storie-e-racconti/casa-che-balla/index.html
@@ -149,5 +149,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/cuore-della-montagna/index.html
+++ b/static/formazione/storie-e-racconti/cuore-della-montagna/index.html
@@ -183,5 +183,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/giardino-parole-sicure/index.html
+++ b/static/formazione/storie-e-racconti/giardino-parole-sicure/index.html
@@ -197,5 +197,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/muschio-dispettoso/index.html
+++ b/static/formazione/storie-e-racconti/muschio-dispettoso/index.html
@@ -161,5 +161,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/notturno-blackout/index.html
+++ b/static/formazione/storie-e-racconti/notturno-blackout/index.html
@@ -153,5 +153,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/nuvola-arrabbiata/index.html
+++ b/static/formazione/storie-e-racconti/nuvola-arrabbiata/index.html
@@ -129,5 +129,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/pioggia-mare/index.html
+++ b/static/formazione/storie-e-racconti/pioggia-mare/index.html
@@ -160,5 +160,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/polvere-angelo/index.html
+++ b/static/formazione/storie-e-racconti/polvere-angelo/index.html
@@ -182,5 +182,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/radio-dimenticata/index.html
+++ b/static/formazione/storie-e-racconti/radio-dimenticata/index.html
@@ -167,5 +167,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/ragazzo-vento/index.html
+++ b/static/formazione/storie-e-racconti/ragazzo-vento/index.html
@@ -179,5 +179,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/sette-sirene-paese/index.html
+++ b/static/formazione/storie-e-racconti/sette-sirene-paese/index.html
@@ -190,5 +190,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/terra-fa-solletico/index.html
+++ b/static/formazione/storie-e-racconti/terra-fa-solletico/index.html
@@ -141,5 +141,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/tina-amico-difficolta/index.html
+++ b/static/formazione/storie-e-racconti/tina-amico-difficolta/index.html
@@ -143,5 +143,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/tina-fischietto-magico/index.html
+++ b/static/formazione/storie-e-racconti/tina-fischietto-magico/index.html
@@ -143,5 +143,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/tina-temporale-gentile/index.html
+++ b/static/formazione/storie-e-racconti/tina-temporale-gentile/index.html
@@ -133,5 +133,6 @@
     </footer>
 
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/formazione/storie-e-racconti/tre-pompieri-amici/index.html
+++ b/static/formazione/storie-e-racconti/tre-pompieri-amici/index.html
@@ -156,5 +156,6 @@
       <p>Storia di Protezione Civile · Genzano di Roma · <a href="/formazione/storie-e-racconti/">Biblioteca delle storie</a></p>
     </footer>
   </article>
+  <script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>
 </body>
 </html>

--- a/static/giochi/assets/css/coach.css
+++ b/static/giochi/assets/css/coach.css
@@ -250,11 +250,93 @@ body.rag-body .coach-trigger:focus-visible {
   .coach-trigger:hover { transform: none; }
 }
 
+/* ── Bottone TTS "Ascolta" (Web Speech API) ─────────────── */
+.coach-speak-row {
+  display: flex;
+  justify-content: flex-start;
+  margin: 0 0 .8rem;
+}
+.coach-speak-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  padding: .55rem 1rem;
+  border: 2px solid #0066CC;
+  background: #fff;
+  color: #003366;
+  font-weight: 700;
+  font-size: 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background .15s, color .15s, transform .12s;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, .08);
+}
+.coach-speak-btn:hover,
+.coach-speak-btn:focus-visible {
+  background: #0066CC;
+  color: #fff;
+  outline: 3px solid #ffbe2e;
+  outline-offset: 2px;
+}
+.coach-speak-btn .coach-speak-icon { font-size: 1.2rem; line-height: 1; }
+.coach-speak-btn.speaking {
+  background: #198754;
+  color: #fff;
+  border-color: #198754;
+  animation: coach-speak-pulse 1.4s ease-in-out infinite;
+}
+@keyframes coach-speak-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(25, 135, 84, .4); }
+  50%      { box-shadow: 0 0 0 8px rgba(25, 135, 84, 0); }
+}
+
+/* Variante mini per i hint contestuali */
+.coach-speak-btn-mini {
+  padding: .3rem .7rem;
+  font-size: .85rem;
+  margin-top: .4rem;
+}
+.coach-hint {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+.coach-hint-text { flex: 1; }
+
+/* Variante visiva per fascia */
+body.inf-body .coach-speak-btn {
+  border-color: #F4B700;
+  color: #17324D;
+  font-size: 1.05rem;
+}
+body.inf-body .coach-speak-btn:hover,
+body.inf-body .coach-speak-btn:focus-visible {
+  background: #F4B700;
+  color: #17324D;
+}
+body.rag-body .coach-speak-btn {
+  background: rgba(255, 255, 255, .12);
+  border-color: #ffbe2e;
+  color: #fff;
+}
+body.rag-body .coach-speak-btn:hover,
+body.rag-body .coach-speak-btn:focus-visible {
+  background: #ffbe2e;
+  color: #17324D;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .coach-speak-btn,
+  .coach-speak-btn.speaking { animation: none !important; transition: none !important; }
+}
+
 /* Stampa: nascondi tutto il coach */
 @media print {
   .coach-trigger,
   .coach-backdrop,
-  .coach-hint {
+  .coach-hint,
+  .coach-speak-btn {
     display: none !important;
   }
 }

--- a/static/giochi/assets/js/coach.js
+++ b/static/giochi/assets/js/coach.js
@@ -518,11 +518,97 @@
   var dialogEl = null;
   var lastFocus = null;
   var hintEl = null;
+  var currentUtterance = null;
+  var currentSpeakBtn = null;
 
   function escHtml(s) {
     return String(s).replace(/[&<>"']/g, function (c) {
       return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
     });
+  }
+
+  // ──────────────────────────────────────────────────────────
+  // Text-to-speech via Web Speech API (browser-native, niente file MP3)
+  // ──────────────────────────────────────────────────────────
+  function ttsSupported() {
+    return typeof window.speechSynthesis !== 'undefined' &&
+           typeof window.SpeechSynthesisUtterance !== 'undefined';
+  }
+
+  function pickItalianVoice() {
+    if (!ttsSupported()) return null;
+    var voices = window.speechSynthesis.getVoices() || [];
+    return voices.find(function(v){ return v.lang === 'it-IT'; }) ||
+           voices.find(function(v){ return v.lang && v.lang.indexOf('it') === 0; }) ||
+           null;
+  }
+
+  function stopSpeaking() {
+    if (!ttsSupported()) return;
+    try { window.speechSynthesis.cancel(); } catch (e) { /* noop */ }
+    if (currentSpeakBtn) {
+      currentSpeakBtn.classList.remove('speaking');
+      currentSpeakBtn.setAttribute('aria-label', currentSpeakBtn.dataset.labelPlay || 'Ascolta');
+      currentSpeakBtn.querySelector('.coach-speak-text').textContent = currentSpeakBtn.dataset.textPlay || 'Ascolta';
+    }
+    currentUtterance = null;
+    currentSpeakBtn = null;
+  }
+
+  function speak(text, btn) {
+    if (!ttsSupported() || !text) return false;
+    // Se sta già parlando lo stesso bottone: stop (toggle)
+    if (currentSpeakBtn === btn && window.speechSynthesis.speaking) {
+      stopSpeaking();
+      return true;
+    }
+    stopSpeaking();
+    var u = new SpeechSynthesisUtterance(text);
+    u.lang = 'it-IT';
+    u.rate = 0.9;
+    u.pitch = 1;
+    var voice = pickItalianVoice();
+    if (voice) u.voice = voice;
+    u.onend = function () {
+      if (currentSpeakBtn === btn) stopSpeaking();
+    };
+    u.onerror = function () {
+      if (currentSpeakBtn === btn) stopSpeaking();
+    };
+    currentUtterance = u;
+    currentSpeakBtn = btn;
+    if (btn) {
+      btn.classList.add('speaking');
+      btn.setAttribute('aria-label', btn.dataset.labelStop || 'Ferma lettura');
+      btn.querySelector('.coach-speak-text').textContent = btn.dataset.textStop || 'Ferma';
+    }
+    window.speechSynthesis.speak(u);
+    return true;
+  }
+
+  function makeSpeakButton(text, labelPlay, textPlay) {
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'coach-speak-btn';
+    btn.dataset.labelPlay = labelPlay || 'Ascolta';
+    btn.dataset.labelStop = 'Ferma lettura';
+    btn.dataset.textPlay = textPlay || 'Ascolta';
+    btn.dataset.textStop = 'Ferma';
+    btn.setAttribute('aria-label', btn.dataset.labelPlay);
+    btn.innerHTML = '<span class="coach-speak-icon" aria-hidden="true">🔊</span><span class="coach-speak-text">' + escHtml(btn.dataset.textPlay) + '</span>';
+    btn.addEventListener('click', function () { speak(text, btn); });
+    return btn;
+  }
+
+  function buildSpeechText(c) {
+    var parts = [];
+    if (c.titolo) parts.push(c.titolo + '.');
+    if (c.regola) parts.push(c.regola);
+    if (c.come && c.come.length) {
+      parts.push('Come si gioca.');
+      c.come.forEach(function (item) { parts.push(item); });
+    }
+    return parts.join(' ');
   }
 
   function trapFocus(container, e) {
@@ -572,6 +658,7 @@
     var html = '';
     html += '<button type="button" class="coach-btn-x" aria-label="Chiudi consigli">&times;</button>';
     html += '<h2 id="coach-title"><span aria-hidden="true">💡</span> ' + escHtml(c.titolo) + '</h2>';
+    html += '<div class="coach-speak-row" data-coach-tts-anchor></div>';
     html += '<div class="coach-regola">' + escHtml(c.regola) + '</div>';
     if (c.come && c.come.length) {
       html += '<h3>Come si gioca</h3>';
@@ -600,6 +687,14 @@
     document.body.appendChild(backdrop);
     dialogEl = backdrop;
 
+    // Bottone TTS "Ascolta i consigli" — solo se la Web Speech API è supportata
+    if (ttsSupported()) {
+      var anchor = dialog.querySelector('[data-coach-tts-anchor]');
+      var speechText = buildSpeechText(c);
+      var speakBtn = makeSpeakButton(speechText, 'Ascolta i consigli ad alta voce', 'Ascolta i consigli');
+      anchor.appendChild(speakBtn);
+    }
+
     dialog.querySelector('.coach-btn-x').addEventListener('click', close);
     dialog.querySelector('.coach-btn-close').addEventListener('click', close);
     document.addEventListener('keydown', onKeydown);
@@ -609,6 +704,7 @@
 
   function close() {
     if (!dialogEl) return;
+    stopSpeaking();
     dialogEl.remove();
     dialogEl = null;
     document.removeEventListener('keydown', onKeydown);
@@ -639,16 +735,28 @@
     hintEl.className = 'coach-hint';
     hintEl.setAttribute('role', 'status');
     hintEl.setAttribute('aria-live', 'polite');
-    var html = '<strong>Suggerimento:</strong> ' + escHtml(testo);
+    var inner = document.createElement('div');
+    inner.className = 'coach-hint-text';
+    var introHtml = '<strong>Suggerimento:</strong> ' + escHtml(testo);
     if (urlOpz) {
-      html += '<br><a href="' + escHtml(urlOpz) + '">Scopri perché →</a>';
+      introHtml += '<br><a href="' + escHtml(urlOpz) + '">Scopri perché →</a>';
     }
-    hintEl.innerHTML = html;
+    inner.innerHTML = introHtml;
+    hintEl.appendChild(inner);
+    if (ttsSupported()) {
+      var speakBtn = makeSpeakButton(testo, 'Ascolta il suggerimento ad alta voce', 'Ascolta');
+      speakBtn.classList.add('coach-speak-btn-mini');
+      hintEl.appendChild(speakBtn);
+    }
     trigger.parentNode.insertBefore(hintEl, trigger.nextSibling);
   }
 
   function clearHint() {
     if (hintEl && hintEl.parentNode) {
+      // Se sta leggendo l'hint corrente, ferma la voce
+      if (currentSpeakBtn && hintEl.contains(currentSpeakBtn)) {
+        stopSpeaking();
+      }
       hintEl.parentNode.removeChild(hintEl);
     }
     hintEl = null;
@@ -695,12 +803,21 @@
     autoInit();
   }
 
+  // Stop speech quando l'utente lascia la pagina o passa in background
+  if (typeof window !== 'undefined' && window.addEventListener) {
+    window.addEventListener('pagehide', stopSpeaking);
+    window.addEventListener('beforeunload', stopSpeaking);
+  }
+
   // Esporta API pubblica
   window.GameCoach = {
     open: open,
     close: close,
     hint: hint,
     clearHint: clearHint,
+    speak: speak,
+    stopSpeaking: stopSpeaking,
+    ttsSupported: ttsSupported,
     /* ammesso solo a fini di test/debug */
     _manifest: CONTENUTI
   };

--- a/static/giochi/infanzia/acchiappa-pericolo/index.html
+++ b/static/giochi/infanzia/acchiappa-pericolo/index.html
@@ -212,12 +212,16 @@
       if (it.danger) {
         btn.classList.add('correct');
         score++;
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
       } else {
         btn.classList.add('wrong');
         // mostra anche quello giusto
         scenaEl.querySelectorAll('.item-btn').forEach(b => {
           if (b !== btn) b.classList.add('dim');
         });
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('Pericolose: fuoco, prese, coltelli, sostanze. Sicure: peluche, libri, acqua da bere.', '/cosa-fare-adesso/');
+        }
       }
       setTimeout(() => {
         cur++;

--- a/static/giochi/infanzia/cielo-oggi/index.html
+++ b/static/giochi/infanzia/cielo-oggi/index.html
@@ -360,6 +360,7 @@
       feedback.textContent = 'Quale bandiera?';
       feedback.style.color = 'var(--inf-testo)';
       bandiere.forEach(function(b){ b.classList.remove('correct','wrong'); b.disabled = false; });
+      if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
     }
 
     function scegli(btn){
@@ -388,6 +389,9 @@
         errori++;
         if (window.AudioSintetico) window.AudioSintetico.tonoNeutro();
         setTimeout(function(){ btn.classList.remove('wrong'); }, 500);
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('Verde = bel tempo. Giallo = vento o nuvole. Arancione = pioggia forte. Rosso = pericolo.', '/allerte-meteo/');
+        }
       }
     }
 

--- a/static/giochi/infanzia/mezzo-giusto/index.html
+++ b/static/giochi/infanzia/mezzo-giusto/index.html
@@ -172,6 +172,7 @@
       buttons.forEach(b => { b.classList.remove('correct', 'wrong', 'dim'); });
       locked = false;
       drawProgress();
+      if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
     }
 
     function onPick(btn) {
@@ -188,6 +189,14 @@
           if (b.getAttribute('data-tipo') === giusto) b.classList.add('correct');
           else if (b !== btn) b.classList.add('dim');
         });
+        if (window.GameCoach && window.GameCoach.hint) {
+          var TIPS = {
+            pompiere: 'Pompieri = fuoco, gas, persone bloccate.',
+            ambulanza: 'Ambulanza = qualcuno è ferito o sta male.',
+            volontari: 'Volontari = aiuti dopo l\'emergenza (acqua, cibo, alberi caduti).'
+          };
+          window.GameCoach.hint(TIPS[giusto] || 'In Italia chiami sempre il 1-1-2.', '/numeri-utili/');
+        }
       }
       setTimeout(() => {
         cur++;

--- a/static/giochi/infanzia/rifugio-tina/index.html
+++ b/static/giochi/infanzia/rifugio-tina/index.html
@@ -413,6 +413,7 @@
         if (window.AudioSintetico) window.AudioSintetico.dingPositivo();
         progressBolli[idx].classList.add('on');
         progressBolli[idx].innerHTML = '<i class="bi bi-check-lg"></i>';
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
         setTimeout(function(){
           idx++;
           if (idx >= SCENE.length) fine();
@@ -425,6 +426,9 @@
         errori++;
         if (window.AudioSintetico) window.AudioSintetico.tonoNeutro();
         setTimeout(function(){ spot.classList.remove('wrong-flash'); }, 900);
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('Cerca un riparo robusto: muri spessi, sotto al tavolo, in una stanza interna. Lontano da finestre e oggetti che cadono.', '/rischi-prevenzione/');
+        }
       }
     }
 

--- a/static/giochi/infanzia/suoni-emergenza/index.html
+++ b/static/giochi/infanzia/suoni-emergenza/index.html
@@ -163,11 +163,15 @@
         feedback.style.color = '#0f5132';
         feedback.innerHTML = '✅ Bravo! Era il ' + target.lbl.toLowerCase() + '.';
         if (window.AudioSintetico) window.AudioSintetico.dingPositivo();
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
       } else {
         btn.classList.add('wrong');
         feedback.style.color = '#8B1F2E';
         feedback.innerHTML = '🐢 Era il ' + target.lbl.toLowerCase() + '. Continua!';
         if (window.AudioSintetico) window.AudioSintetico.tonoNeutro();
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('Sirena ambulanza = 3 toni veloci. Tuono = boom dopo il fulmine. Allarme scuola = suono lungo. IT-Alert = il telefono squilla forte.', '/allerte-meteo/');
+        }
       }
       setTimeout(function(){
         idx++;

--- a/static/giochi/infanzia/tartaruga-saggia/index.html
+++ b/static/giochi/infanzia/tartaruga-saggia/index.html
@@ -170,6 +170,7 @@
       btnSi.disabled = false; btnNo.disabled = false;
       btnSi.classList.remove('correct','wrong');
       btnNo.classList.remove('correct','wrong');
+      if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
     }
 
     function answer(val){
@@ -189,6 +190,9 @@
         feedback.style.color = '#8B1F2E';
         feedback.innerHTML = '🐢 ' + s.tip;
         if (window.AudioSintetico) window.AudioSintetico.tonoNeutro();
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('In emergenza: stai calmo, scegli il posto più sicuro, chiedi aiuto a un adulto. Se serve, chiama il 1-1-2.', '/cosa-fare-adesso/');
+        }
       }
       setTimeout(function(){
         idx++;

--- a/static/giochi/infanzia/trova-cartello/index.html
+++ b/static/giochi/infanzia/trova-cartello/index.html
@@ -278,6 +278,7 @@
         feedbackEl.style.color = '#198754';
         cartelliEl.querySelectorAll('button').forEach(function (b) { b.disabled = true; if (b !== btn) b.classList.add('dim'); });
         if (window.AudioSintetico) window.AudioSintetico.tono({ freq: 659, durata: 0.18 });
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
         setTimeout(function () {
           round++;
           showRound();
@@ -289,6 +290,9 @@
         feedbackEl.style.color = '#dc3545';
         if (window.AudioSintetico) window.AudioSintetico.tonoNeutro();
         setTimeout(function () { btn.classList.remove('wrong'); }, 500);
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('Verde = sicurezza (uscita, primo soccorso). Rosso = divieto. Giallo = attenzione. Blu = obbligo (casco, guanti).', '/pittogrammi/');
+        }
       }
     }
 

--- a/static/giochi/infanzia/vesti-tina/index.html
+++ b/static/giochi/infanzia/vesti-tina/index.html
@@ -241,6 +241,7 @@
     function mostraRound(){
       grid.innerHTML = '';
       feedback.textContent = '';
+      if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
       var r = ROUNDS[idx];
       var items = [{id:r.giusto.id,nome:r.giusto.nome,ok:true}]
         .concat(r.sbagliati.map(function(s){return {id:s.id,nome:s.nome,ok:false};}));
@@ -278,6 +279,9 @@
         errori++;
         if (window.AudioSintetico) window.AudioSintetico.tonoNeutro();
         setTimeout(function(){ btn.classList.remove('sbagliato'); }, 500);
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('In emergenza servono: acqua, cibo, torcia, casco, giacchetto, coperta. NON servono: caramelle, peluche, videogiochi, TV.', '/rischi-prevenzione/kit-emergenza/');
+        }
       }
     }
 

--- a/static/giochi/primaria/abbina-impara/js/script.js
+++ b/static/giochi/primaria/abbina-impara/js/script.js
@@ -101,7 +101,19 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     ];
 
-    let selectedLeft = null, matched = 0, total = 0, errors = 0;
+    let selectedLeft = null, matched = 0, total = 0, errors = 0, currentCat = null;
+
+    // Mappa titolo categoria → pagina teoria del sito
+    const TEORIA_CAT = {
+        'Numeri di emergenza':    { url: '/numeri-utili/',                       titolo: 'numeri utili' },
+        'Codici colore allerta':  { url: '/allerte-meteo/',                      titolo: 'allerte meteo' },
+        'Rischi e comportamenti': { url: '/rischi-prevenzione/',                 titolo: 'rischi e prevenzione' },
+        'Oggetti dello zaino':    { url: '/rischi-prevenzione/kit-emergenza/',   titolo: 'kit di emergenza' },
+        'Cartelli di sicurezza':  { url: '/pittogrammi/',                        titolo: 'pittogrammi' },
+        'Classi di fuoco':        { url: '/rischi-prevenzione/rischio-incendio/',titolo: 'rischio incendio' },
+        'Ruoli in emergenza':     { url: '/chi-siamo/',                          titolo: 'chi siamo' },
+        'Meteo e allerte':        { url: '/allerte-meteo/',                      titolo: 'allerte meteo' }
+    };
 
     function shuffle(arr) {
         for (let i = arr.length - 1; i > 0; i--) {
@@ -129,6 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
         selectScreen.classList.add('hide');
         gameScreen.classList.remove('hide');
         catTitle.textContent = cat.title;
+        currentCat = cat;
         matched = 0; errors = 0; selectedLeft = null;
         total = cat.pairs.length;
         matchedCount.textContent = 0;
@@ -180,6 +193,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 gameFeedback.className = 'game-feedback correct';
                 gameFeedback.textContent = 'Giusto!';
                 gameFeedback.classList.remove('hide');
+                if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
                 selectedLeft = null;
                 if (matched === total) {
                     setTimeout(showEnd, 800);
@@ -191,6 +205,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 gameFeedback.className = 'game-feedback wrong';
                 gameFeedback.textContent = 'Non corrispondono, riprova!';
                 gameFeedback.classList.remove('hide');
+                if (window.GameCoach && window.GameCoach.hint && currentCat) {
+                    const t = TEORIA_CAT[currentCat.title] || { url: '/rischi-prevenzione/', titolo: 'rischi e prevenzione' };
+                    window.GameCoach.hint('Pensa al collegamento più diretto. La pagina ' + t.titolo + ' del sito ti dà gli abbinamenti giusti.', t.url);
+                }
                 setTimeout(() => {
                     el.classList.remove('wrong-flash');
                     if (selectedLeft) selectedLeft.classList.remove('wrong-flash', 'selected');

--- a/static/giochi/primaria/anagrammi/js/script.js
+++ b/static/giochi/primaria/anagrammi/js/script.js
@@ -340,6 +340,7 @@ document.addEventListener('DOMContentLoaded', () => {
         feedbackBox.classList.remove('hide', 'wrong');
         feedbackBox.classList.add('correct');
         feedbackBox.innerHTML = `<i class="bi bi-check-circle-fill" aria-hidden="true"></i> Bravissimo! +${earned} punti`;
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
         nextBtn.classList.remove('hide');
         nextBtn.focus();
       } else {
@@ -347,6 +348,9 @@ document.addEventListener('DOMContentLoaded', () => {
         feedbackBox.classList.remove('hide', 'correct');
         feedbackBox.classList.add('wrong');
         feedbackBox.innerHTML = '<i class="bi bi-x-circle-fill" aria-hidden="true"></i> Non è corretto. Riprova!';
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('Le parole sono tutte legate alla Protezione Civile. Conta le lettere e pensa alla definizione: il glossario del sito ha quasi tutte le parole.', '/glossario/');
+        }
         // sblocca le tile per farle riposizionare
         setTimeout(() => {
           resetWord();

--- a/static/giochi/primaria/chiamata-112/index.html
+++ b/static/giochi/primaria/chiamata-112/index.html
@@ -623,6 +623,11 @@
       var label = opt.kind === 'ok' ? 'Risposta giusta' : (opt.kind === 'ko' ? 'Risposta sbagliata' : 'Risposta poco utile');
       feedbackEl.innerHTML = '<strong>' + label + '.</strong>' + opt.fb;
       feedbackEl.classList.remove('hide');
+      if (opt.kind === 'ok') {
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
+      } else if (window.GameCoach && window.GameCoach.hint) {
+        window.GameCoach.hint('Al 112 dici sempre tre cose: COSA succede, DOVE sei, QUANTI siete. Resta calmo, non riagganciare per primo.', '/numeri-utili/');
+      }
       nextBtn.classList.remove('hide');
       nextBtn.onclick = function () {
         stepIdx++;

--- a/static/giochi/primaria/posiziona-cartelli/index.html
+++ b/static/giochi/primaria/posiziona-cartelli/index.html
@@ -724,10 +724,14 @@
       }
       if (ok === current.cartelli.length) {
         setTimeout(finish, 700);
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
       } else {
         feedbackMsg.className = 'alert alert-warning mt-3';
         feedbackMsg.textContent = 'Hai ' + ko + ' cartell' + (ko === 1 ? 'o' : 'i') + ' da spostare. Sposta quelli sbagliati e riprova.';
         feedbackMsg.classList.remove('hide');
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('Forme e colori aiutano: triangolo giallo = pericolo, cerchio rosso = divieto, cerchio blu = obbligo, quadrato verde = sicurezza, quadrato rosso = antincendio.', '/pittogrammi/');
+        }
       }
     }
 

--- a/static/giochi/primaria/semaforo-rischio/js/script.js
+++ b/static/giochi/primaria/semaforo-rischio/js/script.js
@@ -87,6 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
         progressBar.style.width = ((index / queue.length) * 100) + '%';
         situationText.textContent = queue[index].text;
         buttons.forEach(b => { b.disabled = false; });
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
     }
 
     function handleAnswer(chosen) {
@@ -106,6 +107,9 @@ document.addEventListener('DOMContentLoaded', () => {
             feedback.className = 'feedback-box wrong';
             const colorLabel = { verde: 'Verde', giallo: 'Giallo', rosso: 'Rosso' };
             feedback.innerHTML = '<i class="bi bi-x-circle-fill me-1"></i> La risposta era <strong>' + colorLabel[sit.answer] + '</strong>. ' + sit.tip;
+            if (window.GameCoach && window.GameCoach.hint) {
+                window.GameCoach.hint('Verde = sicuro (lo puoi fare). Giallo = attenzione (rischio basso). Rosso = pericoloso o vietato. Stessa logica dell\'allerta meteo.', '/allerte-meteo/');
+            }
         }
         feedback.classList.remove('hide');
         setTimeout(() => {

--- a/static/giochi/ragazzi/cartelli-pericolo/index.html
+++ b/static/giochi/ragazzi/cartelli-pericolo/index.html
@@ -454,6 +454,18 @@
       feedbackEl.className = 'feedback-box ' + (isOk ? 'ok' : 'ko');
       feedbackEl.innerHTML = '<strong>' + (isOk ? 'Giusto' : 'Sbagliato') + '.</strong>' + q.why;
       feedbackEl.classList.remove('hide');
+      if (window.GameCoach) {
+        if (isOk && window.GameCoach.clearHint) {
+          window.GameCoach.clearHint();
+        } else if (!isOk && window.GameCoach.hint) {
+          var TIPS_CHAPTER = {
+            CLP: 'CLP: diamante bianco con bordo rosso. Pittogramma centrale identifica il pericolo (fiamma, teschio, punto esclamativo, ecc.).',
+            ADR: 'ADR: diamante colorato con numero in basso (1=esplosivo, 2=gas, 3=liquido infiammabile, 6=tossico, 7=radioattivo, 8=corrosivo).',
+            UNI: 'UNI EN ISO 7010: triangolo giallo=pericolo, cerchio rosso=divieto, cerchio blu=obbligo, quadrato verde=salvataggio, quadrato rosso=antincendio.'
+          };
+          window.GameCoach.hint(TIPS_CHAPTER[currentChapter] || 'Guarda forma e colore prima del simbolo: ti danno la categoria.', '/pittogrammi/');
+        }
+      }
       nextBtn.classList.remove('hide');
       nextBtn.onclick = function () { idx++; showQuestion(); };
     }

--- a/static/giochi/ragazzi/codice-arancione/index.html
+++ b/static/giochi/ragazzi/codice-arancione/index.html
@@ -248,6 +248,10 @@
       else msg = 'Allestimento insufficiente: ripassa i requisiti base dell\'accoglienza.';
       document.getElementById('final-msg').textContent = msg;
 
+      if (window.GameCoach && window.GameCoach.hint && score < 70) {
+        window.GameCoach.hint('Le priorità in un\'area di accoglienza: posti letto + bagni + pasti + copertura sanitaria. Senza questi quattro pilastri non si parte. Accessibilità e sicurezza sono obbligatori per legge.', '/rischi-prevenzione/persone-necessita-specifiche/');
+      }
+
       if (window.GiochiUtil) window.GiochiUtil.salvaEMostraAttestato('codice-arancione', score, 100, '#end');
     }
 

--- a/static/giochi/ragazzi/linea-tempo-eventi/index.html
+++ b/static/giochi/ragazzi/linea-tempo-eventi/index.html
@@ -285,6 +285,13 @@
         else { s.classList.add('wrong'); var tuo = EVENTI.filter(function(e){return e.id === id;})[0]; rev.textContent = 'Era: ' + tuo.anno + ' — Qui andava: ' + corretto.titolo + ' (' + corretto.anno + ')'; }
         card.appendChild(rev);
       });
+      if (window.GameCoach) {
+        if (score === EVENTI.length && window.GameCoach.clearHint) {
+          window.GameCoach.clearHint();
+        } else if (score < EVENTI.length && window.GameCoach.hint) {
+          window.GameCoach.hint('Cronologia chiave: Vajont 1963, Friuli 1976, Irpinia 1980 (nascita PC moderna), L\'Aquila 2009 (valutazione rischio sismico), Centro Italia 2016 (sistema COC/COM consolidato).', '/normativa/');
+        }
+      }
       setTimeout(fine.bind(null, score), 900);
     }
 

--- a/static/giochi/ragazzi/mappa-rischio/index.html
+++ b/static/giochi/ragazzi/mappa-rischio/index.html
@@ -242,6 +242,13 @@
       });
       details += '</ul>';
       feedback.innerHTML = '<div class="alert alert-info">' + details + '</div>';
+      if (window.GameCoach) {
+        if (ok === ELEMENTI.length && window.GameCoach.clearHint) {
+          window.GameCoach.clearHint();
+        } else if (ok < ELEMENTI.length && window.GameCoach.hint) {
+          window.GameCoach.hint('Castelli Romani: rischio idrogeologico (versanti) e sismico. Costa: mareggiate. Aree industriali: rischio chimico (Seveso). Boschi: incendio (giugno-settembre). Centro storico: sismico amplificato.', '/rischi-prevenzione/');
+        }
+      }
       setTimeout(function(){ finish(ok); }, 1000);
     });
 

--- a/static/giochi/ragazzi/radio-emergency/index.html
+++ b/static/giochi/ragazzi/radio-emergency/index.html
@@ -267,10 +267,14 @@
               b.classList.add('correct');
               punti++; puntiEl.textContent = punti;
               feedback.innerHTML = '<div class="alert alert-success py-2 mb-0"><i class="bi bi-check-circle-fill me-1"></i> ' + q.spiega + '</div>';
+              if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
             } else {
               b.classList.add('wrong');
               opzioni.querySelectorAll('.opt-btn')[q.corretta].classList.add('correct');
               feedback.innerHTML = '<div class="alert alert-warning py-2 mb-0"><i class="bi bi-x-circle-fill me-1"></i> ' + q.spiega + '</div>';
+              if (window.GameCoach && window.GameCoach.hint) {
+                window.GameCoach.hint('Alfabeto NATO: A=Alfa, B=Bravo, C=Charlie, D=Delta, E=Echo… Numeri cifra-per-cifra: 112 = "uno-uno-due". Termini: "passo"=aspetto risposta, "chiudo"=fine comunicazione.', '/comunicazioni/?categoria=Radiocomunicazioni');
+              }
             }
             setTimeout(function(){ idx++; show(); }, 1700);
           });
@@ -292,8 +296,12 @@
       if (v === q.risposta.toUpperCase()){
         punti++; puntiEl.textContent = punti;
         feedback.innerHTML = '<div class="alert alert-success py-2 mb-0"><i class="bi bi-check-circle-fill me-1"></i> Perfetto! ' + q.spiega + '</div>';
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
       } else {
         feedback.innerHTML = '<div class="alert alert-warning py-2 mb-0"><i class="bi bi-x-circle-fill me-1"></i> Hai scritto "' + inputLibero.value + '". ' + q.spiega + '</div>';
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('Decodifica NATO: ogni parola corrisponde a una lettera. Esempio: Alfa=A, Bravo=B, Charlie=C. La parola finale è la sequenza delle lettere iniziali.', '/comunicazioni/?categoria=Radiocomunicazioni');
+        }
       }
       setTimeout(function(){ idx++; show(); }, 1800);
     });

--- a/static/giochi/ragazzi/scelte-difficili/index.html
+++ b/static/giochi/ragazzi/scelte-difficili/index.html
@@ -315,6 +315,13 @@
       e.innerHTML = '<span class="badge-pt">+' + scelta.pt + ' pt</span>' + scelta.fb;
       e.classList.remove('hide');
       document.getElementById('punti-tot').textContent = totale;
+      if (window.GameCoach) {
+        if (scelta.esito === 'ottimo' && window.GameCoach.clearHint) {
+          window.GameCoach.clearHint();
+        } else if (scelta.esito !== 'ottimo' && window.GameCoach.hint) {
+          window.GameCoach.hint('Priorità in emergenza: 1) sicurezza personale, 2) salvare vite, 3) comunicare alla Sala Operativa, 4) coordinarsi (mai eroi solitari). Le scelte sotto stress vanno in questa scala.', '/cosa-fare-adesso/');
+        }
+      }
       // Last decision of last scenario? Otherwise show next btn
       const isLastDec = (scenarioIdx === SCENARI.length - 1) &&
                        (decisioneIdx === SCENARI[scenarioIdx].decisioni.length - 1);

--- a/static/giochi/ragazzi/simulatore-coc/index.html
+++ b/static/giochi/ragazzi/simulatore-coc/index.html
@@ -253,9 +253,13 @@
       if (corretto){
         ok++; corretteEl.textContent = ok;
         feedback.innerHTML = '<div class="alert alert-success py-2 mb-0 small"><i class="bi bi-check-circle-fill me-1"></i> Corretto! ' + ev.spiega + '</div>';
+        if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
       } else {
         ko++; errateEl.textContent = ko;
         feedback.innerHTML = '<div class="alert alert-warning py-2 mb-0 small"><i class="bi bi-exclamation-triangle-fill me-1"></i> Era <strong>F' + ev.corretta + '</strong>. ' + ev.spiega + '</div>';
+        if (window.GameCoach && window.GameCoach.hint) {
+          window.GameCoach.hint('Le 9 funzioni del Metodo Augustus: F1=tecnica/cartografia, F2=sanità, F3=volontariato, F4=materiali/mezzi, F5=servizi essenziali, F6=danni, F7=strutture/viabilità, F8=telecomunicazioni, F9=accoglienza popolazione.', '/normativa/');
+        }
       }
       kpiFill.style.width = Math.round(((idx+1) / EVENTI.length) * 100) + '%';
       assegnaBtn.disabled = true;


### PR DESCRIPTION
## Sommario

Tre interventi correlati per migliorare apprendimento e accessibilità su tutti i 33 giochi statici, le 21 pagine Hugo essenziali e le 18 fiabe del sito. Più aggiornamento completo della manualistica.

Origine: feedback utente che bambini 3-8 anni abbandonano i giochi dopo i primi errori (rispondono a caso senza nozioni di base) e che servirebbe un audio per chi ancora non legge bene.

## 1. Coach Layer 3 esteso a tutti i giochi (19 nuovi)

Estende il pattern hint contestuale già introdotto in PR #41 (4 giochi) ad altri 19 giochi con feedback discreto su errore. Quando il bambino sbaglia, accanto al bottone "💡 Consigli per giocare" appare un riquadro giallo con suggerimento mirato + link "Scopri perché →" alla teoria.

| Fascia | Giochi con Layer 3 |
|---|---|
| Infanzia (8) | acchiappa-pericolo, cielo-oggi, mezzo-giusto, suoni-emergenza, tartaruga-saggia, trova-cartello, vesti-tina, rifugio-tina |
| Primaria (5) | abbina-impara, anagrammi, chiamata-112, semaforo-rischio, posiziona-cartelli |
| Ragazzi (7) | cartelli-pericolo, codice-arancione, linea-tempo-eventi, mappa-rischio, radio-emergency, scelte-difficili, simulatore-coc |

Pattern uniforme: `clearHint()` su risposta corretta, `hint(testo, url)` su errore.

## 2. TTS audio nel coach (Web Speech API browser-native)

Bottone "🔊 Ascolta" dentro il dialog Consigli + variante mini nei suggerimenti contestuali.

- Voce italiana (`it-IT`), velocità 0.9x per chiarezza.
- Toggle play/stop sullo stesso bottone.
- Stop automatico su close dialog, ESC, page unload.
- Auto-nasconde se Web Speech API non supportata.
- API: `window.GameCoach.{speak, stopSpeaking, ttsSupported}`.

**Niente file MP3 da generare/mantenere**: il browser sintetizza al volo, gratis, e l'audio si aggiorna automaticamente quando cambi il testo.

## 3. TTS esteso al sito (9 pagine Hugo + 18 fiabe)

**Pagine Hugo**: aggiunto `tts: true` al frontmatter di 9 pagine (assistente, faq, piano-emergenza, contatti, chi-siamo, diventa-volontario, glossario, rischi-prevenzione/{kit-emergenza, persone-necessita-specifiche}). Si attiva il partial `leggi-ad-alta-voce.html` già esistente.

**Fiabe e storie**: nuovo modulo `static/formazione/storie-e-racconti/assets/tts-storia.js` auto-iniettato in tutti gli `index.html` delle 18 storie. Aggiunge un bottone "🔊 Ascolta la storia" nella `.storia-toolbar`. Legge `.storia-corpo` spezzando il testo in chunk di ~200 caratteri per evitare cut-off su fiabe lunghe (~4 minuti di lettura).

## 4. Manualistica aggiornata

- `CLAUDE.md`: 2 nuove righe nella tabella architettura per puntare al Coach e al TTS esteso.
- `.claude/rules/03-accessibility.md`: sezione TTS rifatta in 3 contesti + nuova sezione "Coach dei giochi" con architettura, 3 layer e regole operative.
- `.claude/rules/04b-hugo-template-css.md`: 2 nuove sezioni "Coach + TTS sui giochi statici" e "TTS sulle storie e fiabe".
- `README.md`: nuova sezione "Coach didattico nei giochi" + bullet "Bottone Ascolta la storia" nella sezione Storie.
- `MANUALE-SITO.md`: nuova **Parte 17 — Coach didattico nei giochi e TTS esteso (maggio 2026)** con 5 sotto-sezioni (perché esiste, architettura, Layer 3 wiring, TTS esteso, conformità AGID/WCAG).

## Conformità AGID + WCAG 2.2

Web Speech API è la soluzione raccomandata da W3C-WAI per la PA al posto degli overlay commerciali (AccessiBe, UserWay, Equally AI). Soddisfa:
- WCAG 2.2 SC 1.4.5 (Images of Text) e EN 301 549.
- ARIA: `role=dialog`, `aria-modal`, `aria-pressed` dinamico, `aria-live=polite`, focus trap nativo, ESC chiude.
- Reduced motion: animazione pulse rispetta `prefers-reduced-motion`.
- GDPR safe: nessun dato esce dal browser, nessun tracker.

## Smoke test pre-commit

- ✅ `node -c` su 6 script standalone: tutti OK
- ✅ `new Function()` su 17 script inline (giochi infanzia/primaria/ragazzi): tutti OK
- ✅ `coach.css` 62 graffe / 27 parens bilanciate
- ✅ `storia-libro.css` 66 graffe / 32 parens bilanciate
- ✅ `tts-storia.js` syntactically valid
- ✅ Tutte e 18 le storie hanno il `<script>` iniettato
- ✅ Tutte e 9 le pagine Hugo hanno `tts: true` nel frontmatter
- ✅ Tutti i path manifest puntano a pagine esistenti

## Audit dimensioni file (richiesto dall'utente)

`MANUALE-SITO.md` è ora a ~5500 righe / ~290 KB. È il file più grande del repo e dopo questa PR cresce di ~150 righe. **Raccomandazione separata**: spezzarlo in cartella `manuale/parte-{1..17}.md` (1 file per parte) per facilitare manutenzione e revisioni puntuali. Da fare in PR dedicata se concordata.

Tutti gli altri docs sono in dimensioni gestibili: CLAUDE.md 217 righe, regole `.claude/rules/*.md` max 326, README.md 372.

## Test plan

- [ ] Aprire un gioco infanzia (es. trova-cartello), aprire dialog Consigli, premere "🔊 Ascolta" e verificare che la voce italiana legga regola + bullet.
- [ ] Sbagliare una risposta in `quiz/primaria/` e verificare che appaia il hint giallo con bottone mini "🔊 Ascolta".
- [ ] Aprire `/assistente/`, `/faq/` e verificare che il bottone "Leggi ad alta voce" sia presente.
- [ ] Aprire una fiaba (es. tina-fischietto-magico) e verificare che ci sia il bottone "🔊 Ascolta" nella toolbar.
- [ ] Verificare focus visibile da tastiera (Tab) su tutti i bottoni TTS.
- [ ] Verificare ESC chiude dialog e ferma TTS.

https://claude.ai/code/session_01UrYc3nirvW2CVu1ZUpB2T2

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrYc3nirvW2CVu1ZUpB2T2)_