### PR TITLE
Labirinto: stop layout shift su errore + Ricomincia distanziato

### DIFF
--- a/static/giochi/primaria/labirinto-evacuazione/index.html
+++ b/static/giochi/primaria/labirinto-evacuazione/index.html
@@ -179,6 +179,30 @@
     .alert-msg.danger { background: #f8d7da; color: #842029; border: 1px solid #f5c2c7; animation: shake .3s; }
     @keyframes shake { 0%,100%{transform:translateX(0)} 25%{transform:translateX(-6px)} 75%{transform:translateX(6px)} }
 
+    /* Riserva sempre lo spazio dell'area feedback per non spostare i comandi
+       quando appare un errore. Quando hide, l'elemento resta in flusso ma
+       invisibile (visibility:hidden). Override esplicito su .hide perche'
+       altrove .hide e' display:none !important. */
+    #feedback { min-height: 3rem; }
+    #feedback.hide {
+      display: block !important;
+      visibility: hidden;
+      background: transparent !important;
+      border-color: transparent !important;
+      animation: none !important;
+    }
+    @media (max-width: 380px) {
+      #feedback { min-height: 3.6rem; }
+    }
+
+    /* Bottone "Ricomincia scenario" abbassato e distinto dai comandi: anche se
+       l'alert appare e i comandi sticky si comportano in modo diverso da
+       desktop, il reset resta a una distanza chiara dalle frecce. */
+    .reset-wrap { margin-top: 1.5rem; padding-bottom: .5rem; }
+    @media (max-width: 768px) {
+      .reset-wrap { margin-top: 2rem; padding-bottom: 1rem; }
+    }
+
     /* Sizing su mobile gestito direttamente da clamp() su .cell e .comandi */
   </style>
 </head>
@@ -272,7 +296,7 @@
               <button type="button" class="b-right" data-dir="right" aria-label="Vai a destra">▶</button>
             </div>
 
-            <div class="text-center">
+            <div class="text-center reset-wrap">
               <button type="button" id="btn-reset" class="btn btn-outline-secondary btn-sm">
                 <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Ricomincia scenario
               </button>


### PR DESCRIPTION
## Cosa cambia

Fix UX nel gioco labirinto: quando il giocatore sbaglia, l'alert errore appare tra mappa e comandi e spinge giù i bottoni di movimento. Bug segnalato dall'utente: «si spostano i bottoni in quanto appare l'allerta di errore».

## Soluzione

1. **Spazio riservato per l'alert**: `#feedback` ha `min-height` fissa (3rem desktop, 3.6rem ≤380px). Quando nascosto, resta in flusso col `visibility: hidden`. Niente layout shift quando appare l'errore.
2. **Bottone "Ricomincia scenario" abbassato**: nuovo wrapper `.reset-wrap` con `margin-top: 1.5rem` (2rem mobile) + `padding-bottom` per separazione chiara dai comandi direzione.

## Test plan

- [ ] Su desktop: muovere il giocatore contro un muro/trappola → alert appare → comandi e bottone Ricomincia non si spostano.
- [ ] Su mobile: stesso test, comandi sticky restano fermi e Ricomincia ben distanziato.
- [ ] Animazione shake dell'alert continua a funzionare.

https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR)_