### PR TITLE
Posiziona-cartelli: più spazio verticale tra label + niente troncamento

### DIFF
--- a/static/giochi/primaria/posiziona-cartelli/index.html
+++ b/static/giochi/primaria/posiziona-cartelli/index.html
@@ -126,11 +126,15 @@
     .mod-opt small { display: block; color: #5b6b7c; font-weight: 400; margin-top: .15rem; }
 
     .tray {
-      background: #fff; border-radius: 12px; padding: .8rem;
+      background: #fff; border-radius: 12px; padding: 1rem .8rem;
       box-shadow: 0 2px 8px rgba(0,0,0,.06);
-      display: flex; flex-wrap: wrap; gap: .6rem;
+      display: flex; flex-wrap: wrap;
+      /* Gap verticale piu' grande del orizzontale: la label sotto ogni
+         pittogramma ha bisogno di respiro verticale per evitare
+         sovrapposizione fra una riga e l'altra. */
+      gap: 1.8rem 1rem;
       justify-content: center;
-      min-height: 110px;
+      min-height: 130px;
     }
 
     .sign {
@@ -180,14 +184,20 @@
     }
 
     .sign-label {
-      position: absolute; bottom: -22px; left: 50%; transform: translateX(-50%);
-      font-size: .72rem; font-weight: 600; color: #003366;
-      white-space: nowrap; background: rgba(255,255,255,.85);
-      padding: 1px 6px; border-radius: 10px;
-      max-width: 140px; overflow: hidden; text-overflow: ellipsis;
+      position: absolute; bottom: -28px; left: 50%; transform: translateX(-50%);
+      font-size: .75rem; font-weight: 600; color: #003366;
+      background: rgba(255,255,255,.92);
+      padding: 2px 8px; border-radius: 10px;
+      /* Permetto wrapping su 2 righe e larghezza maggiore: prima la label
+         "Primo soccorso" veniva troncata a "Primo soccors" perche' non
+         entrava in 140px nowrap. Ora si adatta al testo. */
+      max-width: 130px; min-width: 70px;
+      white-space: normal;
+      text-align: center;
+      line-height: 1.2;
     }
 
-    .sign-wrap { position: relative; padding-bottom: 18px; }
+    .sign-wrap { position: relative; padding-bottom: 36px; }
 
     .drop-highlight { background: rgba(0,51,102,.15); border-color: #003366 !important; }
 
@@ -216,10 +226,16 @@
     @media (max-width: 576px) {
       .sign { width: 64px; height: 64px; font-size: 1.8rem; }
       .slot { width: 72px; height: 72px; font-size: .75rem; }
-      .sign-label { font-size: .65rem; max-width: 110px; }
-      /* Più spazio fra le sign per evitare sovrapposizione delle label */
-      .tray { gap: 1.4rem 1rem; padding: 1rem .5rem; }
-      .sign-wrap { padding-bottom: 22px; }
+      .sign-label {
+        font-size: .68rem;
+        max-width: 100px;
+        line-height: 1.15;
+        padding: 1px 5px;
+      }
+      /* Più spazio verticale fra le righe di sign su mobile: la label
+         "Primo soccorso" o "Punto di raccolta" puo' andare su 2 righe. */
+      .tray { gap: 2.4rem 1rem; padding: 1rem .5rem; }
+      .sign-wrap { padding-bottom: 36px; }
     }
     @media (prefers-reduced-motion: reduce) {
       .sign, .level-card { transition: none; }


### PR DESCRIPTION
## Bug segnalato

Hai inviato uno screenshot di posiziona-cartelli: le label sotto i pittogrammi (Vietato fumare, Alta tensione, Primo soccorso, ecc.) sono attaccate orizzontalmente e **«Primo soccorso» appare troncato a «Primo soccors»**.

## Causa

Il CSS aveva `white-space: nowrap` + `text-overflow: ellipsis` + `max-width: 140px`: «Primo soccorso» (14 caratteri + spazio) non entra in 140px a quel font-size e viene tagliato.

E il `gap` del tray era `.6rem` orizzontale e verticale: troppo poco quando le label si estendono sotto i pittogrammi.

## Fix CSS

- **`.tray`**: gap verticale `1.8rem` (era `.6rem`). Mobile `2.4rem`.
- **`.sign-label`**: `white-space: normal` (era `nowrap`) → wrap su 2 righe quando serve. `bottom: -28px` (era `-22px`) per più aria. `line-height: 1.2`. `max-width: 130px` adattabile.
- **`.sign-wrap`**: `padding-bottom: 36px` (era `18px`) per accogliere label su 2 righe. Mobile uguale.

Risultato: «Primo soccorso», «Punto di raccolta», «Vietato fumare» visibili per intero, leggibili, ben distanziate.

## Test

- [ ] Desktop: nessuna label troncata, gap verticale evidente
- [ ] Mobile (≤576px): label vanno su 2 righe, niente sovrapposizione

https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ya5ysk9p3ZSMtiVNvdFfR)_