### PR TITLE
Suoni-emergenza (azione tip), cosa-faccio-se (pausa recupero), radio-emergency (jargon)

### DIFF
--- a/static/giochi/infanzia/suoni-emergenza/index.html
+++ b/static/giochi/infanzia/suoni-emergenza/index.html
@@ -38,6 +38,19 @@
     }
     .ascolta:hover { transform: translateY(-2px); }
     .wave { display:inline-block; width: 80px; }
+    /* Tip didattico: cosa fare quando si sente quel suono. */
+    .azione-tip {
+      display: block;
+      margin-top: .4rem;
+      padding: .5rem .7rem;
+      background: rgba(0, 51, 102, .08);
+      border-left: 3px solid #003366;
+      border-radius: 6px;
+      font-size: .92rem;
+      font-weight: 500;
+      color: #003366;
+      text-align: left;
+    }
   </style>
 </head>
 <body class="inf-body" data-coach-game="suoni-emergenza">
@@ -90,22 +103,32 @@
   <script src="/giochi/assets/js/comune.js"></script>
   <script>
   (function(){
+    // Per ogni suono, il campo `azione` dice CHE FARE quando lo si sente:
+    // crea il legame "suono -> reazione corretta", non solo riconoscimento.
     var SUONI = [
-      { id: 'ambulanza', emo: '🚑', lbl: 'Ambulanza', play: function(){ window.AudioSintetico.sirenaAmbulanza(1.5); } },
-      { id: 'tuono', emo: '⛈️', lbl: 'Tuono', play: function(){ window.AudioSintetico.tuono(); } },
-      { id: 'allarme', emo: '🔔', lbl: 'Allarme', play: function(){ window.AudioSintetico.allarmeIncendio(1.2); } },
-      { id: 'campanello', emo: '🛎️', lbl: 'Campanello', play: function(){ window.AudioSintetico.campanello(); } },
-      { id: 'italert', emo: '📱', lbl: 'IT-alert', play: function(){ window.AudioSintetico.itAlert(); } },
+      { id: 'ambulanza', emo: '🚑', lbl: 'Ambulanza', play: function(){ window.AudioSintetico.sirenaAmbulanza(1.5); },
+        azione: 'Quando la senti: stai lontano dalla strada, lascia passare l\'ambulanza, non correre.' },
+      { id: 'tuono', emo: '⛈️', lbl: 'Tuono', play: function(){ window.AudioSintetico.tuono(); },
+        azione: 'Quando lo senti: torna in casa, stai lontano da finestre e oggetti elettrici.' },
+      { id: 'allarme', emo: '🔔', lbl: 'Allarme', play: function(){ window.AudioSintetico.allarmeIncendio(1.2); },
+        azione: 'Quando suona a scuola: ti metti in fila col capofila e segui la maestra al punto di raccolta.' },
+      { id: 'campanello', emo: '🛎️', lbl: 'Campanello', play: function(){ window.AudioSintetico.campanello(); },
+        azione: 'Quando suona alla porta: chiama un grande prima di aprire. Mai aprire da solo a sconosciuti.' },
+      { id: 'italert', emo: '📱', lbl: 'IT-alert', play: function(){ window.AudioSintetico.itAlert(); },
+        azione: 'Quando senti questo suono fortissimo dal cellulare: leggi il messaggio. Il Governo ti sta avvisando di un pericolo.' },
       { id: 'pioggia', emo: '🌧️', lbl: 'Pioggia', play: function(){
           window.AudioSintetico.rumoreBianco({durata: 1.6, gain: 0.18});
-        } },
+        },
+        azione: 'Quando piove tantissimo: stai in casa, niente parchi, mai vicino a fiumi o sottopassi.' },
       { id: 'vento', emo: '💨', lbl: 'Vento', play: function(){
           window.AudioSintetico.rumoreBianco({durata: 1.4, gain: 0.22, freq: 350});
-        } },
+        },
+        azione: 'Quando soffia forte: chiudi le finestre, stai lontano da alberi, cartelloni, balconi.' },
       { id: 'radio', emo: '📻', lbl: 'Radio PC', play: function(){
           window.AudioSintetico.pipRadio();
           setTimeout(function(){ window.AudioSintetico.pipRadio(); }, 350);
-        } }
+        },
+        azione: 'Quando senti la radio della PC: ascolta bene, sta comunicando informazioni utili agli adulti.' }
     ];
 
     var intro = document.getElementById('intro'),
