### PR TITLE
Infanzia: spiegazione del PERCHÉ su 4 giochi (pattern audit)

### DIFF
--- a/static/giochi/infanzia/acchiappa-pericolo/index.html
+++ b/static/giochi/infanzia/acchiappa-pericolo/index.html
@@ -51,6 +51,21 @@
     }
     .round-up .stelle { font-size: 2.5rem; line-height: 1; margin-bottom: .5rem; }
     .round-up .titolo { color: var(--inf-blu); font-weight: 800; font-size: 1.6rem; margin-bottom: .3rem; }
+    .tina-perche {
+      background: #d1e7dd; border: 2px solid #198754;
+      border-radius: 18px; padding: .8rem 1rem;
+      font-size: 1rem; font-weight: 600; color: #0f5132;
+      text-align: center; margin: 1rem 0 0;
+      animation: perche-in .35s ease;
+    }
+    .tina-perche.hide { display: none !important; }
+    @keyframes perche-in {
+      from { opacity: 0; transform: translateY(8px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .tina-perche { animation: none; }
+    }
   </style>
 </head>
 <body class="inf-body" data-coach-game="acchiappa-pericolo">
@@ -79,6 +94,7 @@
         <div class="progress-dots" id="progress" aria-label="Avanzamento gioco"></div>
         <div class="tina-fumetto" id="prompt">Tocca la cosa pericolosa!</div>
         <div class="scena-griglia" id="scena" role="group" aria-label="4 oggetti, tocca quello pericoloso"></div>
+        <div id="perche" class="tina-perche hide" aria-live="polite"></div>
       </div>
 
       <div id="end-screen" class="hide">
@@ -107,6 +123,7 @@
     const POOL = [
       {
         domanda: 'Cosa NON puoi toccare in cucina?',
+        perche: 'La fiamma del fornello scotta tantissimo. Chiama sempre un adulto.',
         items: [
           { emo: '🍎', nome: 'Mela', danger: false },
           { emo: '🍞', nome: 'Pane', danger: false },
@@ -116,6 +133,7 @@
       },
       {
         domanda: 'Cosa è pericoloso a casa?',
+        perche: "La presa elettrica ha la corrente: non infilarci le dita o oggetti.",
         items: [
           { emo: '🧸', nome: 'Orsetto', danger: false },
           { emo: '⚡', nome: 'Presa elettrica', danger: true },
@@ -125,6 +143,7 @@
       },
       {
         domanda: 'Cosa NON puoi prendere?',
+        perche: 'I petardi possono far male alle mani e agli occhi. Solo i grandi li usano.',
         items: [
           { emo: '✏️', nome: 'Matita', danger: false },
           { emo: '🪪', nome: 'Tessera', danger: false },
@@ -133,7 +152,8 @@
         ]
       },
       {
-        domanda: 'Cosa fa pericolo se cammini?',
+        domanda: 'Cosa fa pericolo se cammini in montagna?',
+        perche: 'Sui sentieri di montagna possono cadere sassi: guarda sempre in alto e cammina lontano dalle pareti.',
         items: [
           { emo: '🌳', nome: 'Albero', danger: false },
           { emo: '🪨', nome: 'Sasso che cade', danger: true },
@@ -143,6 +163,7 @@
       },
       {
         domanda: 'Cosa è pericoloso se piove fortissimo?',
+        perche: "L'acqua in strada può nascondere buche profonde o portarti via. Stai lontano e aspetta che smetta.",
         items: [
           { emo: '☔', nome: 'Ombrello', danger: false },
           { emo: '🌊', nome: 'Acqua per strada', danger: true },
@@ -152,6 +173,7 @@
       },
       {
         domanda: 'Cosa NON tocco MAI?',
+        perche: 'Le medicine sembrano caramelle ma fanno male. Solo mamma o papà te le danno quando servono.',
         items: [
           { emo: '🎈', nome: 'Palloncino', danger: false },
           { emo: '💊', nome: 'Medicine', danger: true },
@@ -161,6 +183,7 @@
       },
       {
         domanda: 'Durante un terremoto cosa NON è sicuro?',
+        perche: 'Vicino alla finestra i vetri possono rompersi. Mettiti SOTTO il tavolo finché non finisce la scossa.',
         items: [
           { emo: '🪟', nome: 'Vicino alla finestra', danger: true },
           { emo: '🪑', nome: 'Sotto il tavolo', danger: false },
@@ -170,6 +193,7 @@
       },
       {
         domanda: 'Se piove tantissimo cosa NON faccio?',
+        perche: "I sottopassi allagati nascondono l'acqua: anche le auto galleggiano via. Mai entrarci, neanche a piedi.",
         items: [
           { emo: '🚗', nome: 'Sottopasso allagato', danger: true },
           { emo: '🏠', nome: 'Stare in casa', danger: false },
@@ -179,6 +203,7 @@
       },
       {
         domanda: 'Se sento odore di gas in casa, NON devo:',
+        perche: "Accendere una luce o un fiammifero col gas in aria può far esplodere la cucina. Apri le finestre, esci e chiama il 112.",
         items: [
           { emo: '🚪', nome: 'Aprire le finestre', danger: false },
           { emo: '🔥', nome: 'Accendere la luce', danger: true },
@@ -188,6 +213,7 @@
       },
       {
         domanda: 'Durante un temporale cosa NON tocco?',
+        perche: 'I cavi della TV portano elettricità: durante un temporale i fulmini possono passare attraverso i fili. Stacca tutto e non toccare.',
         items: [
           { emo: '📺', nome: 'Cavi della TV', danger: true },
           { emo: '🛋️', nome: 'Divano', danger: false },
@@ -197,6 +223,7 @@
       },
       {
         domanda: 'In bosco con vento forte cosa fa pericolo?',
+        perche: 'Gli alberi alti con vento forte possono cadere. Allontanati dai boschi e cerca un edificio robusto.',
         items: [
           { emo: '🌲', nome: 'Albero alto che dondola', danger: true },
           { emo: '🍄', nome: 'Funghi sul terreno', danger: false },
@@ -206,6 +233,7 @@
       },
       {
         domanda: 'Quando fa caldissimo, cosa NON faccio?',
+        perche: "Correre al sole nelle ore più calde può farti svenire. Sta all'ombra dalle 11 alle 17 e bevi tanta acqua.",
         items: [
           { emo: '🥤', nome: 'Bere acqua', danger: false },
           { emo: '🧴', nome: 'Crema solare', danger: false },
@@ -215,6 +243,7 @@
       },
       {
         domanda: 'Se vedo fuoco nel bosco cosa faccio SUBITO?',
+        perche: 'Davanti al fuoco non si fanno selfie: il vento può cambiare in un attimo. Allontanati e chiama il 112 con un adulto.',
         items: [
           { emo: '📞', nome: 'Chiamo il 112 con un adulto', danger: false },
           { emo: '🤳', nome: 'Faccio un selfie col fuoco dietro', danger: true },
@@ -279,6 +308,9 @@
         b.addEventListener('click', () => onPick(b, it));
         scenaEl.appendChild(b);
       });
+      // Nascondi spiegazione precedente al cambio scena
+      const perEl = document.getElementById('perche');
+      if (perEl) { perEl.classList.add('hide'); perEl.textContent = ''; }
       locked = false;
       drawProgress();
     }
@@ -286,6 +318,13 @@
     function onPick(btn, it) {
       if (locked) return;
       locked = true;
+      // Mostra spiegazione didattica del PERCHE' della risposta giusta
+      // (sia che il bambino abbia scelto bene sia che abbia sbagliato).
+      const perEl = document.getElementById('perche');
+      if (perEl && SCENE[cur].perche) {
+        perEl.textContent = '💡 ' + SCENE[cur].perche;
+        perEl.classList.remove('hide');
+      }
       if (it.danger) {
         btn.classList.add('correct');
         score++;

--- a/static/giochi/infanzia/memory-facile/index.html
+++ b/static/giochi/infanzia/memory-facile/index.html
@@ -59,6 +59,21 @@
       transform: rotateY(180deg);
     }
     .mem-card.matched .mem-back { background: #d1e7dd; border-color: var(--inf-verde); }
+    .tina-perche {
+      background: #d1e7dd; border: 2px solid #198754;
+      border-radius: 18px; padding: .8rem 1rem;
+      font-size: 1rem; font-weight: 600; color: #0f5132;
+      text-align: center; margin: 1rem 0 0;
+      animation: perche-in .35s ease;
+    }
+    .tina-perche.hide { display: none !important; }
+    @keyframes perche-in {
+      from { opacity: 0; transform: translateY(8px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .tina-perche { animation: none; }
+    }
   </style>
 </head>
 <body class="inf-body" data-coach-game="memory-facile">
@@ -79,6 +94,7 @@
         <span class="inf-score"><i class="bi bi-heart-fill"></i> Coppie: <span id="count">0</span> / <span id="total">3</span></span>
       </div>
       <div id="grid" class="mem-grid cols-3" role="group" aria-label="Griglia del memory"></div>
+      <div id="perche" class="tina-perche hide" aria-live="polite"></div>
     </div>
 
     <div id="level-up" class="inf-card hide">
@@ -111,15 +127,15 @@
   <script>
   (function(){
     var ICONE_TOTALI = [
-      { emo: '🚑', lbl: 'ambulanza' },
-      { emo: '🚒', lbl: 'pompieri' },
-      { emo: '⛑️', lbl: 'casco' },
-      { emo: '🔦', lbl: 'torcia' },
-      { emo: '🧯', lbl: 'estintore' },
-      { emo: '🚓', lbl: 'polizia' },
-      { emo: '⚠️', lbl: 'attenzione' },
-      { emo: '🚪', lbl: 'uscita' },
-      { emo: '📞', lbl: 'telefono' }
+      { emo: '🚑', lbl: 'ambulanza',  perche: "L'ambulanza porta in ospedale chi sta male." },
+      { emo: '🚒', lbl: 'pompieri',   perche: 'I pompieri spengono il fuoco e salvano le persone.' },
+      { emo: '⛑️', lbl: 'casco',     perche: 'Il casco protegge la testa dei volontari.' },
+      { emo: '🔦', lbl: 'torcia',     perche: 'La torcia fa luce quando manca la corrente.' },
+      { emo: '🧯', lbl: 'estintore',  perche: "L'estintore spegne le piccole fiamme. Solo i grandi lo usano." },
+      { emo: '🚓', lbl: 'polizia',    perche: 'La polizia aiuta a tenere tutti al sicuro.' },
+      { emo: '⚠️', lbl: 'attenzione', perche: 'Il triangolo giallo dice: stai attento, c\'è un pericolo!' },
+      { emo: '🚪', lbl: 'uscita',     perche: "L'uscita di emergenza è la strada per uscire in sicurezza." },
+      { emo: '📞', lbl: 'telefono',   perche: 'Per chiamare aiuto in Italia si fa il 1-1-2.' }
     ];
     var LIVELLI = [
       { coppie: 3, cols: 3 },
@@ -177,6 +193,9 @@
       btn.setAttribute('aria-label', c.lbl);
       if (window.AudioSintetico) { window.AudioSintetico.init(); window.AudioSintetico.tono({freq: 440, durata: 0.1, gain: 0.15}); }
       if (!first){ first = {btn: btn, lbl: c.lbl}; return; }
+      // Nasconde "perche" precedente quando si gira la seconda carta del turno
+      var perBox = document.getElementById('perche');
+      if (perBox) { perBox.classList.add('hide'); perBox.textContent = ''; }
       if (first.lbl === c.lbl){
         first.btn.classList.add('matched');
         btn.classList.add('matched');
@@ -184,8 +203,15 @@
         totaleCoppie++;
         countEl.textContent = matched;
         if (window.AudioSintetico) window.AudioSintetico.dingPositivo();
+        // Mostra spiegazione didattica della coppia trovata (1 frase per
+        // bambini 3-6 anni). Resta visibile fino alla prossima carta girata.
+        var perEl = document.getElementById('perche');
+        if (perEl && c.perche) {
+          perEl.textContent = '💡 ' + c.emo + ' ' + c.perche;
+          perEl.classList.remove('hide');
+        }
         first = null;
-        if (matched === iconeLivello.length) setTimeout(fineLivello, 700);
+        if (matched === iconeLivello.length) setTimeout(fineLivello, 1800);
       } else {
         lock = true;
         var f = first;

--- a/static/giochi/infanzia/mezzo-giusto/index.html
+++ b/static/giochi/infanzia/mezzo-giusto/index.html
@@ -27,6 +27,21 @@
     }
     .scenario .emo { font-size: 4.5rem; line-height: 1; }
     .scenario .testo { font-size: 1.05rem; font-weight: 700; color: #495057; margin-top: 0.5rem; }
+    .tina-perche {
+      background: #d1e7dd; border: 2px solid #198754;
+      border-radius: 18px; padding: .8rem 1rem;
+      font-size: 1rem; font-weight: 600; color: #0f5132;
+      text-align: center; margin: 1rem 0 0;
+      animation: perche-in .35s ease;
+    }
+    .tina-perche.hide { display: none !important; }
+    @keyframes perche-in {
+      from { opacity: 0; transform: translateY(8px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .tina-perche { animation: none; }
+    }
     .mezzi-griglia {
       display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.7rem;
       max-width: 540px; margin: 0 auto;
@@ -103,6 +118,7 @@
             <span aria-hidden="true">🚐</span><span class="nome">Volontari PC</span>
           </button>
         </div>
+        <div id="perche" class="tina-perche hide" aria-live="polite"></div>
       </div>
 
       <div id="end-screen" class="hide">
@@ -130,20 +146,34 @@
     // 6 random. Le risposte sono 3: pompieri (fuoco/gas/blocchi), ambulanza
     // (chi sta male), volontari PC (aiuto post-evento). Coerente con NUE 112.
     const POOL = [
-      { emo: '🔥', testo: 'Una casa va a fuoco!', giusto: 'pompiere' },
-      { emo: '🤕', testo: 'Una persona si è fatta male!', giusto: 'ambulanza' },
-      { emo: '🌊', testo: "C'è stata un'alluvione: serve acqua e cibo!", giusto: 'volontari' },
-      { emo: '🚗💥', testo: 'Un incidente in strada con feriti!', giusto: 'ambulanza' },
-      { emo: '🌳', testo: 'Un albero è caduto sulla strada e blocca tutto!', giusto: 'volontari' },
-      { emo: '😵', testo: "Un signore anziano si è sentito male per il caldo!", giusto: 'ambulanza' },
-      { emo: '💨', testo: "C'è fumo dalla cucina dei vicini!", giusto: 'pompiere' },
-      { emo: '🐱', testo: "Un gatto è bloccato sull'albero più alto!", giusto: 'pompiere' },
-      { emo: '🚧', testo: "Una frana ha bloccato la strada del paese!", giusto: 'volontari' },
-      { emo: '🩹', testo: "La nonna è caduta e si è fatta una bua al ginocchio!", giusto: 'ambulanza' },
-      { emo: '⛑️', testo: "Dopo il terremoto serve allestire le tende!", giusto: 'volontari' },
-      { emo: '🚒', testo: "Un piccolo incendio nel bosco vicino casa!", giusto: 'pompiere' },
-      { emo: '💧', testo: "Una grossa perdita d'acqua allaga la cantina!", giusto: 'volontari' },
-      { emo: '😷', testo: "Un bambino non riesce a respirare bene!", giusto: 'ambulanza' }
+      { emo: '🔥', testo: 'Una casa va a fuoco!', giusto: 'pompiere',
+        perche: 'I pompieri spengono il fuoco e portano fuori le persone.' },
+      { emo: '🤕', testo: 'Una persona si è fatta male!', giusto: 'ambulanza',
+        perche: "L'ambulanza ha medici e infermieri: aiuta chi sta male." },
+      { emo: '🌊', testo: "C'è stata un'alluvione: serve acqua e cibo!", giusto: 'volontari',
+        perche: 'I volontari portano acqua e cibo a chi non ha più la casa.' },
+      { emo: '🚗💥', testo: 'Un incidente in strada con feriti!', giusto: 'ambulanza',
+        perche: "Per i feriti chiama subito l'ambulanza con il 112." },
+      { emo: '🌳', testo: 'Un albero è caduto sulla strada e blocca tutto!', giusto: 'volontari',
+        perche: 'I volontari liberano la strada con motoseghe e trattori.' },
+      { emo: '😵', testo: "Un signore anziano si è sentito male per il caldo!", giusto: 'ambulanza',
+        perche: 'Quando una persona si sente male, chiama il 112 e arriva l\'ambulanza.' },
+      { emo: '💨', testo: "C'è fumo dalla cucina dei vicini!", giusto: 'pompiere',
+        perche: 'Il fumo significa fuoco. Avvisa subito un adulto e chiama i pompieri.' },
+      { emo: '🐱', testo: "Un gatto è bloccato sull'albero più alto!", giusto: 'pompiere',
+        perche: 'I pompieri hanno la scala alta per salvare anche gli animali.' },
+      { emo: '🚧', testo: "Una frana ha bloccato la strada del paese!", giusto: 'volontari',
+        perche: 'I volontari aiutano a liberare la strada e a portare aiuti dove serve.' },
+      { emo: '🩹', testo: "La nonna è caduta e si è fatta una bua al ginocchio!", giusto: 'ambulanza',
+        perche: 'Per chi non riesce a camminare arriva l\'ambulanza con la barella.' },
+      { emo: '⛑️', testo: "Dopo il terremoto serve allestire le tende!", giusto: 'volontari',
+        perche: 'I volontari montano le tende per chi non può tornare a casa.' },
+      { emo: '🚒', testo: "Un piccolo incendio nel bosco vicino casa!", giusto: 'pompiere',
+        perche: 'I pompieri hanno i mezzi giusti per spegnere il fuoco nei boschi.' },
+      { emo: '💧', testo: "Una grossa perdita d'acqua allaga la cantina!", giusto: 'volontari',
+        perche: 'I volontari arrivano con le pompe per togliere l\'acqua.' },
+      { emo: '😷', testo: "Un bambino non riesce a respirare bene!", giusto: 'ambulanza',
+        perche: 'Quando manca il respiro è un\'emergenza: ambulanza subito col 112.' }
     ];
     function pescaScene(){
       const arr = POOL.slice();
@@ -193,6 +223,8 @@
       emoEl.textContent = r.emo;
       testoEl.textContent = r.testo;
       buttons.forEach(b => { b.classList.remove('correct', 'wrong', 'dim'); });
+      const perEl = document.getElementById('perche');
+      if (perEl) { perEl.classList.add('hide'); perEl.textContent = ''; }
       locked = false;
       drawProgress();
       if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
@@ -203,6 +235,12 @@
       locked = true;
       const tipo = btn.getAttribute('data-tipo');
       const giusto = ROUNDS[cur].giusto;
+      const perche = ROUNDS[cur].perche;
+      const perEl = document.getElementById('perche');
+      if (perEl && perche) {
+        perEl.textContent = '💡 ' + perche;
+        perEl.classList.remove('hide');
+      }
       if (tipo === giusto) {
         btn.classList.add('correct');
         score++;

--- a/static/giochi/infanzia/trova-cartello/index.html
+++ b/static/giochi/infanzia/trova-cartello/index.html
@@ -151,22 +151,38 @@
     var ISO  = '/pittogrammi/iso7010/';
     var ARAS = '/pittogrammi/arasaac/';
     var CATALOGO = {
-      fuoco:     { img: ISO  + 'materiale-infiammabile.svg',  sfondo: 'sfondo-giallo', nome: 'il fuoco' },
-      alta:      { img: ISO  + 'pericolo-elettrico.svg',      sfondo: 'sfondo-giallo', nome: 'l\'alta tensione (la corrente elettrica)' },
-      scivolo:   { img: ISO  + 'pavimento-scivoloso.svg',     sfondo: 'sfondo-giallo', nome: 'attenzione: pavimento scivoloso' },
-      caduta:    { img: ISO  + 'pericolo-generico.svg',       sfondo: 'sfondo-giallo', nome: 'attenzione al rischio di caduta' },
-      fumo:      { img: ISO  + 'vietato-fumare.svg',          sfondo: 'sfondo-rosso',  nome: 'vietato fumare' },
-      entrare:   { img: ISO  + 'vietato-pedoni.svg',          sfondo: 'sfondo-rosso',  nome: 'vietato entrare' },
-      ascensore: { img: ARAS + 'ascensore.png',               sfondo: 'sfondo-rosso',  nome: 'vietato usare l\'ascensore' },
-      mangiare:  { img: ARAS + 'cibo.png',                    sfondo: 'sfondo-rosso',  nome: 'vietato mangiare e bere' },
-      casco:     { img: ISO  + 'casco-protettivo.svg',        sfondo: 'sfondo-blu',    nome: 'mettere il casco' },
-      guanti:    { img: ISO  + 'guanti-protettivi.svg',       sfondo: 'sfondo-blu',    nome: 'mettere i guanti' },
-      mascherina:{ img: ISO  + 'maschera-protettiva.svg',     sfondo: 'sfondo-blu',    nome: 'mettere la mascherina' },
-      croce:     { img: ISO  + 'cassetta-primo-soccorso.svg', sfondo: 'sfondo-verde',  nome: 'il primo soccorso' },
-      raccolta:  { img: ISO  + 'punto-raccolta.svg',          sfondo: 'sfondo-verde',  nome: 'il punto di raccolta' },
-      uscita:    { img: ISO  + 'uscita-emergenza-destra.svg', sfondo: 'sfondo-uscita', nome: 'l\'uscita di emergenza' },
-      estintore: { img: ISO  + 'estintore.svg',               sfondo: 'sfondo-vvf',    nome: 'l\'estintore per spegnere il fuoco' },
-      vvf:       { img: ISO  + 'telefono-antincendio.svg',    sfondo: 'sfondo-vvf',    nome: 'i vigili del fuoco' }
+      fuoco:     { img: ISO  + 'materiale-infiammabile.svg',  sfondo: 'sfondo-giallo', nome: 'il fuoco',
+                   perche: 'I cartelli gialli con il triangolo avvisano di un pericolo: qui il fuoco.' },
+      alta:      { img: ISO  + 'pericolo-elettrico.svg',      sfondo: 'sfondo-giallo', nome: 'l\'alta tensione (la corrente elettrica)',
+                   perche: 'Il fulmine giallo avvisa che lì c\'è la corrente elettrica: non toccare i cavi.' },
+      scivolo:   { img: ISO  + 'pavimento-scivoloso.svg',     sfondo: 'sfondo-giallo', nome: 'attenzione: pavimento scivoloso',
+                   perche: 'Il pavimento bagnato fa scivolare: cammina piano e con scarpe asciutte.' },
+      caduta:    { img: ISO  + 'pericolo-generico.svg',       sfondo: 'sfondo-giallo', nome: 'attenzione al rischio di caduta',
+                   perche: 'Il triangolo con il punto esclamativo dice "stai attento": qui si può cadere.' },
+      fumo:      { img: ISO  + 'vietato-fumare.svg',          sfondo: 'sfondo-rosso',  nome: 'vietato fumare',
+                   perche: 'I cartelli rotondi rossi sono divieti: qui non si può fumare perché può prendere fuoco.' },
+      entrare:   { img: ISO  + 'vietato-pedoni.svg',          sfondo: 'sfondo-rosso',  nome: 'vietato entrare',
+                   perche: 'Il rosso col taglio significa "non fare": qui non puoi entrare perché è pericoloso.' },
+      ascensore: { img: ARAS + 'ascensore.png',               sfondo: 'sfondo-rosso',  nome: 'vietato usare l\'ascensore',
+                   perche: 'Durante un\'emergenza l\'ascensore può bloccarsi: usa sempre le scale.' },
+      mangiare:  { img: ARAS + 'cibo.png',                    sfondo: 'sfondo-rosso',  nome: 'vietato mangiare e bere',
+                   perche: 'In alcuni posti (laboratori, sale operative) non si mangia e non si beve per sicurezza.' },
+      casco:     { img: ISO  + 'casco-protettivo.svg',        sfondo: 'sfondo-blu',    nome: 'mettere il casco',
+                   perche: 'I cartelli blu rotondi sono obblighi: qui devi mettere il casco per proteggere la testa.' },
+      guanti:    { img: ISO  + 'guanti-protettivi.svg',       sfondo: 'sfondo-blu',    nome: 'mettere i guanti',
+                   perche: 'I guanti proteggono le mani da tagli, scottature e materiali sporchi.' },
+      mascherina:{ img: ISO  + 'maschera-protettiva.svg',     sfondo: 'sfondo-blu',    nome: 'mettere la mascherina',
+                   perche: 'La mascherina protegge naso e bocca da fumo, polvere o malattie.' },
+      croce:     { img: ISO  + 'cassetta-primo-soccorso.svg', sfondo: 'sfondo-verde',  nome: 'il primo soccorso',
+                   perche: 'I cartelli verdi indicano un posto di sicurezza: qui ci sono cerotti, bende e medicazioni.' },
+      raccolta:  { img: ISO  + 'punto-raccolta.svg',          sfondo: 'sfondo-verde',  nome: 'il punto di raccolta',
+                   perche: 'Dopo l\'evacuazione tutti vanno qui in fila: serve a contare chi è uscito.' },
+      uscita:    { img: ISO  + 'uscita-emergenza-destra.svg', sfondo: 'sfondo-uscita', nome: 'l\'uscita di emergenza',
+                   perche: 'I cartelli verdi con la freccia indicano la strada più sicura per uscire.' },
+      estintore: { img: ISO  + 'estintore.svg',               sfondo: 'sfondo-vvf',    nome: 'l\'estintore per spegnere il fuoco',
+                   perche: 'I cartelli rossi indicano gli strumenti antincendio: qui c\'è l\'estintore. Solo gli adulti lo usano.' },
+      vvf:       { img: ISO  + 'telefono-antincendio.svg',    sfondo: 'sfondo-vvf',    nome: 'i vigili del fuoco',
+                   perche: 'Il telefono rosso ricorda di chiamare i pompieri: in Italia il numero è 1-1-2.' }
     };
 
     // Pool di 16 domande: ogni partita ne pesca 12 random, divise in 2 round
@@ -284,7 +300,11 @@
       var q = domande[round];
       if (id === q.target) {
         btn.classList.add('correct');
-        feedbackEl.textContent = 'Giusto! Hai trovato ' + CATALOGO[id].nome + '.';
+        // Spiegazione didattica del cartello: 1 frase semplice (3-6 anni)
+        // sul significato del simbolo, non solo la conferma.
+        var perche = CATALOGO[id].perche || '';
+        feedbackEl.innerHTML = 'Giusto! Hai trovato ' + CATALOGO[id].nome + '.' +
+          (perche ? ' <small style="display:block;margin-top:.3rem;font-weight:400;color:#0f5132;">💡 ' + perche + '</small>' : '');
         feedbackEl.style.color = '#198754';
         cartelliEl.querySelectorAll('button').forEach(function (b) { b.disabled = true; if (b !== btn) b.classList.add('dim'); });
         if (window.AudioSintetico) window.AudioSintetico.tono({ freq: 659, durata: 0.18 });
@@ -292,7 +312,7 @@
         setTimeout(function () {
           round++;
           showRound();
-        }, 1100);
+        }, 2400);
       } else {
         errors++;
         btn.classList.add('wrong');


### PR DESCRIPTION
## Cosa cambia

L'utente: «avevi scritto che vi erano dei giochi mancanti della motivazione del perché quella risposta. li hai sistemati?». L'audit indicava come pattern trasversale: «manca quasi ovunque la spiegazione del PERCHÉ una risposta è giusta — presente in quiz, chiamata-112, scelte-difficili, cosa-faccio-se, vero-o-bufala. Manca in: acchiappa-pericolo, mezzo-giusto, trova-cartello, memory, memory-facile, cielo-oggi».

Nel batch infanzia precedente (PR #61) avevo aggiunto solo i pool random e dimenticato le spiegazioni. Sistemato qui.

## 4 giochi modificati

| Gioco | Pattern aggiunto | Esempio spiegazione |
|---|---|---|
| **mezzo-giusto** | `perche` su 14 scene del POOL | «I pompieri spengono il fuoco e portano fuori le persone.» |
| **acchiappa-pericolo** | `perche` su 14 scene del POOL | «Vicino alla finestra i vetri possono rompersi. Mettiti SOTTO il tavolo finché non finisce la scossa.» |
| **trova-cartello** | `perche` su 16 cartelli del CATALOGO | «Il triangolo giallo dice 'stai attento': qui c'è un pericolo.» |
| **memory-facile** | `perche` su 9 icone | «L'ambulanza porta in ospedale chi sta male.» |

Stile uniforme: box `.tina-perche` verde con icona 💡, bordo, animazione slide (rispetta `prefers-reduced-motion`).

## Esclusioni dell'audit

- `cielo-oggi`: già conforme (campo `tip` per ogni scena con spiegazione del codice colore).
- `memory` (primaria): già fatto in PR #54 con campo `explain`.

## Test plan

- [ ] mezzo-giusto: dopo ogni scelta appare la spiegazione
- [ ] acchiappa-pericolo: dopo aver toccato qualcosa appare la spiegazione del PC angle
- [ ] trova-cartello: dopo aver trovato il cartello giusto, il feedback include il significato del simbolo
- [ ] memory-facile: dopo aver trovato una coppia appare un fumetto con la spiegazione

https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR)_