### PR TITLE
Labirinto: +3 mosse extra al budget per ogni cella di fumo apparsa

### DIFF
--- a/static/giochi/primaria/labirinto-evacuazione/index.html
+++ b/static/giochi/primaria/labirinto-evacuazione/index.html
@@ -460,7 +460,7 @@
           '#.........E#',
           '############'
         ],
-        max: 38
+        max: 42
       }
     ];
 
@@ -478,6 +478,11 @@
     var passiDaFumo = 0;    // contatore mosse per propagazione fumo
     var spreadFuoco = null; // map "r,c" -> volte che il fuoco ha propagato (cap)
     var MAX_SPREAD_PER_F = 2;
+    var budgetBonus = 0;    // mosse extra concesse per ogni cella di fumo
+                            // apparsa: il fumo costringe a deviazioni e non
+                            // sarebbe giusto far perdere il budget per un
+                            // evento casuale fuori dal controllo del giocatore.
+    var BONUS_PER_FUMO = 3;
 
     var intro = document.getElementById('intro');
     var game = document.getElementById('game');
@@ -513,7 +518,7 @@
       descEl.textContent = s.desc;
       numEl.textContent = (scenarioIdx + 1);
       mosse = 0; erroriScenario = 0; traccia = []; bloccato = false;
-      passiDaFumo = 0; spreadFuoco = {};
+      passiDaFumo = 0; spreadFuoco = {}; budgetBonus = 0;
       mosseEl.textContent = '0'; erroriEl.textContent = '0';
       fbEl.className = 'alert-msg hide'; fbEl.textContent = '';
       // converte righe in matrice mutabile
@@ -529,7 +534,7 @@
     }
 
     function aggiornaBudget(){
-      var max = SCENARI[scenarioIdx].max;
+      var max = SCENARI[scenarioIdx].max + budgetBonus;
       var rest = max - mosse;
       budgetEl.textContent = rest;
       if (rest < 0) {
@@ -698,7 +703,7 @@
           // (provera al prossimo ciclo, eventualmente con candidate diverse)
         }
       }
-      return nuove.length > 0;
+      return nuove.length;
     }
 
     function muovi(dir){
@@ -781,15 +786,22 @@
       nascondiMessaggio();
       if (window.AudioSintetico) window.AudioSintetico.tono(380, 0.04);
 
-      // propagazione fumo (solo scenari con fumo:true)
+      // propagazione fumo (solo scenari con fumo:true): ogni cella di fumo
+      // costringe il giocatore a deviazioni che mangerebbero il budget
+      // calcolato sulla mappa pulita. Compensiamo con +BONUS_PER_FUMO mosse
+      // extra per ogni cella M apparsa, cosi' la randomicita' della
+      // propagazione non penalizza ingiustamente.
       var sc = SCENARI[scenarioIdx];
       if (sc.fumo && target !== 'E') {
         passiDaFumo++;
         if (passiDaFumo >= (sc.passiFumo || 4)) {
           passiDaFumo = 0;
           var spread = propagaFumo();
-          if (spread) {
-            mostraMessaggio('💨 Il fumo si sta diffondendo dai fuochi: muoviti con attenzione.', 'warning');
+          if (spread > 0) {
+            var bonus = spread * BONUS_PER_FUMO;
+            budgetBonus += bonus;
+            aggiornaBudget();
+            mostraMessaggio('💨 Il fumo si sta diffondendo: hai +' + bonus + ' mosse extra per deviare.', 'warning');
             if (window.AudioSintetico) window.AudioSintetico.tono(140, 0.18);
           }
         }
@@ -800,7 +812,8 @@
         disegna();
         bloccato = true;
         scenariOk++;
-        var over = Math.max(0, mosse - sc.max);
+        var budgetEff = sc.max + budgetBonus;
+        var over = Math.max(0, mosse - budgetEff);
         if (over > 0) overTotali += over;
         var msg = '🏁 Punto di raccolta raggiunto! Mosse: ' + mosse + ' · Errori: ' + erroriScenario;
         if (over > 0) msg += ' · Oltre il budget: +' + over + ' mosse';


### PR DESCRIPTION
## Bug

Anche con il safeguard BFS della PR #52, l'utente ha segnalato che S6 resta di fatto ingiocabile: «l'ultimo fuoco non farei in tempo ad arrivare coi passi che hai calcolato». Il fumo costringe deviazioni e il budget mappa-pulita finisce prima.

## Fix

**Bonus dinamico al budget**: ogni cella di fumo che appare estende il budget di **+3 mosse extra**. La randomicità della propagazione è fuori dal controllo del giocatore — non è giusto fargli perdere il budget per un evento casuale esterno.

Modifiche:
- `aggiornaBudget()` legge `sc.max + budgetBonus` invece di solo `sc.max`.
- `propagaFumo()` ritorna il numero di celle apparse (era booleano).
- In `muovi()` quando il fumo si propaga: `budgetBonus += spread × 3`, refresh pill HUD.
- Messaggio più chiaro: «💨 Il fumo si sta diffondendo: hai +3 mosse extra per deviare».
- **S6 base budget: 38 → 42** (slack 9 sul percorso ottimo da 33 mosse).

## Math S6 worst case

- Percorso ottimo: 33 mosse
- Budget base: 42 (slack +9)
- Bonus max: 4 celle fumo × 3 = +12
- Budget effettivo max: 54 mosse → slack +21 sul percorso ottimo

Sempre giocabile, sempre con margine.

https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR)_