@@ -161,13 +184,16 @@
         stars++;
         starsEl.textContent = stars;
         feedback.style.color = '#0f5132';
-        feedback.innerHTML = '✅ Bravo! Era il ' + target.lbl.toLowerCase() + '.';
+        // Feedback con riconoscimento + azione corretta da fare quando si
+        // sente quel suono. Crea il legame "suono -> reazione" (livello 2
+        // implicito: non solo identifica, ma sai cosa fare).
+        feedback.innerHTML = '✅ Bravo! Era il ' + target.lbl.toLowerCase() + '.<br><span class="azione-tip">💡 ' + target.azione + '</span>';
         if (window.AudioSintetico) window.AudioSintetico.dingPositivo();
         if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
       } else {
         btn.classList.add('wrong');
         feedback.style.color = '#8B1F2E';
-        feedback.innerHTML = '🐢 Era il ' + target.lbl.toLowerCase() + '. Continua!';
+        feedback.innerHTML = '🐢 Era il ' + target.lbl.toLowerCase() + '.<br><span class="azione-tip">💡 ' + target.azione + '</span>';
         if (window.AudioSintetico) window.AudioSintetico.tonoNeutro();
         if (window.GameCoach && window.GameCoach.hint) {
           window.GameCoach.hint('Sirena ambulanza = 3 toni veloci. Tuono = boom dopo il fulmine. Allarme scuola = suono lungo. IT-Alert = il telefono squilla forte.', '/allerte-meteo/');

--- a/static/giochi/primaria/cosa-faccio-se/css/style.css
+++ b/static/giochi/primaria/cosa-faccio-se/css/style.css
@@ -39,3 +39,36 @@
     .story-text { font-size: 0.95rem; }
     .choice-btn { font-size: 0.88rem; padding: 12px 14px; }
 }
+
+/* Pausa per riflettere — appare dopo 2 errori consecutivi.
+   Mini-recupero didattico: il bambino vede i punti chiave dello scenario
+   prima di continuare. Cliccare "Riprendo!" chiude e si torna al gioco. */
+.pausa-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+.pausa-box {
+  background: #fffbf0;
+  border: 3px solid #b45309;
+  border-radius: 16px;
+  padding: 1.5rem 1.2rem;
+  max-width: 480px;
+  text-align: left;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  animation: pausaSlide .35s ease;
+}
+.pausa-box h3 { color: #b45309; margin: 0 0 .6rem; font-size: 1.2rem; }
+.pausa-box p { margin: 0 0 .6rem; font-size: .95rem; }
+.pausa-box ul { margin: 0 0 1rem 1.2rem; padding: 0; }
+.pausa-box li { margin: .3rem 0; line-height: 1.45; font-weight: 500; }
+.pausa-box button { width: 100%; padding: .7rem; font-weight: 700; }
+@keyframes pausaSlide {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .pausa-box { animation: none; }
+}

--- a/static/giochi/primaria/cosa-faccio-se/js/script.js
+++ b/static/giochi/primaria/cosa-faccio-se/js/script.js
@@ -290,7 +290,20 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     ];
 
-    let currentScenario, stepIndex, errors;
+    let currentScenario, stepIndex, errors, consecutiveErrors;
+    // Punti chiave per il "Pausa per riflettere" box che appare dopo 2 errori
+    // consecutivi: aiuta il bambino a fermarsi e ripensare alle regole base
+    // dello scenario, prima di continuare a sbagliare.
+    const PAUSA_PUNTI = {
+      terremoto: ['Sotto un tavolo robusto', 'Lontano dalle finestre', 'Mai correre durante la scossa', 'Mai usare l\'ascensore'],
+      incendio: ['Esci subito senza tornare indietro', 'Mai usare l\'ascensore', 'Copri naso e bocca con un panno', 'Chiama il 112'],
+      alluvione: ['Sali ai piani alti', 'Mai entrare in cantina o garage', 'Mai attraversare sottopassi allagati', 'Chiudi acqua, gas, luce'],
+      temporale: ['Stai in casa, lontano da finestre', 'Niente cellulari sotto carica', 'Niente doccia o lavandino', 'Aspetta che passi'],
+      fuga_gas: ['Apri tutte le finestre', 'Chiudi il rubinetto del gas', 'Niente fiamme né interruttori', 'Esci e chiama il 112'],
+      smarrimento: ['Resta dove sei', 'Cerca un adulto in divisa', 'Non seguire sconosciuti', 'Memorizza nome e telefono di un adulto'],
+      bullismo: ['Parla con un adulto di fiducia', 'Non rispondere con violenza', 'Salva le prove (screenshot)', 'Chiedi aiuto: non sei solo'],
+      maltempo_scuola: ['Segui le indicazioni dei docenti', 'Resta nei corridoi sicuri', 'Mai aprire le finestre', 'Aspetta che passi']
+    };
 
     function renderScenarioList() {
         selectScreen.classList.remove('hide');
@@ -310,6 +323,7 @@ document.addEventListener('DOMContentLoaded', () => {
         currentScenario = sc;
         stepIndex = 0;
         errors = 0;
+        consecutiveErrors = 0;
         selectScreen.classList.add('hide');
         storyScreen.classList.remove('hide');
         scenarioBadge.textContent = sc.title;
@@ -356,6 +370,7 @@ document.addEventListener('DOMContentLoaded', () => {
             storyFeedback.innerHTML = '<strong><i class="bi bi-check-circle-fill me-1"></i> Giusto!</strong> ' + choice.tip;
             storyFeedback.classList.remove('hide');
             if (window.GameCoach && window.GameCoach.clearHint) { window.GameCoach.clearHint(); }
+            consecutiveErrors = 0; // risposta giusta azzera il contatore
             setTimeout(() => {
                 stepIndex++;
                 if (stepIndex < currentScenario.steps.length) { showStep(); }
@@ -364,6 +379,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             btn.classList.add('wrong-choice');
             errors++;
+            consecutiveErrors++;
             storyFeedback.className = 'story-feedback wrong';
             storyFeedback.innerHTML = '<strong><i class="bi bi-x-circle-fill me-1"></i> Non proprio...</strong> ' + choice.tip;
             storyFeedback.classList.remove('hide');
@@ -377,8 +393,32 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (!b.classList.contains('wrong-choice')) { b.disabled = false; }
                 });
                 storyFeedback.classList.add('hide');
+                // Mini-recupero: dopo 2 errori consecutivi mostro un box
+                // "Pausa per riflettere" con i punti chiave dello scenario,
+                // poi azzero il contatore (cosi' non ricompare immediatamente).
+                if (consecutiveErrors >= 2) {
+                    mostraPausaRecupero();
+                    consecutiveErrors = 0;
+                }
             }, 2200);
         }
+    }
+
+    function mostraPausaRecupero() {
+        const punti = PAUSA_PUNTI[currentScenario.id];
+        if (!punti) return;
+        const overlay = document.createElement('div');
+        overlay.className = 'pausa-overlay';
+        overlay.innerHTML = '<div class="pausa-box">' +
+          '<h3>🌿 Pausa per riflettere</h3>' +
+          '<p>Stai sbagliando un po\' di scelte. Fermati e ripensa a queste regole:</p>' +
+          '<ul>' + punti.map(p => '<li>' + p + '</li>').join('') + '</ul>' +
+          '<button type="button" class="btn btn-primary">Riprendo!</button>' +
+          '</div>';
+        document.body.appendChild(overlay);
+        const closeBtn = overlay.querySelector('button');
+        closeBtn.addEventListener('click', () => overlay.remove());
+        closeBtn.focus();
     }
 
     function showEnd() {

--- a/static/giochi/ragazzi/radio-emergency/index.html
+++ b/static/giochi/ragazzi/radio-emergency/index.html
@@ -171,6 +171,50 @@
         ],
         corretta: 1,
         spiega: 'Frasi brevi e chiare: la radio ha tempo limitato e va capita subito.'
+      },
+      {
+        domanda: 'In radioamatorialismo, "CQ" significa:',
+        opzioni: [
+          'Chiudo la frequenza',
+          'Chiamata generale a tutte le stazioni',
+          'Codice di emergenza',
+          'Cambio canale'
+        ],
+        corretta: 1,
+        spiega: '"CQ" (dall\'inglese "seek you") è la chiamata generale: il radioamatore lancia "CQ CQ CQ" per cercare un contatto.'
+      },
+      {
+        domanda: '"QRZ?" in radio significa:',
+        opzioni: [
+          'Hai un\'emergenza?',
+          'Chi mi sta chiamando?',
+          'Ripeti il messaggio',
+          'Cambio frequenza'
+        ],
+        corretta: 1,
+        spiega: '"QRZ?" è il codice Q internazionale per "Chi mi sta chiamando?". Lo si usa quando si è ricevuta una chiamata ma non si è capito il nominativo.'
+      },
+      {
+        domanda: '"Mayday Mayday Mayday" si dice solo per:',
+        opzioni: [
+          'Festeggiare il primo maggio',
+          'Pericolo di vita imminente (massima priorità)',
+          'Test di trasmissione',
+          'Cambio antenna'
+        ],
+        corretta: 1,
+        spiega: '"Mayday" (dal francese m\'aidez) è il segnale di pericolo internazionale di massima priorità. Lo si ripete 3 volte. Solo per pericolo di vita imminente.'
+      },
+      {
+        domanda: '"Pan-Pan" in radio significa:',
+        opzioni: [
+          'Pericolo di vita imminente',
+          'Urgenza ma non pericolo immediato di vita',
+          'Test di linea',
+          'Cambio operatore'
+        ],
+        corretta: 1,
+        spiega: '"Pan-Pan" (dal francese "panne") segnala un\'urgenza grave ma non immediato pericolo di vita. Es: motore in avaria, persona ferita non grave. Sotto Mayday.'
       }
     ];
 
