### PR TITLE
Quiz + abbina-impara + semaforo-rischio: tema fake news / IT-alert / fonti ufficiali

### DIFF
--- a/static/giochi/primaria/abbina-impara/js/script.js
+++ b/static/giochi/primaria/abbina-impara/js/script.js
@@ -98,6 +98,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 { left: 'Gelo', right: 'Strade scivolose, attenzione al ghiaccio' },
                 { left: 'Vento forte', right: 'Attenzione ad alberi e cartelloni' }
             ]
+        },
+        {
+            title: 'Comunicazione di crisi', icon: '📢',
+            pairs: [
+                { left: 'IT-alert', right: 'SMS d\'emergenza dal Governo a tutti i cellulari nella zona' },
+                { left: 'Fonti ufficiali', right: 'Comune, DPC, Centro Funzionale Regionale' },
+                { left: 'Fake news', right: 'Notizia falsa: verifica prima di credere e di inoltrare' },
+                { left: 'Direttiva Mattarella 2008', right: 'Regole nazionali sulla comunicazione del rischio' },
+                { left: 'Bollettino di criticita', right: 'Documento ufficiale con il codice colore di allerta' },
+                { left: 'Non amplificare', right: 'Non condividere il post falso, neanche per smentirlo' }
+            ]
         }
     ];
 
