### PR TITLE
Memory: fix coppia "caduta massi" — il file SVG mostrava W023 corrosivo

### DIFF
--- a/static/giochi/primaria/memory/js/script.js
+++ b/static/giochi/primaria/memory/js/script.js
@@ -44,8 +44,13 @@
       explain: 'Il triangolo giallo col fulmine avvisa di alta tensione. Mai toccare cavi scoperti o pali della luce.' },
     { id: 'infiammabile', sign: 'materiale-infiammabile', name: 'Materiale infiammabile', action: 'Lontano da fiamme',
       explain: 'Liquidi che prendono fuoco facilmente: benzina, alcol, vernici. Mai accendere fiamme vicino.' },
-    { id: 'massi', sign: 'caduta-massi', name: 'Caduta massi', action: 'Attento alle frane',
-      explain: 'Nei sentieri di montagna e lungo i versanti questo segnale avvisa che possono cadere sassi: non fermarti sotto.' },
+    // Nota: il file static/pittogrammi/iso7010/caduta-massi.svg scaricato da
+    // Wikimedia mostra in realta' il pittogramma W023 (sostanza corrosiva),
+    // non W022 (caduta massi). Bug della libreria. Per ora usiamo
+    // pavimento-scivoloso come 10a coppia: file corretto e concetto chiaro
+    // per primaria. TODO: sostituire caduta-massi.svg con il vero W022.
+    { id: 'scivoloso', sign: 'pavimento-scivoloso', name: 'Pavimento scivoloso', action: 'Cammina piano, non correre',
+      explain: 'Il segnale giallo con la persona che scivola avvisa che il pavimento e\' bagnato. Cammina piano, mai correre: cadute e fratture.' },
     { id: 'fuochi', sign: 'vietato-fuochi', name: 'Vietato accendere fuochi', action: 'Niente fiamme nel bosco',
       explain: 'D\'estate è vietato accendere fuochi nei boschi: bastano poche scintille per un grande incendio.' },
     { id: 'acqua', sign: 'acqua-potabile', name: 'Acqua potabile', action: 'Si può bere senza paura',


### PR DESCRIPTION
## Bug

Hai segnalato che nel Memory dei Segnali la voce **"Attento alle frane"** è abbinata a un pittogramma giallo che mostra **una mano corrosa**, non sassi che cadono. Confermo: l'icona è ISO W023 (sostanza corrosiva), non W022 (caduta massi).

## Causa

Il file `static/pittogrammi/iso7010/caduta-massi.svg` scaricato da Wikimedia in realtà contiene il pittogramma W023. Bug del download della libreria. Il filename è fuorviante.

## Fix puntuale (questa PR)

Nel pool del Memory sostituisco la coppia problematica con **"Pavimento scivoloso + Cammina piano, non correre"** (file `pavimento-scivoloso.svg` corrisponde correttamente al W011, e il concetto è educativo per la primaria).

Aggiunto un commento nel codice per documentare il bug della libreria e ricordare la TODO di sostituire `caduta-massi.svg` col vero W022 (lavoro più ampio sulla libreria).

## Test plan

- [ ] Memory primaria: nessuna delle 12 coppie mostra il pittogramma corrosivo
- [ ] La nuova coppia "Pavimento scivoloso ↔ Cammina piano" funziona correttamente

https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR)_