@@ -178,7 +222,11 @@
       { frase: 'GENZANO', spell: 'Golf - Echo - November - Zulu - Alfa - November - Oscar' },
       { frase: 'COC', spell: 'Charlie - Oscar - Charlie' },
       { frase: 'BRAVO 3', spell: 'Bravo - Romeo - Alfa - Victor - Oscar - tre' },
-      { frase: 'APPIA', spell: 'Alfa - Papa - Papa - India - Alfa' }
+      { frase: 'APPIA', spell: 'Alfa - Papa - Papa - India - Alfa' },
+      { frase: 'NEMI', spell: 'November - Echo - Mike - India' },
+      { frase: 'AIB 7', spell: 'Alfa - India - Bravo - sette' },
+      { frase: 'COM', spell: 'Charlie - Oscar - Mike' },
+      { frase: 'DPC', spell: 'Delta - Papa - Charlie' }
     ];
 
     // Render ripasso


### PR DESCRIPTION
## Cosa cambia

Ultimi 3 giochi del piano audit completo.

### suoni-emergenza (infanzia)
**Livello 2 didattico implicito**: dopo la risposta corretta il bambino legge cosa FARE quando sente quel suono.
- Sirena ambulanza → «stai lontano dalla strada, lascia passare»
- IT-alert → «leggi il messaggio, il Governo ti sta avvisando»
- Allarme scuola → «ti metti in fila col capofila»
- Tuono → «torna in casa, lontano da finestre»
- Vento forte → «chiudi finestre, stai lontano da alberi»
- ecc.

### cosa-faccio-se (primaria)
**Mini-recupero didattico** dopo 2 errori consecutivi: appare un overlay "🌿 Pausa per riflettere" con i 3-4 punti chiave dello scenario, prima di lasciare proseguire.

8 scenari coperti (terremoto, incendio, alluvione, temporale, fuga gas, smarrimento, bullismo, maltempo scuola). Counter `consecutiveErrors` si azzera ad ogni risposta giusta.

### radio-emergency (ragazzi)
**4 nuove domande jargon radioamatoriale**:
- CQ CQ CQ — chiamata generale (seek you)
- QRZ? — chi mi sta chiamando? (codice Q)
- Mayday Mayday Mayday — pericolo di vita imminente
- Pan-Pan — urgenza grave (sotto Mayday)

**DETTATO ampliato** con NEMI, AIB 7, COM, DPC: allena su termini PC reali del territorio.

## Test plan

- [ ] suoni: dopo ogni suono compare il box azione
- [ ] cosa-faccio-se: 2 errori filati → appare overlay pausa
- [ ] radio: nuove 4 domande sul jargon

https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR)_