@@ -112,7 +123,8 @@ document.addEventListener('DOMContentLoaded', () => {
         'Cartelli di sicurezza':  { url: '/pittogrammi/',                        titolo: 'pittogrammi' },
         'Classi di fuoco':        { url: '/rischi-prevenzione/rischio-incendio/',titolo: 'rischio incendio' },
         'Ruoli in emergenza':     { url: '/chi-siamo/',                          titolo: 'chi siamo' },
-        'Meteo e allerte':        { url: '/allerte-meteo/',                      titolo: 'allerte meteo' }
+        'Meteo e allerte':        { url: '/allerte-meteo/',                      titolo: 'allerte meteo' },
+        'Comunicazione di crisi': { url: '/social-media-policy/',                titolo: 'social media policy' }
     };
 
     function shuffle(arr) {

--- a/static/giochi/primaria/quiz/js/script.js
+++ b/static/giochi/primaria/quiz/js/script.js
@@ -27,7 +27,8 @@ document.addEventListener('DOMContentLoaded', () => {
         { id: 'zaino', name: 'Zaino di emergenza', icon: 'bi-backpack2' },
         { id: 'evacuazione', name: 'Evacuazione scuola', icon: 'bi-door-open' },
         { id: 'protezione-civile', name: 'Protezione Civile', icon: 'bi-shield-check' },
-        { id: 'sicurezza', name: 'Sicurezza in casa', icon: 'bi-house-check' }
+        { id: 'sicurezza', name: 'Sicurezza in casa', icon: 'bi-house-check' },
+        { id: 'comunicazione', name: 'Fonti ufficiali e IT-alert', icon: 'bi-broadcast' }
     ];
 
     const questions = [
@@ -1087,6 +1088,98 @@ document.addEventListener('DOMContentLoaded', () => {
                 { text: 'A controllare il Wi-Fi', correct: false }
             ],
             explanation: 'Il rilevatore di fumo è un piccolo apparecchio che suona forte appena sente fumo. Può salvare la vita, soprattutto di notte quando si dorme.'
+        },
+
+        // ═══════════════════════════════════════════════════════════════
+        // CATEGORIA 9: FONTI UFFICIALI E IT-ALERT (8 domande)
+        // ═══════════════════════════════════════════════════════════════
+        {
+            category: 'comunicazione',
+            question: 'Cosa è IT-alert?',
+            answers: [
+                { text: 'Un nuovo gioco di emergenza', correct: false },
+                { text: 'Un messaggio del Governo che arriva su tutti i cellulari nella zona di pericolo', correct: true },
+                { text: 'Una sigla dei volontari', correct: false },
+                { text: 'Una radio per i pompieri', correct: false }
+            ],
+            explanation: 'IT-alert è il sistema italiano di allarme pubblico, attivo dal 2024: il Governo manda un messaggio (cell broadcast) a tutti i cellulari accesi nella zona del pericolo. Arriva anche se non hai i contatti del Comune.'
+        },
+        {
+            category: 'comunicazione',
+            question: 'Tuo cugino ti manda su WhatsApp un messaggio "Allerta rossa! È previsto terremoto stanotte!". Cosa fai?',
+            answers: [
+                { text: 'Lo inoltro a tutti per avvisare', correct: false },
+                { text: 'Vado a dormire fuori casa', correct: false },
+                { text: 'Verifico sul sito del Comune o della Protezione Civile e non lo inoltro', correct: true },
+                { text: 'Chiamo subito il 112 per chiedere conferma', correct: false }
+            ],
+            explanation: 'I terremoti NON si possono prevedere. Ogni "allerta sismica" su WhatsApp è una bufala. Verifica sempre su fonti ufficiali (Comune, DPC, Centro Funzionale Regionale) prima di credere e di inoltrare.'
+        },
+        {
+            category: 'comunicazione',
+            question: 'Quale di queste NON è una fonte ufficiale per le allerte meteo nel Lazio?',
+            answers: [
+                { text: 'Il Centro Funzionale Regionale del Lazio', correct: false },
+                { text: 'Il sito del Dipartimento di Protezione Civile (DPC)', correct: false },
+                { text: 'Il sito del Comune di Genzano', correct: false },
+                { text: 'Un canale Telegram di un meteo amatoriale', correct: true }
+            ],
+            explanation: 'I canali amatoriali e i meteo "sensazionalistici" non sono ufficiali. Le sole fonti affidabili per le allerte sono Centro Funzionale Regionale, DPC e Comune.'
+        },
+        {
+            category: 'comunicazione',
+            question: 'Perché il messaggio di IT-alert arriva fortissimo e non puoi metterlo in silenzio?',
+            answers: [
+                { text: 'Per fare uno scherzo', correct: false },
+                { text: 'Perché in emergenza l\'allarme deve raggiungere TUTTI, anche chi dorme', correct: true },
+                { text: 'Per pubblicizzare il Governo', correct: false },
+                { text: 'Perché è un test', correct: false }
+            ],
+            explanation: 'IT-alert usa un suono forte e una vibrazione speciale che ignora le impostazioni silenziose: in emergenza vera, ogni minuto conta e la notifica deve svegliare anche chi dorme.'
+        },
+        {
+            category: 'comunicazione',
+            question: 'Una signora in metro ti dice che ha visto su Facebook che "il sindaco evacua mezzo paese stanotte". Come reagisci?',
+            answers: [
+                { text: 'La credo subito e lo dico ai miei genitori', correct: false },
+                { text: 'La ignoro completamente', correct: false },
+                { text: 'Le rispondo che è una bufala perché è su Facebook', correct: false },
+                { text: 'Verifico sul sito del Comune o sul canale ufficiale prima di credere', correct: true }
+            ],
+            explanation: 'In emergenza non si crede né si esclude a priori. Si verifica sulle fonti ufficiali. I social non sono fonti ufficiali (anche se a volte le riportano).'
+        },
+        {
+            category: 'comunicazione',
+            question: 'Cosa significa "non amplificare la fake news"?',
+            answers: [
+                { text: 'Non urlare quando la racconti', correct: false },
+                { text: 'Non condividere il post falso, nemmeno per smentirlo', correct: true },
+                { text: 'Mettere il volume basso al video', correct: false },
+                { text: 'Non parlare di politica', correct: false }
+            ],
+            explanation: 'Quando condividi una fake news (anche per criticarla) il post diventa più visibile e raggiunge più persone. Meglio rispondere SENZA citare il post falso, indicando solo la fonte ufficiale corretta.'
+        },
+        {
+            category: 'comunicazione',
+            question: 'In allerta arancione, dove cerchi le indicazioni del Comune di Genzano?',
+            answers: [
+                { text: 'Solo sui giornali del giorno dopo', correct: false },
+                { text: 'Sul sito ufficiale del Comune e sui canali social istituzionali', correct: true },
+                { text: 'Sul gruppo WhatsApp degli amici', correct: false },
+                { text: 'Su Wikipedia', correct: false }
+            ],
+            explanation: 'Il Comune comunica le emergenze sul sito istituzionale e sui canali social ufficiali (verificati con il bollino blu). In più ci sono il sito della Regione Lazio e quello del DPC.'
+        },
+        {
+            category: 'comunicazione',
+            question: 'I codici colore delle allerte meteo (verde/giallo/arancione/rosso) chi li stabilisce per il Lazio?',
+            answers: [
+                { text: 'Il Comune di Genzano', correct: false },
+                { text: 'Il Centro Funzionale Regionale del Lazio', correct: true },
+                { text: 'Il meteo della TV nazionale', correct: false },
+                { text: 'Il Sindaco', correct: false }
+            ],
+            explanation: 'Il Centro Funzionale Regionale (CFR) del Lazio è la struttura tecnica che valuta i bollettini di criticità ed emette i codici colore. Il Comune e il Sindaco poi attivano le misure operative.'
         }
     ];
 

--- a/static/giochi/primaria/semaforo-rischio/js/script.js
+++ b/static/giochi/primaria/semaforo-rischio/js/script.js
@@ -55,6 +55,18 @@ document.addEventListener('DOMContentLoaded', () => {
         { text: 'Allerta meteo gialla per temporali nel pomeriggio.', answer: 'giallo', tip: 'Preparati: evita parchi, stadi, piscine. Se scoppia il temporale, rifugiati in un edificio.' },
         { text: 'Sei a casa e non hai connessione internet da 5 minuti.', answer: 'verde', tip: 'Internet può guastarsi per tanti motivi: aspetta, riavvia il router. Non è un\'emergenza.' },
         { text: 'Vedi un bambino più piccolo di te che sembra essersi perso al supermercato.', answer: 'giallo', tip: 'Chiedigli come si chiama e portalo da un commesso o alla cassa: loro chiameranno al microfono.' },
+
+        // Tema "comunicazione del rischio" — fonti ufficiali + IT-alert + fake news
+        { text: 'Tuo cugino ti gira un audio WhatsApp: "ho saputo che stanotte fanno saltare la diga di Nemi!".', answer: 'verde', tip: 'Audio anonimi su WhatsApp = quasi sempre fake news. Non lo inoltri, non ci credi, verifichi sul sito del Comune.' },
+        { text: 'Sul cellulare arriva un messaggio "IT-alert" con sirena fortissima e vibrazione.', answer: 'rosso', tip: 'IT-alert e ufficiale del Governo. Leggi attentamente le indicazioni: stanno avvisando di un pericolo concreto nella tua zona.' },
+        { text: 'Un meteorologo TikTok dice: "domani il Lazio sara colpito da uragano!".', answer: 'verde', tip: 'TikTok non e fonte ufficiale. Verifica sul sito del Centro Funzionale Regionale: senza allerta ufficiale, e sensazionalismo.' },
+        { text: 'Il sindaco di Genzano pubblica un video sui canali ufficiali del Comune: allerta arancione confermata.', answer: 'rosso', tip: 'Comunicazione ufficiale del sindaco: prendi sul serio. Limita gli spostamenti e segui le indicazioni.' },
+        { text: 'Su Instagram vedi un post di un negozio "evacuazione totale di Genzano stanotte!" con tante condivisioni.', answer: 'verde', tip: 'Le condivisioni non rendono vera una notizia. Mai un\'evacuazione si comunica via post di un negozio: si comunica per IT-alert, sito Comune e sirene.' },
+        { text: 'Sul sito del Centro Funzionale Regionale Lazio leggi: codice giallo per temporali domani 12-18.', answer: 'giallo', tip: 'Bollettino ufficiale codice giallo: criticita ordinaria. Preparati, ma niente panico.' },
+        { text: 'Un amico ti chiede di rilanciare un suo post che chiede preghiere per "il terremoto in arrivo".', answer: 'verde', tip: 'I terremoti non si possono prevedere. Niente preghiere preventive, niente allarmismo: si chiama "diffondere falsi allarmi".' },
+        { text: 'Il bollettino DPC (Dipartimento Protezione Civile) annuncia codice rosso per ondata di calore.', answer: 'rosso', tip: 'Codice rosso ufficiale: rischio elevato per anziani e bambini. Bevi tantissimo, niente sole tra 11 e 17, controlla i nonni.' },
+        { text: 'Un canale Telegram non ufficiale dice "il Comune sta nascondendo l\'emergenza!".', answer: 'verde', tip: 'Tipico schema cospirazionista. Le emergenze vere vengono comunicate dai canali ufficiali, non "rivelate" da canali anonimi.' },
+        { text: 'A scuola la maestra spiega l\'app "Allerta Lazio" della Regione e ti chiede di scaricarla con i genitori.', answer: 'giallo', tip: 'L\'app ufficiale Allerta Lazio manda gli avvisi del Centro Funzionale: utile, va attivata. Pre-emergenza informativa.' }
     ];
 
     let queue, index, score, locked;


### PR DESCRIPTION
## Cosa cambia

3 giochi primaria con nuovo focus sul tema **fake news, IT-alert e fonti ufficiali** (rules `06-protezione-civile-scientifica.md` § "Comunicazione di crisi").

### Quiz primaria — 9ª categoria "Fonti ufficiali e IT-alert"

8 domande nuove su:
- IT-alert e cell broadcast del Governo (operativo 2024)
- Riconoscere fake news ("terremoto stanotte!" su WhatsApp)
- Fonti ufficiali (CFR, DPC, Comune) vs meteo amatoriali
- Perché IT-alert non si silenzia
- "Non amplificare" — non condividere il post falso
- Codici colore stabiliti dal CFR Lazio

### Abbina-impara — 9ª categoria "Comunicazione di crisi"

6 coppie: IT-alert, fonti ufficiali, fake news, Direttiva Mattarella 2008, bollettino di criticità, non amplificare. URL teoria → `/social-media-policy/`.

### Semaforo-rischio — +10 situazioni nuove

Esempi:
- Audio WhatsApp anonimo «fanno saltare la diga di Nemi» → 🟢 verde (no panico)
- Messaggio IT-alert con sirena → 🔴 rosso (è ufficiale)
- Meteorologo TikTok sensazionalista → 🟢 verde (non ufficiale)
- Bollettino CFR codice giallo → 🟡 giallo
- Telegram non ufficiale «il Comune nasconde» → 🟢 verde (cospirazione)
- App Allerta Lazio → 🟡 giallo (informativo)

## Test plan

- [ ] Quiz: nuova categoria visibile in selezione, tutte e 8 le domande funzionano
- [ ] Abbina-impara: 9 categorie totali (era 8), accoppiamento corretto
- [ ] Semaforo: 50 situazioni totali (era 40), shuffle estrae casualmente

https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR)_