### PR TITLE
Memory: fix bottoni livello inattivi + restyle prominente 3D

### DIFF
--- a/static/giochi/primaria/memory/css/style.css
+++ b/static/giochi/primaria/memory/css/style.css
@@ -31,45 +31,95 @@
 }
 .livelli-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: .8rem;
-  margin-top: .5rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
 }
 .btn-livello {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: .15rem;
-  padding: 1rem .8rem;
-  border: 2px solid var(--pc-blue);
-  background: #fff;
+  gap: .35rem;
+  padding: 1.5rem 1rem;
+  border: 3px solid var(--pc-blue);
+  background: linear-gradient(180deg, #ffffff 0%, #e7f1ff 100%);
   color: var(--pc-blue);
-  border-radius: 12px;
+  border-radius: 16px;
   cursor: pointer;
-  transition: transform .12s, background .15s, color .15s;
+  transition: transform .15s, background .2s, color .2s, box-shadow .2s;
   font-weight: 600;
+  font-family: inherit;
+  width: 100%;
+  min-height: 140px;
+  box-shadow: 0 4px 0 var(--pc-blue), 0 6px 12px rgba(0,51,102,.15);
+  position: relative;
 }
-.btn-livello:hover, .btn-livello:focus {
-  background: var(--pc-blue);
+.btn-livello:hover {
+  background: linear-gradient(180deg, var(--pc-blue) 0%, #002244 100%);
   color: #fff;
-  transform: translateY(-2px);
-  outline: 3px solid #ffbe2e;
-  outline-offset: 2px;
+  transform: translateY(-3px);
+  box-shadow: 0 7px 0 #001a33, 0 10px 16px rgba(0,51,102,.3);
 }
+.btn-livello:focus-visible {
+  outline: 4px solid #ffbe2e;
+  outline-offset: 3px;
+}
+.btn-livello:active {
+  transform: translateY(1px);
+  box-shadow: 0 2px 0 var(--pc-blue), 0 3px 6px rgba(0,51,102,.15);
+}
+.btn-livello[data-livello="medio"]   { border-color: #b45309; box-shadow: 0 4px 0 #b45309, 0 6px 12px rgba(180,83,9,.15); color: #b45309; }
+.btn-livello[data-livello="medio"]:hover  { background: linear-gradient(180deg, #b45309 0%, #7c3a0c 100%); color: #fff; box-shadow: 0 7px 0 #7c3a0c, 0 10px 16px rgba(180,83,9,.3); }
+.btn-livello[data-livello="esperto"] { border-color: #7f1d1d; box-shadow: 0 4px 0 #7f1d1d, 0 6px 12px rgba(127,29,29,.15); color: #7f1d1d; }
+.btn-livello[data-livello="esperto"]:hover { background: linear-gradient(180deg, #7f1d1d 0%, #5a0f0f 100%); color: #fff; box-shadow: 0 7px 0 #5a0f0f, 0 10px 16px rgba(127,29,29,.3); }
+
 .livello-num {
-  font-size: 2rem;
+  font-size: 2.4rem;
   font-weight: 700;
   line-height: 1;
+  background: currentColor;
+  color: #fff;
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: .35rem;
 }
+.btn-livello:hover .livello-num,
+.btn-livello[data-livello="medio"]:hover .livello-num,
+.btn-livello[data-livello="esperto"]:hover .livello-num {
+  background: #fff;
+  color: var(--pc-blue);
+}
+.btn-livello[data-livello="medio"]:hover .livello-num   { color: #b45309; }
+.btn-livello[data-livello="esperto"]:hover .livello-num { color: #7f1d1d; }
 .livello-nome {
-  font-size: 1.1rem;
-  margin-top: .25rem;
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin-top: .15rem;
+  letter-spacing: .02em;
 }
 .livello-info {
-  font-size: .82rem;
+  font-size: .88rem;
   opacity: .85;
   margin-top: .15rem;
+}
+.livello-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: .25rem;
+  font-size: .82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  margin-top: .35rem;
+}
+@media (prefers-reduced-motion: reduce) {
+  .btn-livello { transition: none; }
+  .btn-livello:hover, .btn-livello:active { transform: none; }
 }
 
 .hud-row {

--- a/static/giochi/primaria/memory/index.html
+++ b/static/giochi/primaria/memory/index.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="/css/custom.css">
   <link rel="stylesheet" href="/app-shared/app-common.css">
-  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="css/style.css?v=20260502b">
   <link rel="stylesheet" href="/giochi/assets/css/coach.css">
 </head>
 <body data-coach-game="memory">
@@ -48,16 +48,19 @@
                   <span class="livello-num">1</span>
                   <span class="livello-nome">Facile</span>
                   <span class="livello-info">4 coppie · 8 carte</span>
+                  <span class="livello-cta"><i class="bi bi-play-fill" aria-hidden="true"></i> Inizia</span>
                 </button>
                 <button type="button" class="btn-livello" data-livello="medio">
                   <span class="livello-num">2</span>
                   <span class="livello-nome">Medio</span>
                   <span class="livello-info">6 coppie · 12 carte</span>
+                  <span class="livello-cta"><i class="bi bi-play-fill" aria-hidden="true"></i> Inizia</span>
                 </button>
                 <button type="button" class="btn-livello" data-livello="esperto">
                   <span class="livello-num">3</span>
                   <span class="livello-nome">Esperto</span>
                   <span class="livello-info">8 coppie · 16 carte</span>
+                  <span class="livello-cta"><i class="bi bi-play-fill" aria-hidden="true"></i> Inizia</span>
                 </button>
               </div>
               <div class="text-center mt-3">
@@ -109,7 +112,7 @@
   <script src="/giochi/assets/js/progressione.js"></script>
   <script src="/giochi/assets/js/attestato.js"></script>
   <script src="/giochi/assets/js/comune.js"></script>
-  <script src="js/script.js" defer></script>
+  <script src="js/script.js?v=20260502b" defer></script>
   <script src="/giochi/assets/js/coach.js" defer></script>
 </body>
 </html>

--- a/static/giochi/primaria/memory/js/script.js
+++ b/static/giochi/primaria/memory/js/script.js
@@ -3,8 +3,13 @@
 // (segnale di sicurezza standard) si abbina al comportamento corretto. Tre livelli
 // (4/6/8 coppie) estratti random da un pool di 12. Dopo ogni match, breve spiegazione
 // del segnale per fissare la nozione (rules 03 — apprendimento, non solo decorativo).
+//
+// Lo script viene caricato con `defer`: il DOM e' gia' parsato quando esegue,
+// quindi non serve aspettare DOMContentLoaded (e su alcuni browser mobile il
+// listener registrato dopo l'evento non veniva chiamato — i bottoni livello
+// non rispondevano al click).
 
-document.addEventListener('DOMContentLoaded', () => {
+(function init(){
   const introScreen = document.getElementById('intro-screen');
   const gameScreen = document.getElementById('game-screen');
   const winScreen = document.getElementById('win-screen');
@@ -263,4 +268,15 @@ document.addEventListener('DOMContentLoaded', () => {
       introScreen.classList.remove('hide');
     });
   }
-});
+
+  // Event delegation di backup sui bottoni livello: se per qualche ragione
+  // querySelectorAll non li ha catturati al boot, click su un [data-livello]
+  // viene comunque gestito.
+  document.body.addEventListener('click', (e) => {
+    const lvlBtn = e.target.closest('[data-livello]');
+    if (lvlBtn && introScreen && !introScreen.classList.contains('hide')) {
+      e.preventDefault();
+      avviaLivello(lvlBtn.dataset.livello);
+    }
+  });
+})();


### PR DESCRIPTION
## Bug

L'utente: «non funzionano i bottoni!!!!». Cliccando i bottoni livello del Memory non si avvia il gioco. Inoltre i bottoni sono graficamente poco prominenti.

## Causa

Lo script era wrappato in `DOMContentLoaded` ma caricato con `defer`. Su alcuni browser mobile l'evento `DOMContentLoaded` può scattare PRIMA che il defer script venga eseguito: il listener registrato dopo non viene mai chiamato → nessun click handler attivo sui bottoni livello.

## Fix funzionale

1. **IIFE al posto di DOMContentLoaded**: con `defer` il DOM è già parsato quando lo script esegue. Setup eseguito direttamente.
2. **Event delegation di backup** su `document.body`: anche se il setup iniziale fallisse per qualche motivo, click su `[data-livello]` viene comunque gestito.
3. **Cache busting** `?v=20260502b` su CSS e JS: forza il reload sui browser che hanno la versione vecchia.

## Restyle bottoni livello

- Min-height **140px** (era ~80px)
- **Ombra 3D** che dà rilievo (4px verso il basso) come bottoni reali
- **Numero in cerchio** bianco/colorato grande (2.4rem)
- Nome livello **bold 1.3rem**
- Badge **"▶ Inizia"** in basso, fa capire chiaramente che è cliccabile
- **Colori distinti per livello**: 🔵 blu (facile), 🟠 arancio (medio), 🔴 rosso (esperto) — coerente col linguaggio cromatico delle allerte PC
- **Hover**: solleva di 3px + inverte i colori
- **Active**: si comprime di 1px (feedback tattile su touch)

## Test plan

- [ ] Su mobile cliccare ognuno dei 3 livelli → gioco si avvia
- [ ] I bottoni hanno ombra 3D e si vedono come "premibili"
- [ ] Cache: una hard-reload mostra subito la nuova versione

https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR)_