### PR TITLE
Cita norme ISO/EN gratuite (22315, 22322, 22324, 40500, EN 301 549) nei punti naturali del sito

### DIFF
--- a/content/accessibilita/_index.md
+++ b/content/accessibilita/_index.md
@@ -17,6 +17,8 @@ La presente dichiarazione si applica al sito web **www.protezionecivilegenzano.i
 
 Questo sito web è progettato seguendo i principi delle **Linee guida AGID sull'accessibilità** e delle **WCAG 2.2 livello AA** (W3C). Utilizza il framework Bootstrap Italia 2.x del design system della Pubblica Amministrazione italiana.
 
+I requisiti di accessibilità per i siti della Pubblica Amministrazione italiana derivano dal recepimento della **Direttiva (UE) 2016/2102** attraverso lo standard europeo **EN 301 549** ("Requisiti di accessibilità per prodotti e servizi ICT"), a sua volta allineato alle WCAG 2.2 e ratificato come **ISO/IEC 40500**. Il quadro è quindi coerente a livello italiano (Legge Stanca + AGID), europeo (EN 301 549) e internazionale (WCAG 2.2 / ISO/IEC 40500).
+
 Sono in corso le **verifiche periodiche** per migliorare continuamente l'accessibilità. La **dichiarazione di accessibilità ufficiale**, compilata secondo quanto previsto dalla *Decisione di esecuzione (UE) 2018/1523*, è in fase di predisposizione su [form.agid.gov.it](https://form.agid.gov.it/) e il relativo link verrà inserito in questa pagina al termine della procedura. Nel frattempo, per qualsiasi segnalazione di accessibilità, usa il [meccanismo di feedback](#meccanismo-di-feedback) descritto in fondo alla pagina.
 
 ## Strumenti di Accessibilità del sito

--- a/content/allerte-meteo/_index.md
+++ b/content/allerte-meteo/_index.md
@@ -91,12 +91,16 @@ Il sistema nazionale di allertamento per il rischio meteo-idrogeologico e idraul
 
 Il nostro Comune rientra nella **Zona di allerta F — Bacini Costieri Sud**, secondo la classificazione regionale [DGR 865/2019](https://protezionecivile.regione.lazio.it/sites/default/files/2021-10/2-Tabella%20Zone%20Allerta%20per%20Comuni%20DGR%20865%202019_0.pdf). Il bollettino viene emesso ogni giorno, generalmente entro le ore 14:00, con validità per le successive 24-36 ore.
 
+L'architettura italiana — Dipartimento della Protezione Civile → Centro Funzionale Regionale → Sindaco → cittadini — recepisce i principi della norma internazionale **ISO 22322:2022** *Public warning systems*. La fonte istituzionale operativa per il cittadino resta il bollettino del Centro Funzionale Regionale del Lazio.
+
 ### Differenza tra previsione meteo e allerta
 
 - **Previsione meteo:** indica il tempo atmosferico previsto (pioggia, vento, temperature).
 - **Allerta di criticità:** indica gli effetti attesi al suolo (allagamenti, frane, piene). È la criticità — non la meteo — che determina il codice colore.
 
 ## Significato dei codici colore
+
+I quattro livelli — **verde** (nessuna allerta), **giallo** (attenzione), **arancione** (preallarme), **rosso** (allarme) — sono lo standard italiano definito dal Dipartimento della Protezione Civile e applicato dal Centro Funzionale Regionale del Lazio. Il principio del codice-colore graduato è recepito anche nella norma internazionale **ISO 22324:2015** *Guidelines for color-coded alerts*, che lo identifica come metodo riconosciuto per la comunicazione del rischio alla popolazione. In Italia prevale lo schema DPC: il verde è incluso volutamente per dichiarare anche l'assenza di criticità.
 
 ### <span class="badge badge-allerta-verde">VERDE</span> — Nessuna Allerta
 

--- a/content/piano-emergenza/_index.md
+++ b/content/piano-emergenza/_index.md
@@ -18,6 +18,8 @@ Il Piano di Emergenza Comunale è lo strumento fondamentale che stabilisce le pr
 
 Il suo scopo principale è **salvare vite umane**. Definisce chi fa cosa, quali risorse utilizzare e come coordinare i soccorsi. Identifica le "Aree di Emergenza", luoghi sicuri destinati ad accogliere la popolazione in caso di evacuazione.
 
+L'impianto del Piano segue il **D.Lgs. 1/2018** (Codice della Protezione Civile) e le **direttive del Dipartimento della Protezione Civile**. La parte sull'evacuazione di massa, la pianificazione dei punti di raccolta e l'attenzione alle persone con esigenze specifiche recepisce inoltre i principi della norma internazionale **ISO 22315:2014** *Mass evacuation — Guidelines for planning*.
+
 ## Come leggere il Piano
 
 Il Piano di Emergenza è un documento tecnico, ma i concetti chiave che ogni cittadino deve conoscere sono semplici:

--- a/content/piano-familiare/_index.md
+++ b/content/piano-familiare/_index.md
@@ -21,6 +21,8 @@ Un piano familiare efficace risponde a tre domande:
 2. **Chi chiamiamo?** — Il contatto di riferimento fuori città
 3. **Cosa portiamo?** — Dove si trova il kit di emergenza
 
+Il modello che proponiamo qui segue le **campagne nazionali del Dipartimento della Protezione Civile** ("Io non rischio"). Lo schema dei punti di ritrovo, del contatto fuori area e dell'attenzione ai familiari fragili recepisce anche i principi della norma internazionale **ISO 22315:2014** *Mass evacuation — Guidelines for planning*, che tratta proprio la preparazione dell'unità famiglia all'evacuazione.
+
 ## Compila il tuo Piano
 
 <div class="card shadow-sm p-4 mb-4">

--- a/content/rischi-prevenzione/persone-necessita-specifiche.md
+++ b/content/rischi-prevenzione/persone-necessita-specifiche.md
@@ -8,6 +8,8 @@ tts: true
 ---
 In ogni emergenza, le persone con necessità specifiche sono le più vulnerabili. Pianificare in anticipo le loro esigenze è fondamentale per garantirne la sicurezza. Questa pagina raccoglie indicazioni pratiche per chi si prende cura di persone fragili e per le persone stesse.
 
+Il principio dell'attenzione prioritaria alle persone con esigenze specifiche durante l'evacuazione è recepito dalla norma internazionale **ISO 22315:2014** *Mass evacuation — Guidelines for planning*, che riconosce queste categorie come la priorità nella pianificazione dei soccorsi. La normativa italiana (Codice della Protezione Civile, **D.Lgs. 1/2018**) e le linee guida del **Dipartimento della Protezione Civile** ne definiscono l'applicazione operativa nei piani comunali di emergenza.
+
 ## Chi sono le persone con necessità specifiche
 
 - **Anziani**, soprattutto se soli o con difficoltà motorie

--- a/manuale/parte-13-social-media-policy-pubblica.md
+++ b/manuale/parte-13-social-media-policy-pubblica.md
@@ -229,8 +229,14 @@ CNR garantisce la **correttezza scientifica** dei contenuti, DPC la **correttezz
 
 #### 13.9.4 — Livello standard (internazionali)
 
-- **ISO 22329:2021** *Security and resilience — Emergency management — Guidelines for the use of social media in emergencies* — quadro di riferimento per monitoraggio, disseminazione, interazione e gestione della disinformazione (vedi **13.7**).
-- **WCAG 2.2 AA** (W3C) per l'accessibilità tecnica dei contenuti.
+Le norme ISO che riguardano la nostra attività sono **citate come principio recepito**, mai come certificazione: il Gruppo non è ente certificatore e non sostiene di essere conforme certificato a una norma. Le norme ISO sono pubblicazioni a pagamento di proprietà ISO/UNI: non vengono mai redistribuite dal sito; ne facciamo solo riferimento testuale nei contenuti pubblici.
+
+- **ISO 22329:2021** *Security and resilience — Emergency management — Guidelines for the use of social media in emergencies* — quadro per monitoraggio, disseminazione, interazione e gestione della disinformazione sui social. Recepita nei contenuti del **13.7** e citata esplicitamente nella pagina pubblica `/social-media-policy/`.
+- **ISO 22322:2022** *Public warning systems* — quadro per i sistemi di allerta pubblici. Recepita dall'architettura italiana DPC → Centro Funzionale Regionale → Sindaco → cittadini. Citata in `/allerte-meteo/`.
+- **ISO 22324:2015** *Guidelines for color-coded alerts* — codici colore graduati per l'allerta pubblica. Recepita dallo schema italiano verde/giallo/arancione/rosso del DPC. Citata in `/allerte-meteo/`.
+- **ISO 22315:2014** *Mass evacuation — Guidelines for planning* — pianificazione delle evacuazioni di massa, punti di raccolta, attenzione prioritaria alle persone con esigenze specifiche. Recepita dai piani comunali italiani. Citata in `/piano-emergenza/`, `/piano-familiare/`, `/rischi-prevenzione/persone-necessita-specifiche/`.
+- **ISO 7010:2019** *Graphical symbols — Safety colours and safety signs* — pittogrammi standardizzati di sicurezza. Adottata operativamente in `static/pittogrammi/iso7010/` (46 simboli) e usata via shortcode `pittogramma`.
+- **ISO/IEC 40500** (= **WCAG 2.0** / aggiornato a **WCAG 2.2 AA**) per l'accessibilità tecnica dei contenuti, recepita in Italia tramite la **Direttiva UE 2016/2102** e lo standard europeo **EN 301 549**. Citata in `/accessibilita/`.
 
 #### 13.9.5 — Riferimenti normativi orizzontali
 
@@ -246,7 +252,7 @@ CNR garantisce la **correttezza scientifica** dei contenuti, DPC la **correttezz
 | 1 | Italiano vincolante | AGID + DPC (DPC prevale su AGID per la PC) |
 | 2 | Scientifico italiano | CNR (IRPI, INGV, IGAG), ISPRA |
 | 3 | Tecnico-operativo europeo | EENA, CWA CEN/CENELEC |
-| 4 | Standard internazionali | ISO 22329:2021, WCAG 2.2 AA |
+| 4 | Standard internazionali | ISO 22329:2021, ISO 22322:2022, ISO 22324:2015, ISO 22315:2014, ISO 7010:2019, ISO/IEC 40500 (WCAG 2.2 AA), EN 301 549 |
 | 5 | Normativa orizzontale | DL 25/2025, GDPR, L. 4/2004, CAD |
 
 Il livello inferiore si applica **quando** il livello superiore non dispone diversamente.


### PR DESCRIPTION
## Sommario

Aggiunge **citazioni testuali** (zero costi, nessuna norma scaricata) di 6 standard internazionali nei punti pubblici del sito dove sono già recepiti operativamente. Il cittadino capisce ora che l'architettura italiana DPC/AGID è coerente con gli standard internazionali — senza falsi claim di certificazione.

## Norme ISO/EN citate (tutte gratuite via riferimento testuale)

| Norma | Cosa | Dove citata | Perché |
|---|---|---|---|
| **ISO 22322:2022** | Public warning systems | `/allerte-meteo/` § "Come funziona" | L'architettura DPC → CFR → Sindaco → cittadini recepisce questo quadro |
| **ISO 22324:2015** | Color-coded alerts | `/allerte-meteo/` § "Significato dei codici colore" | Lo schema verde/giallo/arancione/rosso italiano è allineato a questo standard |
| **ISO 22315:2014** | Mass evacuation guidelines | `/piano-emergenza/`, `/piano-familiare/`, `/rischi-prevenzione/persone-necessita-specifiche/` | Pianificazione evacuazioni e priorità alle persone con esigenze specifiche |
| **ISO 22329:2021** | Social media in emergencies | `/social-media-policy/` (già esplicita, no changes) | Quadro per messaggi di crisi sui social |
| **ISO 7010:2019** | Safety signs/pictograms | citata in `manuale/parte-13` (operativa nel sito via `static/pittogrammi/iso7010/`) | 46 pittogrammi standard usati nel sito |
| **ISO/IEC 40500** (= WCAG 2.0/2.2) + **EN 301 549** | Accessibility ICT | `/accessibilita/` § "Conformità" | Catena Direttiva UE 2016/2102 → EN 301 549 → WCAG 2.2 → ISO/IEC 40500 |

## Conformità con le rules del progetto

- **`06-protezione-civile-scientifica.md` § "Gerarchia fonti"**: DPC prevale su ISO. Le citazioni ISO sono al livello 4 (standard internazionali), DPC al livello 1. Nei testi le ISO sono presentate come "*principio recepito*", non come fonte primaria.
- **`02-content-design-pa.md`**: italiano AGID, frasi <20 parole, voce attiva.
- **Nessuna norma ISO scaricata o redistribuita** (sono copyright UNI/ISO, non possiamo allegarle).
- **Nessun claim di certificazione**: il Gruppo non è ente certificatore. Le citazioni dichiarano "*recepito da*", mai "*conforme a*".

## Aggiornamento manuale

`manuale/parte-13-social-media-policy-pubblica.md` § 13.9.4 (Standard internazionali):
- Aggiunta premessa che chiarisce che le norme ISO sono "*principio recepito*", mai "*certificazione*".
- Elenco esteso con tutte le 7 ISO citate operativamente nel sito (ognuna con riferimento al punto del sito dove è citata).
- Tabella § 13.9.6 (Gerarchia di prevalenza) aggiornata al livello 4 con i 7 standard.

## Files modificati

```
content/accessibilita/_index.md                            +2  -0
content/allerte-meteo/_index.md                            +4  -0
content/piano-emergenza/_index.md                          +2  -0
content/piano-familiare/_index.md                          +2  -0
content/rischi-prevenzione/persone-necessita-specifiche.md +2  -0
manuale/parte-13-social-media-policy-pubblica.md           +12 -3
                                                          ────
                                                          21  insertions, 3 deletions
```

## Test plan

- [ ] Aprire `/allerte-meteo/` e verificare che le citazioni ISO 22322 e 22324 siano leggibili e ben integrate nel testo.
- [ ] Aprire `/piano-emergenza/` e `/piano-familiare/` e verificare che ISO 22315 sia presente nei paragrafi introduttivi.
- [ ] Aprire `/accessibilita/` e verificare che la catena UE 2016/2102 → EN 301 549 → WCAG 2.2 → ISO/IEC 40500 sia chiara.
- [ ] Verificare che nessun testo dica "il sito è certificato ISO" (sarebbe falso) — usa sempre "principio recepito" o "allineato a".

https://claude.ai/code/session_01UrYc3nirvW2CVu1ZUpB2T2

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrYc3nirvW2CVu1ZUpB2T2)_