### PR TITLE
Lettura accessibile per fasce deboli: TTS dappertutto + glossario inline + tempo lettura + sillabazione

### DIFF
--- a/.claude/rules/03-accessibility.md
+++ b/.claude/rules/03-accessibility.md
@@ -124,9 +124,14 @@ Bottone "🔊 Ascolta" nella `.storia-toolbar` di tutte le fiabe in `static/form
 ### Caratteristiche accessibilità (comuni ai tre contesti)
 
 - ARIA: `role=button` o `<button>` nativo, `aria-pressed` o `aria-label` dinamico (idle/speaking), `aria-live=polite` per stato annunciato a screen reader.
-- Tastiera: bottone nativo, attivabile con Enter/Space, focus visibile (`outline 3px #ffbe2e`). Anche i radio del selettore velocità sono tastiera-navigabili.
+- Tastiera: bottone nativo, attivabile con Enter/Space, focus visibile (`outline 3px #ffbe2e`). Anche i radio del selettore velocità e il toggle "Segui parole" sono tastiera-navigabili.
 - Voce italiana: priorità `it-IT`, fallback qualsiasi voce con `lang.startsWith("it")`, fallback voce default browser.
 - Velocità: tre opzioni (**0.75x lento / 0.95x normale / 1.15x veloce**) selezionabili dall'utente accanto al bottone. Persistite in `localStorage` (chiave `pcgenzano-tts-rate`) — la scelta vale per tutte le pagine. Default normale.
+- **"Segui parole" (highlight della parola in lettura)**: toggle accanto al selettore velocità. Quando attivo, la parola attualmente pronunciata dal TTS si evidenzia con `<mark class="tts-word-mark">` (sfondo `#fff3cd`, sottolineatura `#ffbe2e`). Sincronizzazione audio-visiva via evento `SpeechSynthesisUtterance.onboundary` (`event.name === 'word'`). Persistito in `localStorage` (chiave `pcgenzano-tts-follow`). Default OFF (alcuni utenti lo trovano "rumoroso" su pagine lunghe). Beneficio principale: dislessia, italiano L2, anziani che si distraggono, bambini in lettura lenta — gli occhi seguono l'orecchio. Letteratura: Sumner et al. 2013-2018, principio dei software didattici ClaroRead/Read&Write.
+  - **Fallback graceful**: se l'evento `word` non arriva entro 2.5s dall'avvio (Safari iOS ha bug noti), l'highlight si auto-disattiva per la sessione e il TTS continua puro. Niente regressione.
+  - **Varianti CSS** per la toolbar a11y: contrasto invertito (`html.a11y-contrast-invert`), scala grigi (`html.a11y-grayscale`), alto contrasto (`html.a11y-contrast-high`) → palette dedicate per non perdere leggibilità.
+  - **Auto-scroll** centrato sulla parola (`scrollIntoView({ block: 'center' })` con `behavior: smooth`, override `auto` se `prefers-reduced-motion`).
+  - **Override stampa**: il `<mark>` viene resettato in `@media print` per evitare che una stampa avviata durante la lettura mostri evidenziazione gialla casuale.
 - Stati visivi distinti: idle (outline), speaking (riempito + animazione pulse, rispetta `prefers-reduced-motion`).
 - Stop automatico su: page unload, dialog close, ESC, click su altro bottone TTS.
 - Fallback graceful: se browser senza Web Speech API, bottone nascosto via `ttsSupported()`.

--- a/.claude/rules/03-accessibility.md
+++ b/.claude/rules/03-accessibility.md
@@ -160,6 +160,41 @@ CSS scoped sezione **SILLABAZIONE AUTOMATICA v1.0** in `custom.css`. Esclusioni 
 
 Compatibilità: Chrome 88+, Firefox 43+, Safari 5.1+ (tutti i browser moderni). Su browser senza supporto, il fallback è il rendering standard senza sillabazione (zero regressione).
 
+## Glossario inline con popover
+
+Il sito ha una libreria di voci di glossario (sigle e termini specialistici PC) che il browser **sostituisce automaticamente** alla **prima occorrenza** in ogni pagina con un bottone cliccabile + popover accessibile (definizione breve di 1-2 frasi + link al glossario completo). Aiuta cittadini non tecnici, anziani, italiano L2 e persone in stress da emergenza che incontrano sigle come **DPC**, **COC**, **AeDES**, **IT-alert**, **CFR** senza sapere cosa significhino.
+
+**Architettura:**
+- `data/glossario.yaml` — fonte unica delle voci. Ogni voce: `id`, `termine`, `varianti` (lista di forme da matchare), `definizione` (1-2 frasi AGID, max ~200 caratteri), `link` (URL della voce completa nel `/glossario/`).
+- `static/js/glossario-inline.js` — al `DOMContentLoaded` scansiona `.article-body` e `.list-intro-content`, costruisce una mega-regex con tutte le varianti (ordinata per lunghezza decrescente per priorità), sostituisce la **prima occorrenza** di ogni termine con `<button class="gloss-term">termine ⓘ</button>` + `<span class="gloss-popover" role="tooltip" hidden>`. Scansione O(N) sulla lunghezza del testo.
+- `themes/flavour-pcgenzano/layouts/partials/glossario-inline.html` — inietta `window.PCGENZANO_GLOSSARIO` come JSON statico al build (passa i `link` per `relURL` per compatibilità subpath GitHub Pages) e carica il JS con `defer`.
+- CSS scoped sezione **GLOSSARIO INLINE v1.0** in `custom.css`: termine sottolineato tratteggiato blu istituzionale + icona `ⓘ`, popover con triangolino, varianti per toolbar a11y (contrasto invertito, alto contrasto), nascosto in stampa.
+
+**Vincoli di copyright:** le definizioni sono **parafrasi originali** del Gruppo Comunale, basate sul glossario interno `content/glossario/_index.md` (già di sua penna) e sul glossario DPC pubblico (opera della PA italiana → libera, art. 5 L. 633/1941). **Mai copiare da Treccani** o altre opere protette: solo definizioni nostre, anche quando consultate come riferimento. Cf. policy concordata maggio 2026.
+
+**Esclusioni dal match:** il JS salta i nodi dentro `<a>`, `<button>`, `<code>`, `<pre>`, `<h1>`, `<kbd>`, `[aria-hidden="true"]`, `.no-gloss`, `.tts-wrapper`, `.gloss-term`. Così non si sovrappone a link esistenti, codice, intestazioni di pagina, o altri bottoni. Inoltre solo la **prima occorrenza** di ogni termine viene sostituita: niente rumore visivo se "DPC" appare 10 volte in un articolo.
+
+**Pagine escluse (blacklist nel template, identica a TTS):** `/privacy/`, `/note-legali/`, `/accessibilita/`, `/social-media-policy/`, `/mappa-sito/`, `/attribuzioni-pittogrammi/`, `/cerca/`, `/comunicazioni/` (list), `/glossario/` (auto-esclusa per non popolare popover sui termini del glossario stesso). Per disattivare su una singola pagina: `tts: false` nel frontmatter (la condizione è la stessa del TTS).
+
+**Accessibilità del popover:**
+- Tastiera: bottone nativo, **Enter/Space** apre, **ESC** chiude (con focus che torna al button), **Tab** esce normalmente (non c'è focus trap, è un popover non-modal).
+- ARIA: `aria-expanded` sul button, `aria-describedby` che punta al popover, `role="tooltip"` sul popover, `aria-label` esplicito sul link "Scopri di più nel glossario".
+- Mouse: hover su desktop con `pointer:fine` (no hover su touch), click ovunque chiude (delegato).
+- Scroll: chiude i popover quando l'utente scrolla, perché la posizione assoluta non li segue.
+- Stampa: il bottone torna a testo normale, il popover sparisce.
+
+**Quando aggiungere voci al glossario:**
+- Sigle PC ricorrenti che il cittadino non riconosce (DPC, COC, COI, AeDES, AIB, IT-alert, NUE, CFR…).
+- Termini tecnici che cambiano significato fra linguaggio comune e tecnico (allerta vs emergenza, magnitudo vs intensità, vulnerabilità vs pericolosità).
+- Sigle giuridiche e normative (D.Lgs. 1/2018, OdV, ETS, DPCM, TUSL).
+
+**Regole operative:**
+- Aggiungere una voce: editare `data/glossario.yaml` con id univoco, varianti complete (sigla + espansione + plurali), definizione AGID. Niente più nulla — il prossimo build la prende automaticamente.
+- Disattivare il glossario su una pagina specifica (es. articolo poetico, schede di servizio): `tts: false` nel frontmatter (esclude TTS + glossario insieme — sono accoppiati intenzionalmente, hanno la stessa logica di blacklist).
+- **Evitare definizioni-pubblicità** (mai *"il nostro Gruppo è esperto di X"*): la definizione deve essere **didattica** e **istituzionale**, lo stesso principio del glossario `content/glossario/_index.md`.
+
+Specifiche complete in `MANUALE-SITO.md` (futura parte) e nella regola `02-content-design-pa.md` § "Vocabolario PA".
+
 ## Coach dei giochi — onboarding e teoria di rinforzo
 
 Tutti i giochi statici in `static/giochi/{infanzia,primaria,ragazzi}/` hanno un sistema condiviso di **onboarding** + **teoria di rinforzo** che riduce l'abbandono dei bambini che non hanno nozioni di base e rispondono a caso. Ispirato a "Io non rischio" del DPC e alla regola AGID di accessibilità cognitiva.

--- a/.claude/rules/03-accessibility.md
+++ b/.claude/rules/03-accessibility.md
@@ -99,13 +99,19 @@ Per la struttura dei file, le regole di estensione e i divieti operativi vedi `0
 
 Il sito usa la **Web Speech API browser-native** in tre contesti distinti, tutti basati sullo stesso paradigma (`window.speechSynthesis` + `SpeechSynthesisUtterance`, voce italiana, niente file MP3, niente API key esterne, niente costi). Il W3C-WAI raccomanda questa scelta per la PA al posto degli overlay commerciali (AccessiBe, UserWay, Equally AI), che mascherano problemi invece di risolverli.
 
-### 1. TTS pagine Hugo (partial `leggi-ad-alta-voce.html`)
+### 1. TTS pagine Hugo (partial `leggi-ad-alta-voce.html`) — default ON con blacklist
 
-Pulsante grande "Leggi ad alta voce" inserito automaticamente all'inizio del corpo articolo nelle pagine con frontmatter `tts: true`. Componente in `themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html`.
+Pulsante "Leggi ad alta voce" inserito automaticamente in cima al contenuto di **tutte le pagine** del sito (single + list page con contenuto editoriale > 30 parole). Include un **selettore di velocità** (lento 0.75x / normale 0.95x / veloce 1.15x) persistito in `localStorage` (chiave `pcgenzano-tts-rate`). Componente in `themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html` (v2.0).
 
-**Pagine attive (21):**
-- 12 pagine storiche: cosa-fare-adesso, numeri-utili, facile-da-leggere, allerte-meteo, piano-familiare + 7 sotto-pagine rischi-prevenzione (sismico, idrogeologico, incendio, vento, temporali, blackout, ondate-calore).
-- 9 pagine aggiunte (PR coach + TTS): assistente, faq, piano-emergenza, contatti, chi-siamo, diventa-volontario, glossario, rischi-prevenzione/{kit-emergenza, persone-necessita-specifiche}.
+**Default ON** — la logica è invertita rispetto alla v1 (era opt-in via `tts: true`). Da maggio 2026 il bottone appare **ovunque** tranne dove esplicitamente escluso da:
+
+1. **Blacklist hard-coded nel template** (`single.html` + `list.html`):
+   - `/privacy/`, `/note-legali/`, `/accessibilita/`, `/social-media-policy/` — pagine legali
+   - `/mappa-sito/`, `/attribuzioni-pittogrammi/`, `/cerca/` — pagine tecniche/funzionali
+2. **Frontmatter opt-out**: aggiungere `tts: false` a una pagina specifica.
+3. **Soglia minima**: pagine con `WordCount ≤ 30` non mostrano il bottone (titolo o pagina ponte priva di contenuto).
+
+Why: il TTS è uno strumento di accessibilità trasversale per anziani, dislessici, italiano L2, bambini in lettura lenta, persone in stress da emergenza. Lasciarlo opt-in significava averlo solo sul ~20% delle pagine (22 pagine su 100+). La blacklist mantiene comunque escluse pagine dove la lettura ad alta voce non è utile (cookie/privacy notice, mappa-sito tecnica, motore di ricerca).
 
 ### 2. TTS dentro il "Coach" dei giochi (`giochi/assets/js/coach.js`)
 
@@ -118,9 +124,9 @@ Bottone "🔊 Ascolta" nella `.storia-toolbar` di tutte le fiabe in `static/form
 ### Caratteristiche accessibilità (comuni ai tre contesti)
 
 - ARIA: `role=button` o `<button>` nativo, `aria-pressed` o `aria-label` dinamico (idle/speaking), `aria-live=polite` per stato annunciato a screen reader.
-- Tastiera: bottone nativo, attivabile con Enter/Space, focus visibile (`outline 3px #ffbe2e`).
+- Tastiera: bottone nativo, attivabile con Enter/Space, focus visibile (`outline 3px #ffbe2e`). Anche i radio del selettore velocità sono tastiera-navigabili.
 - Voce italiana: priorità `it-IT`, fallback qualsiasi voce con `lang.startsWith("it")`, fallback voce default browser.
-- Velocità: 0.9-0.95x default per chiarezza (più lento del default).
+- Velocità: tre opzioni (**0.75x lento / 0.95x normale / 1.15x veloce**) selezionabili dall'utente accanto al bottone. Persistite in `localStorage` (chiave `pcgenzano-tts-rate`) — la scelta vale per tutte le pagine. Default normale.
 - Stati visivi distinti: idle (outline), speaking (riempito + animazione pulse, rispetta `prefers-reduced-motion`).
 - Stop automatico su: page unload, dialog close, ESC, click su altro bottone TTS.
 - Fallback graceful: se browser senza Web Speech API, bottone nascosto via `ttsSupported()`.
@@ -128,11 +134,26 @@ Bottone "🔊 Ascolta" nella `.storia-toolbar` di tutte le fiabe in `static/form
 **Caso d'uso target:** anziani con vista debole, persone in stress/emergenza, parlanti italiano L2, bambini che leggono lentamente, utenti con dislessia.
 
 **Regole operative:**
-- Per attivare TTS su una **nuova pagina Hugo**: aggiungere `tts: true` nel frontmatter (opt-in esplicito, non automatico).
+- Per le **pagine Hugo**: niente da fare. Il TTS è ON di default. Per **disattivarlo** su una pagina specifica aggiungere `tts: false` nel frontmatter. Per **escludere una nuova categoria** (es. nuove pagine legali future) aggiungere il path alla blacklist `$ttsBlacklist` in `single.html` e `list.html`.
 - Per **giochi statici**: il TTS dentro il coach è già attivo via `coach.js` su tutti i giochi con `data-coach-game` sul `<body>` — niente da fare manualmente.
 - Per **nuove storie/racconti**: includere `<script src="/formazione/storie-e-racconti/assets/tts-storia.js" defer></script>` prima di `</body>` nell'index.html della storia. Il modulo trova `.storia-toolbar` e inietta il bottone.
-- **Non attivare TTS** su pagine legali (privacy, note legali, accessibilità, social-media-policy) o tecniche (mappa sito, attribuzioni-pittogrammi) — non utili da leggere ad alta voce.
 - **Non aggiungere altri TTS provider** (es. Google Cloud TTS, AWS Polly) che richiedono API key/costo: Web Speech API browser è gratuita, sempre aggiornata col testo, e raccomandata da W3C-WAI per PA.
+
+## Tempo di lettura stimato (`reading-time`)
+
+In cima a ogni pagina con `WordCount > 30` (e non in blacklist TTS) compare un'etichetta discreta del tipo *"Lettura: ~3 minuti"*, calcolata da Hugo con `.ReadingTime` (200 parole/min). Riduce l'ansia da "muro di testo" per anziani, dislessici, italiano L2 e persone che leggono lentamente — chi guarda la pagina sa subito quanto tempo gli serve.
+
+Implementata in `_default/single.html` e `_default/list.html` con la stessa condizione del TTS. CSS scoped sezione **TEMPO DI LETTURA v1.0** in `custom.css`: pill arrotondata azzurro istituzionale, font 0.88rem, nascosta in stampa.
+
+Niente da configurare per pagina: è automatica. Per disattivarla su un caso specifico, condivide la condizione del TTS — `tts: false` la nasconde insieme al bottone.
+
+## Sillabazione automatica (`hyphens: auto`)
+
+Il corpo articolo (`.article-body` su single.html, `.list-intro-content` su list.html) ha sillabazione automatica attivata via CSS `hyphens: auto` con regole italiane (lingua dichiarata in `<html lang="it">`). Beneficio cognitivo per **dislessici e parlanti italiano L2**: meno parole lunghe spezzate brutalmente a fine riga, ritmo di lettura più uniforme.
+
+CSS scoped sezione **SILLABAZIONE AUTOMATICA v1.0** in `custom.css`. Esclusioni tecniche automatiche: `<pre>`, `<code>`, `<table>`, classe utility `.no-hyphens` per casi speciali (toponimi, marchi).
+
+Compatibilità: Chrome 88+, Firefox 43+, Safari 5.1+ (tutti i browser moderni). Su browser senza supporto, il fallback è il rendering standard senza sillabazione (zero regressione).
 
 ## Coach dei giochi — onboarding e teoria di rinforzo
 

--- a/data/glossario.yaml
+++ b/data/glossario.yaml
@@ -1,0 +1,525 @@
+# ============================================================
+# Glossario inline — voci con tooltip che il JS sostituisce
+# automaticamente nella prima occorrenza in .article-body e
+# .list-intro-content delle pagine Hugo.
+#
+# REGOLA COPYRIGHT (vincolo del progetto):
+#   Le definizioni qui scritte sono parafrasi originali del
+#   Gruppo Comunale, basate sul glossario interno
+#   `content/glossario/_index.md` e sul glossario DPC pubblico
+#   (opera della PA italiana → libera, art. 5 L. 633/1941).
+#   Nessun testo è copiato da Treccani o altre opere protette.
+#
+# COME AGGIUNGERE UNA VOCE:
+#   - id: identificatore univoco minuscolo, da usare nell'anchor
+#         del glossario completo (es. coc → /glossario/#coc)
+#   - termine: la parola/sigla che appare visibile nel testo
+#             quando il match scatta (case originale del match)
+#   - varianti: lista di stringhe da matchare. Tutte le forme
+#               grammaticali e le espressioni complete della sigla.
+#               Match case-insensitive, word-boundary regex.
+#   - definizione: 1-2 frasi, voce attiva, frasi <20 parole,
+#                  italiano AGID. Max ~200 caratteri (sta nel tooltip).
+#   - link: URL della voce completa nel /glossario/.
+#
+# REGOLE DI MATCH:
+#   - Solo PRIMA occorrenza per articolo (un termine non si
+#     evidenzia 10 volte di fila — sarebbe rumore visivo).
+#   - Mai dentro <a>, <button>, <code>, <pre>, <h1>, <kbd>,
+#     [aria-hidden=true], .no-gloss, .tts-wrapper.
+#   - Se il termine è già parte di un link/bottone esistente,
+#     non viene riprocessato.
+# ============================================================
+
+- id: dpc
+  termine: "DPC"
+  varianti:
+    - "DPC"
+    - "Dipartimento della Protezione Civile"
+    - "Dipartimento di Protezione Civile"
+  definizione: "Dipartimento della Protezione Civile: struttura della Presidenza del Consiglio che coordina il Servizio Nazionale di Protezione Civile."
+  link: "/glossario/#dpc"
+
+- id: coc
+  termine: "COC"
+  varianti:
+    - "COC"
+    - "Centro Operativo Comunale"
+  definizione: "Centro Operativo Comunale: la sala operativa che il Sindaco attiva per gestire un'emergenza sul territorio comunale."
+  link: "/glossario/#coc-centro-operativo-comunale"
+
+- id: coi
+  termine: "COI"
+  varianti:
+    - "COI"
+    - "Centro Operativo Intercomunale"
+  definizione: "Centro Operativo Intercomunale: coordina più Comuni vicini in un'emergenza estesa. Genzano fa parte del 15° COI Castelli Romani Sud."
+  link: "/glossario/#coi-centro-operativo-intercomunale"
+
+- id: nue
+  termine: "NUE"
+  varianti:
+    - "NUE"
+    - "Numero Unico Emergenze"
+    - "Numero Unico Europeo"
+  definizione: "Numero Unico Emergenze 112: dal 2017 è l'unico numero da chiamare per qualsiasi emergenza nel Lazio. Smista la chiamata all'ente competente."
+  link: "/glossario/#nue-112"
+
+- id: cfr
+  termine: "CFR"
+  varianti:
+    - "CFR"
+    - "Centro Funzionale Regionale"
+  definizione: "Centro Funzionale Regionale: emette il bollettino di criticità giornaliero per il Lazio (verde, giallo, arancione, rosso)."
+  link: "/glossario/#centro-funzionale-regionale-cfr"
+
+- id: aedes
+  termine: "AeDES"
+  varianti:
+    - "AeDES"
+  definizione: "Scheda Agibilità e Danno nell'Emergenza Sismica: tecnici qualificati la compilano dopo un terremoto per dichiarare un edificio agibile, parzialmente agibile o inagibile."
+  link: "/glossario/#aedes"
+
+- id: aib
+  termine: "AIB"
+  varianti:
+    - "AIB"
+    - "Antincendio Boschivo"
+  definizione: "Antincendio Boschivo: prevenzione, avvistamento e spegnimento degli incendi nei boschi. Stagione AIB nel Lazio: giugno-settembre."
+  link: "/glossario/#aib"
+
+- id: area-attesa
+  termine: "Area di Attesa"
+  varianti:
+    - "Area di Attesa"
+    - "Aree di Attesa"
+    - "Area Attesa"
+  definizione: "Punto sicuro dove la popolazione si raduna nelle prime fasi di un'emergenza, in attesa di indicazioni. A Genzano sono numerate AA1, AA2…"
+  link: "/glossario/#aa-area-di-attesa"
+
+- id: area-ricovero
+  termine: "Area di Ricovero"
+  varianti:
+    - "Area di Ricovero"
+    - "Aree di Ricovero"
+  definizione: "Aree dove si allestiscono tende o moduli abitativi per ospitare la popolazione evacuata, anche per settimane o mesi."
+  link: "/glossario/#ar-area-di-ricovero"
+
+- id: area-ammassamento
+  termine: "Area di Ammassamento"
+  varianti:
+    - "Area di Ammassamento"
+    - "Area di Ammassamento Soccorritori"
+    - "Aree di Ammassamento"
+  definizione: "Spazio dove si concentrano uomini, mezzi e materiali in arrivo da fuori comune per supportare un'emergenza. A Genzano: AS1 e AS2."
+  link: "/glossario/#as-area-di-ammassamento-soccorritori"
+
+- id: dicomac
+  termine: "DICOMAC"
+  varianti:
+    - "DICOMAC"
+  definizione: "Direzione Comando e Controllo: struttura nazionale di coordinamento operativo che il DPC attiva sul luogo di un'emergenza di rilevanza nazionale."
+  link: "/glossario/#dicomac"
+
+- id: codice-pc
+  termine: "Codice della Protezione Civile"
+  varianti:
+    - "Codice della Protezione Civile"
+    - "Codice di Protezione Civile"
+    - "D.Lgs. 1/2018"
+    - "D.Lgs. 2 gennaio 2018 n. 1"
+  definizione: "D.Lgs. 1/2018: la legge che regola tutto il Sistema Nazionale di Protezione Civile (chi fa cosa, le 4 attività, diritti dei volontari)."
+  link: "/glossario/#codice-della-protezione-civile"
+
+- id: it-alert
+  termine: "IT-alert"
+  varianti:
+    - "IT-alert"
+    - "ITalert"
+    - "IT Alert"
+  definizione: "Sistema di allarme pubblico nazionale: il DPC invia messaggi al cellulare nelle aree colpite da un'emergenza grave (terremoti, eruzioni, dighe)."
+  link: "/glossario/#it-alert"
+
+- id: bollettino-criticita
+  termine: "Bollettino di criticità"
+  varianti:
+    - "Bollettino di criticità"
+    - "Bollettino di criticità idrogeologica e idraulica"
+    - "Bollettino criticità"
+  definizione: "Documento del CFR emesso ogni giorno entro le 14:00, valido 24-36 ore. Indica il livello di rischio idrogeologico, idraulico e temporali."
+  link: "/glossario/#bollettino-di-criticita-idrogeologica-e-idraulica"
+
+- id: pec
+  termine: "PEC"
+  varianti:
+    - "Piano di Emergenza Comunale"
+    - "Piano Comunale di Protezione Civile"
+  definizione: "Piano di Emergenza Comunale: il documento del Comune che descrive scenari di rischio, aree di attesa, attivazione del COC e ruoli operativi."
+  link: "/glossario/#piano-di-emergenza-comunale"
+
+- id: pai
+  termine: "PAI"
+  varianti:
+    - "PAI"
+    - "Piano di Assetto Idrogeologico"
+  definizione: "Piano di Assetto Idrogeologico: mappa frane, alluvioni e dissesti del territorio. Definisce dove si può e non si può costruire."
+  link: "/glossario/#pai"
+
+- id: dpi
+  termine: "DPI"
+  varianti:
+    - "DPI"
+    - "Dispositivi di Protezione Individuale"
+  definizione: "Dispositivi di Protezione Individuale: caschi, guanti, scarpe antinfortunistiche, giubbotti alta visibilità che il volontario indossa in attivazione."
+  link: "/glossario/#dpi"
+
+- id: dvr
+  termine: "DVR"
+  varianti:
+    - "DVR"
+    - "Documento di Valutazione dei Rischi"
+  definizione: "Documento di Valutazione dei Rischi: obbligatorio per ogni datore di lavoro (D.Lgs. 81/2008). Nelle scuole è la base del piano di evacuazione."
+  link: "/glossario/#dvr"
+
+- id: copernicus-ems
+  termine: "Copernicus EMS"
+  varianti:
+    - "Copernicus EMS"
+    - "Copernicus Emergency Management Service"
+  definizione: "Emergency Management Service della Commissione Europea: fornisce mappe satellitari rapide dopo grandi emergenze (alluvioni, incendi estesi, terremoti)."
+  link: "/glossario/#copernicus-ems"
+
+- id: colonna-mobile
+  termine: "Colonna Mobile"
+  varianti:
+    - "Colonna Mobile"
+    - "Colonna mobile"
+  definizione: "Mezzi, attrezzature e personale che una Regione invia in un'altra Regione colpita da emergenza grave. Mobilitabile in poche ore."
+  link: "/glossario/#colonna-mobile"
+
+- id: arpa-lazio
+  termine: "ARPA Lazio"
+  varianti:
+    - "ARPA Lazio"
+  definizione: "Agenzia Regionale per la Protezione dell'Ambiente del Lazio: monitora aria, acqua, rumore, radiazioni. In emergenza fornisce dati a DPC e Regione."
+  link: "/glossario/#arpa-lazio"
+
+- id: ares-118
+  termine: "ARES 118"
+  varianti:
+    - "ARES 118"
+    - "ARES Lazio"
+  definizione: "Azienda Regionale Emergenza Sanitaria del Lazio: gestisce l'emergenza sanitaria territoriale. Per chiamare: NUE 112 (non più direttamente il 118)."
+  link: "/glossario/#ares-118"
+
+- id: bradisismo
+  termine: "Bradisismo"
+  varianti:
+    - "Bradisismo"
+  definizione: "Lento sollevamento o abbassamento del suolo dovuto ad attività vulcanica. Esempio italiano: i Campi Flegrei in Campania."
+  link: "/glossario/#bradisismo"
+
+- id: vulnerabilita
+  termine: "Vulnerabilità"
+  varianti:
+    - "vulnerabilità"
+  definizione: "Capacità di resistere all'evento dannoso. Un edificio antisismico è meno vulnerabile, una persona anziana è più vulnerabile a un'ondata di calore."
+  link: "/glossario/#rischio"
+
+- id: pericolosita
+  termine: "Pericolosità"
+  varianti:
+    - "pericolosità"
+  definizione: "Probabilità che un evento dannoso (terremoto, alluvione) si verifichi in una certa area in un certo tempo. È un dato del territorio."
+  link: "/glossario/#rischio"
+
+- id: resilienza
+  termine: "Resilienza"
+  varianti:
+    - "resilienza"
+  definizione: "Capacità di una comunità di assorbire un evento avverso, riorganizzarsi e tornare a funzionare. Si costruisce con prevenzione, formazione, pianificazione."
+  link: "/glossario/#resilienza"
+
+- id: allerta
+  termine: "allerta"
+  varianti:
+    - "allerta"
+    - "allerta meteo"
+    - "allerta meteorologica"
+  definizione: "Stato di attenzione comunicato dalle autorità prima che un evento si verifichi. Quattro livelli: verde, gialla, arancione, rossa. Diversa da emergenza."
+  link: "/glossario/#allerta"
+
+- id: emergenza
+  termine: "emergenza"
+  varianti:
+    - "emergenza"
+  definizione: "Situazione in cui un evento sta accadendo adesso e impone risposte immediate. Il Codice PC distingue tre tipi: A comunale, B regionale, C nazionale."
+  link: "/glossario/#emergenza"
+
+- id: evacuazione
+  termine: "Evacuazione"
+  varianti:
+    - "evacuazione"
+  definizione: "Allontanamento ordinato della popolazione da un'area a rischio verso aree sicure (di norma le aree di attesa del Piano Comunale)."
+  link: "/glossario/#evacuazione"
+
+- id: esercitazione
+  termine: "Esercitazione"
+  varianti:
+    - "esercitazione"
+  definizione: "Simulazione di emergenza per verificare piani e procedure. Può essere per posti di comando (solo decisori) o in pieno scenario (con uomini e mezzi reali)."
+  link: "/glossario/#esercitazione"
+
+- id: ingv
+  termine: "INGV"
+  varianti:
+    - "INGV"
+    - "Istituto Nazionale di Geofisica e Vulcanologia"
+  definizione: "Istituto Nazionale di Geofisica e Vulcanologia: monitora terremoti e vulcani in Italia 24/7. Pubblica le prime info dopo ogni scossa rilevante."
+  link: "/glossario/#ingv"
+
+- id: ispra
+  termine: "ISPRA"
+  varianti:
+    - "ISPRA"
+    - "Istituto Superiore per la Protezione e la Ricerca Ambientale"
+  definizione: "Istituto Superiore per la Protezione e la Ricerca Ambientale: gestisce dati nazionali su frane, alluvioni, costa, suolo. Pubblica il rapporto IdroGEO."
+  link: "/glossario/#ispra"
+
+- id: magnitudo
+  termine: "Magnitudo"
+  varianti:
+    - "magnitudo"
+  definizione: "Misura dell'energia liberata da un terremoto, calcolata dagli strumenti. Scala logaritmica: ogni unità in più moltiplica l'energia per ~32 volte."
+  link: "/glossario/#magnitudo"
+
+- id: intensita-sismica
+  termine: "Intensità"
+  varianti:
+    - "intensità sismica"
+    - "scala Mercalli"
+    - "scala MCS"
+    - "scala MSK"
+    - "scala EMS-98"
+  definizione: "Misura degli effetti del terremoto sull'uomo, sugli edifici e sull'ambiente. Diversa dalla magnitudo: si valuta osservando i danni, non con strumenti."
+  link: "/glossario/#intensita-sismica"
+
+- id: epicentro
+  termine: "Epicentro"
+  varianti:
+    - "epicentro"
+  definizione: "Punto in superficie sulla verticale dell'ipocentro: l'area più vicina alla sorgente del terremoto. Spesso coincide con la zona di maggiore danno."
+  link: "/glossario/#epicentro-e-ipocentro"
+
+- id: ipocentro
+  termine: "Ipocentro"
+  varianti:
+    - "ipocentro"
+    - "fuoco sismico"
+  definizione: "Punto in profondità dove si genera il terremoto, dentro la crosta terrestre. La distanza dal suolo si chiama profondità ipocentrale."
+  link: "/glossario/#epicentro-e-ipocentro"
+
+- id: shakemap
+  termine: "ShakeMap"
+  varianti:
+    - "ShakeMap"
+  definizione: "Mappa che mostra l'intensità di scuotimento del terreno dopo un terremoto, calcolata in pochi minuti da INGV o USGS sulla base delle stazioni sismiche."
+  link: "/glossario/#shakemap"
+
+- id: sciame-sismico
+  termine: "Sciame sismico"
+  varianti:
+    - "sciame sismico"
+  definizione: "Sequenza di molte scosse di magnitudo simile, in un'area ristretta, in giorni o settimane. Non sempre indica un terremoto maggiore in arrivo."
+  link: "/glossario/#sciame-sismico"
+
+- id: faglia
+  termine: "Faglia"
+  varianti:
+    - "faglia"
+  definizione: "Frattura nella crosta terrestre lungo cui si muovono le rocce. Quando il movimento è brusco si genera un terremoto. L'Italia centrale ne è ricca."
+  link: "/glossario/#faglia"
+
+- id: where-are-u
+  termine: "Where Are U"
+  varianti:
+    - "Where Are U"
+    - "WhereAreU"
+  definizione: "App ufficiale del NUE 112: invia automaticamente la tua posizione all'operatore di Centrale Unica quando chiami in emergenza. Gratuita per Android e iOS."
+  link: "/glossario/#where-are-u"
+
+- id: cell-broadcast
+  termine: "Cell Broadcast"
+  varianti:
+    - "Cell Broadcast"
+    - "Cell-Broadcast"
+  definizione: "Tecnologia che invia un messaggio a tutti i cellulari connessi alle antenne di una zona, senza usare la rubrica. È la base di IT-alert."
+  link: "/glossario/#cell-broadcast"
+
+- id: sala-operativa-lazio
+  termine: "Sala Operativa Lazio"
+  varianti:
+    - "Sala Operativa Lazio"
+    - "Sala Operativa Protezione Civile Lazio"
+    - "803 555"
+  definizione: "Sala Operativa della Protezione Civile della Regione Lazio (numero verde 803 555): per segnalazioni non urgenti. Per le emergenze chiama il NUE 112."
+  link: "/glossario/#sala-operativa-protezione-civile-lazio"
+
+- id: direttiva-pcm
+  termine: "Direttiva PCM"
+  varianti:
+    - "Direttiva PCM"
+    - "Direttiva del Presidente del Consiglio dei Ministri"
+  definizione: "Atto normativo di indirizzo del Presidente del Consiglio. Per la PC le più rilevanti sono la Direttiva 30 aprile 2021 e quella sulla pianificazione comunale."
+  link: "/glossario/#direttiva-pcm"
+
+- id: tusl
+  termine: "TUSL"
+  varianti:
+    - "TUSL"
+    - "D.Lgs. 81/2008"
+    - "Testo Unico Sicurezza Lavoro"
+    - "Testo Unico sulla Sicurezza"
+  definizione: "Testo Unico sulla Sicurezza sul Lavoro (D.Lgs. 81/2008): obbliga ogni datore di lavoro a valutare i rischi (DVR) e a redigere un piano di emergenza."
+  link: "/glossario/#tusl"
+
+- id: odv
+  termine: "OdV"
+  varianti:
+    - "OdV"
+    - "Organizzazione di Volontariato"
+    - "Organizzazioni di Volontariato"
+  definizione: "Organizzazione di Volontariato: forma giuridica del Codice Terzo Settore (D.Lgs. 117/2017). Il Gruppo Comunale Volontari di PC Genzano è iscritto come OdV."
+  link: "/glossario/#odv"
+
+- id: ets
+  termine: "ETS"
+  varianti:
+    - "ETS"
+    - "Ente del Terzo Settore"
+    - "Enti del Terzo Settore"
+  definizione: "Ente del Terzo Settore: categoria giuridica che raggruppa associazioni, OdV, fondazioni e imprese sociali che operano per finalità civiche e di utilità sociale."
+  link: "/glossario/#ets"
+
+- id: stato-emergenza
+  termine: "Stato di emergenza"
+  varianti:
+    - "stato di emergenza"
+    - "stato di emergenza nazionale"
+  definizione: "Atto del Consiglio dei Ministri (art. 24 Codice PC) che dichiara un'emergenza di rilevanza nazionale. Sblocca poteri straordinari e ordinanze di necessità."
+  link: "/glossario/#stato-di-emergenza"
+
+- id: tipo-emergenza
+  termine: "Tipo A/B/C"
+  varianti:
+    - "tipo A"
+    - "tipo B"
+    - "tipo C"
+  definizione: "Classificazione delle emergenze (art. 7 Codice PC): A gestita dal Comune, B dalla Regione, C di rilevanza nazionale (terremoto maggiore, alluvione estesa)."
+  link: "/glossario/#tipo-emergenza"
+
+- id: io-non-rischio
+  termine: "Io non rischio"
+  varianti:
+    - "Io non rischio"
+    - "Io Non Rischio"
+  definizione: "Campagna nazionale del DPC e ANPAS per la riduzione del rischio: ogni anno volontari informano i cittadini in piazza su terremoti, alluvioni, incendi e maremoti."
+  link: "/glossario/#io-non-rischio"
+
+- id: soggetto-attuatore
+  termine: "Soggetto Attuatore"
+  varianti:
+    - "Soggetto Attuatore"
+    - "soggetto attuatore"
+  definizione: "Figura nominata nelle ordinanze di emergenza per realizzare interventi specifici (es. la ricostruzione post-sisma). Risponde direttamente al Commissario."
+  link: "/glossario/#soggetto-attuatore"
+
+- id: ondata-calore
+  termine: "Ondata di calore"
+  varianti:
+    - "ondata di calore"
+    - "ondata di caldo"
+  definizione: "Periodo di almeno 3 giorni con temperature massime e minime molto sopra la media stagionale. Aumenta i ricoveri e la mortalità nelle persone fragili."
+  link: "/glossario/#ondata-di-calore"
+
+- id: capo-dipartimento
+  termine: "Capo Dipartimento"
+  varianti:
+    - "Capo Dipartimento"
+    - "Capo del Dipartimento della Protezione Civile"
+  definizione: "Massima autorità tecnico-operativa del Servizio Nazionale di PC, alle dipendenze della Presidenza del Consiglio. Coordina la risposta alle emergenze nazionali."
+  link: "/glossario/#capo-dipartimento"
+
+- id: allertamento
+  termine: "Sistema di allertamento"
+  varianti:
+    - "sistema di allertamento"
+    - "allertamento nazionale"
+  definizione: "Catena di soggetti (DPC, CFR, Comuni) che valutano il rischio e fanno arrivare l'allerta al cittadino. In Italia opera 24 ore su 24, 7 giorni su 7."
+  link: "/glossario/#sistema-di-allertamento"
+
+- id: zona-allerta
+  termine: "Zona di allerta"
+  varianti:
+    - "Zona di allerta"
+    - "Zone di allerta"
+    - "ZA"
+  definizione: "Area omogenea per caratteristiche meteo-idro-geologiche su cui il CFR emette il bollettino di criticità. Genzano è nella Zona F — Bacini Costieri Sud."
+  link: "/glossario/#zona-di-allerta"
+
+- id: censimento-danni
+  termine: "Censimento dei danni"
+  varianti:
+    - "censimento dei danni"
+    - "censimento del danno"
+  definizione: "Rilevazione tecnica post-evento, di norma con scheda AeDES per i terremoti, per quantificare i danni e attivare i contributi di ricostruzione."
+  link: "/glossario/#censimento-dei-danni"
+
+- id: pcm
+  termine: "PCM"
+  varianti:
+    - "PCM"
+    - "Presidenza del Consiglio dei Ministri"
+  definizione: "Presidenza del Consiglio dei Ministri: il DPC è una struttura della PCM, e da essa derivano le direttive che regolano il sistema di Protezione Civile."
+  link: "/glossario/#pcm"
+
+- id: ari
+  termine: "ARI"
+  varianti:
+    - "ARI"
+    - "Associazione Radioamatori Italiani"
+  definizione: "Associazione Radioamatori Italiani: federazione nazionale dei radioamatori, partner storico della PC nelle radiocomunicazioni di emergenza."
+  link: "/glossario/#ari"
+
+- id: hf-vhf-uhf
+  termine: "HF/VHF/UHF"
+  varianti:
+    - "HF"
+    - "VHF"
+    - "UHF"
+  definizione: "Bande di frequenza radio: HF a lunga portata (centinaia/migliaia di km), VHF e UHF a corto raggio (qualche km, ottime in città e per maglie comunali)."
+  link: "/glossario/#hf-vhf-uhf"
+
+- id: anpas
+  termine: "ANPAS"
+  varianti:
+    - "ANPAS"
+    - "Associazione Nazionale Pubbliche Assistenze"
+  definizione: "Associazione Nazionale Pubbliche Assistenze: rete nazionale di pubbliche assistenze sanitarie e di Protezione Civile, partner storica del DPC."
+  link: "/glossario/#anpas"
+
+- id: cri
+  termine: "CRI"
+  varianti:
+    - "CRI"
+    - "Croce Rossa Italiana"
+  definizione: "Croce Rossa Italiana: associazione di pubblica utilità nata nel 1864, oggi ente del Terzo Settore. Componente operativa del Servizio Nazionale di PC."
+  link: "/glossario/#cri"
+
+- id: dpcm
+  termine: "DPCM"
+  varianti:
+    - "DPCM"
+    - "Decreto del Presidente del Consiglio dei Ministri"
+  definizione: "Decreto del Presidente del Consiglio dei Ministri: atto amministrativo di rango secondario. Per la PC se ne usano molti per stati di emergenza e ordinanze."
+  link: "/glossario/#dpcm"

--- a/static/js/glossario-inline.js
+++ b/static/js/glossario-inline.js
@@ -1,0 +1,304 @@
+/* ============================================================
+ * glossario-inline.js (v1.0)
+ *
+ * Cosa fa:
+ *   Alla prima occorrenza di ogni termine del glossario in
+ *   .article-body o .list-intro-content, sostituisce il termine
+ *   con un <button class="gloss-term"> + popover accessibile
+ *   (definizione breve + link al glossario completo).
+ *
+ * Beneficiari: cittadini non tecnici, anziani, italiano L2,
+ * persone in stress da emergenza che incontrano sigle
+ * specialistiche (DPC, COC, AeDES, AIB, IT-alert, ecc.).
+ *
+ * Vincoli:
+ *   - Solo PRIMA occorrenza per articolo (ogni id viene marcato
+ *     "consumato" e ignorato per il resto del walk).
+ *   - Mai dentro: <a>, <button>, <code>, <pre>, <h1>, <kbd>,
+ *     [aria-hidden=true], .no-gloss, .tts-wrapper, .gloss-term.
+ *   - Mega-regex unica con alternazione di tutte le varianti:
+ *     scansione O(N) sulla lunghezza del testo, non O(N×termini).
+ *   - Popover non-modal, posizionato sotto il button con flip
+ *     se overflow viewport. Tastiera: Enter/Space apre, ESC chiude,
+ *     Tab esce. Click-outside chiude.
+ *
+ * Sorgente dati: window.PCGENZANO_GLOSSARIO iniettato dal partial
+ *                 glossario-inline.html (legge data/glossario.yaml).
+ * ============================================================ */
+(function () {
+  'use strict';
+
+  if (!Array.isArray(window.PCGENZANO_GLOSSARIO) || !window.PCGENZANO_GLOSSARIO.length) return;
+  if (document.documentElement.classList.contains('no-glossario')) return;
+
+  var GLOSSARIO = window.PCGENZANO_GLOSSARIO;
+
+  // Indice di lookup: variante normalizzata (lowercase) → voce
+  var INDEX = Object.create(null);
+  var allVariants = [];
+  GLOSSARIO.forEach(function (voce) {
+    if (!voce.id || !voce.varianti || !voce.definizione) return;
+    voce.varianti.forEach(function (v) {
+      if (!v) return;
+      var key = v.toLowerCase();
+      if (!INDEX[key]) {
+        INDEX[key] = voce;
+        allVariants.push(v);
+      }
+    });
+  });
+  if (!allVariants.length) return;
+
+  // Costruisce la mega-regex. Ordina le varianti per lunghezza decrescente
+  // così "Centro Operativo Comunale" vince su "COC" se entrambe sarebbero
+  // catturate (regex alternation è greedy sul primo match della lista).
+  function escapeRegex(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+  allVariants.sort(function (a, b) { return b.length - a.length; });
+  var pattern = '\\b(' + allVariants.map(escapeRegex).join('|') + ')\\b';
+  var MEGA_RE = new RegExp(pattern, 'gi');
+
+  // Selettori da ignorare (no-glossario)
+  var SKIP_TAGS = { A: 1, BUTTON: 1, CODE: 1, PRE: 1, KBD: 1, H1: 1, INPUT: 1, TEXTAREA: 1, SELECT: 1, OPTION: 1, LABEL: 1, SCRIPT: 1, STYLE: 1, MARK: 1, FIGCAPTION: 1 };
+  var SKIP_CLASSES = ['no-gloss', 'no-glossario', 'tts-wrapper', 'tts-status', 'gloss-term', 'gloss-popover', 'visually-hidden', 'pittogramma', 'pittogramma-figure', 'reading-meta', 'badge'];
+
+  function shouldSkipElement(node) {
+    if (!node || node.nodeType !== 1) return false;
+    if (SKIP_TAGS[node.tagName]) return true;
+    if (node.getAttribute && node.getAttribute('aria-hidden') === 'true') return true;
+    if (node.classList) {
+      for (var i = 0; i < SKIP_CLASSES.length; i++) {
+        if (node.classList.contains(SKIP_CLASSES[i])) return true;
+      }
+    }
+    return false;
+  }
+
+  function isInsideSkip(node) {
+    var p = node.parentNode;
+    while (p && p.nodeType === 1) {
+      if (shouldSkipElement(p)) return true;
+      p = p.parentNode;
+    }
+    return false;
+  }
+
+  // Set degli id già "consumati" durante il walk (prima occorrenza only)
+  var consumed = Object.create(null);
+
+  // Walk dei TextNode discendenti di un container, restituisce array
+  // (separato dal rendering perché i replace modificano il DOM)
+  function collectTextNodes(root) {
+    var out = [];
+    var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (n) {
+        if (!n.nodeValue || !n.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
+        if (isInsideSkip(n)) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+    var n;
+    while ((n = walker.nextNode())) out.push(n);
+    return out;
+  }
+
+  // Counter univoco per id popover
+  var popoverCounter = 0;
+
+  function makeGlossElement(matchedText, voce) {
+    var idPop = 'gloss-pop-' + (++popoverCounter);
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'gloss-term';
+    btn.setAttribute('aria-expanded', 'false');
+    btn.setAttribute('aria-describedby', idPop);
+    btn.setAttribute('data-gloss-id', voce.id);
+    btn.title = 'Spiegazione: clicca per leggere la definizione';
+    btn.appendChild(document.createTextNode(matchedText));
+    var ico = document.createElement('span');
+    ico.className = 'gloss-icon';
+    ico.setAttribute('aria-hidden', 'true');
+    ico.textContent = 'ⓘ';
+    btn.appendChild(ico);
+
+    var pop = document.createElement('span');
+    pop.className = 'gloss-popover';
+    pop.id = idPop;
+    pop.setAttribute('role', 'tooltip');
+    pop.hidden = true;
+
+    var defP = document.createElement('span');
+    defP.className = 'gloss-popover-def';
+    defP.textContent = voce.definizione;
+    pop.appendChild(defP);
+
+    if (voce.link) {
+      var more = document.createElement('a');
+      more.className = 'gloss-popover-link';
+      more.href = voce.link;
+      more.textContent = 'Scopri di più nel glossario';
+      more.setAttribute('aria-label', 'Apri la voce «' + (voce.termine || matchedText) + '» nel glossario completo');
+      pop.appendChild(more);
+    }
+
+    // Wrapper inline-block per posizionare il popover relativamente al button
+    var wrap = document.createElement('span');
+    wrap.className = 'gloss-wrap';
+    wrap.appendChild(btn);
+    wrap.appendChild(pop);
+    return wrap;
+  }
+
+  // Sostituisce in-place le occorrenze di MEGA_RE in un singolo TextNode.
+  function processTextNode(textNode) {
+    var text = textNode.nodeValue;
+    MEGA_RE.lastIndex = 0;
+    var match;
+    var lastIndex = 0;
+    var fragment = null;
+    while ((match = MEGA_RE.exec(text)) !== null) {
+      var matched = match[0];
+      var key = matched.toLowerCase();
+      var voce = INDEX[key];
+      if (!voce) continue;
+      // Skip se id già consumato (prima occorrenza only)
+      if (consumed[voce.id]) continue;
+      // Lazy init fragment alla prima sostituzione utile
+      if (!fragment) fragment = document.createDocumentFragment();
+      var matchStart = match.index;
+      // Testo prima del match
+      if (matchStart > lastIndex) {
+        fragment.appendChild(document.createTextNode(text.substring(lastIndex, matchStart)));
+      }
+      // Elemento glossario
+      fragment.appendChild(makeGlossElement(matched, voce));
+      consumed[voce.id] = true;
+      lastIndex = matchStart + matched.length;
+    }
+    if (fragment) {
+      // Testo residuo dopo l'ultima sostituzione
+      if (lastIndex < text.length) {
+        fragment.appendChild(document.createTextNode(text.substring(lastIndex)));
+      }
+      textNode.parentNode.replaceChild(fragment, textNode);
+    }
+  }
+
+  // ============================================================
+  // Popover behaviour: apri/chiudi, focus management, tastiera
+  // ============================================================
+
+  var openPopover = null;
+  var openButton = null;
+
+  function closePopover() {
+    if (!openPopover) return;
+    openPopover.hidden = true;
+    openPopover.classList.remove('is-flipped-up');
+    if (openButton) openButton.setAttribute('aria-expanded', 'false');
+    openPopover = null;
+    openButton = null;
+  }
+
+  function flipIfOverflow(pop) {
+    pop.classList.remove('is-flipped-up');
+    var rect = pop.getBoundingClientRect();
+    var vh = window.innerHeight || document.documentElement.clientHeight;
+    if (rect.bottom > vh - 10) pop.classList.add('is-flipped-up');
+  }
+
+  function openFor(btn) {
+    var pop = btn.parentNode.querySelector('.gloss-popover');
+    if (!pop) return;
+    if (openPopover && openPopover !== pop) closePopover();
+    pop.hidden = false;
+    btn.setAttribute('aria-expanded', 'true');
+    openPopover = pop;
+    openButton = btn;
+    // Calcola flip dopo render
+    requestAnimationFrame(function () { flipIfOverflow(pop); });
+  }
+
+  function togglePopover(btn) {
+    var pop = btn.parentNode.querySelector('.gloss-popover');
+    if (!pop) return;
+    if (pop.hidden) openFor(btn); else closePopover();
+  }
+
+  // Click su un .gloss-term apre/chiude il suo popover
+  document.addEventListener('click', function (ev) {
+    var target = ev.target;
+    var btn = target.closest && target.closest('.gloss-term');
+    if (btn) {
+      ev.preventDefault();
+      togglePopover(btn);
+      return;
+    }
+    // Click fuori da un popover aperto → chiudi
+    if (openPopover && !target.closest('.gloss-popover') && !target.closest('.gloss-term')) {
+      closePopover();
+    }
+  });
+
+  // ESC chiude
+  document.addEventListener('keydown', function (ev) {
+    if (ev.key === 'Escape' && openPopover) {
+      var btnToFocus = openButton;
+      closePopover();
+      if (btnToFocus) btnToFocus.focus();
+    }
+  });
+
+  // Hover desktop (con safety: niente hover su touch — pointer:fine)
+  if (window.matchMedia && window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
+    document.addEventListener('mouseover', function (ev) {
+      var btn = ev.target.closest && ev.target.closest('.gloss-term');
+      if (btn && (!openPopover || openButton !== btn)) {
+        openFor(btn);
+      }
+    });
+    document.addEventListener('mouseout', function (ev) {
+      var btn = ev.target.closest && ev.target.closest('.gloss-term');
+      var wrap = ev.target.closest && ev.target.closest('.gloss-wrap');
+      if (!wrap) return;
+      // Se il mouse esce dal wrap (sia button sia popover)
+      var related = ev.relatedTarget;
+      if (!related || !wrap.contains(related)) {
+        if (openButton === btn) closePopover();
+      }
+    });
+  }
+
+  // Chiudi su scroll della pagina (i popover non seguono lo scroll)
+  var scrollTimer = null;
+  window.addEventListener('scroll', function () {
+    if (!openPopover) return;
+    if (scrollTimer) clearTimeout(scrollTimer);
+    scrollTimer = setTimeout(closePopover, 100);
+  }, { passive: true });
+
+  // ============================================================
+  // Avvio: scansiona tutti i container target
+  // ============================================================
+  function processContainer(container) {
+    if (!container) return;
+    var nodes = collectTextNodes(container);
+    for (var i = 0; i < nodes.length; i++) {
+      processTextNode(nodes[i]);
+      // Uscita anticipata se tutti i termini sono stati consumati
+      if (Object.keys(consumed).length === GLOSSARIO.length) break;
+    }
+  }
+
+  function init() {
+    var containers = document.querySelectorAll('.article-body, .list-intro-content');
+    for (var i = 0; i < containers.length; i++) processContainer(containers[i]);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/themes/flavour-pcgenzano/layouts/_default/list.html
+++ b/themes/flavour-pcgenzano/layouts/_default/list.html
@@ -25,8 +25,8 @@
       </div>
       {{ end }}
 
-      {{/* ── TEMPO DI LETTURA + PULSANTE TTS ── */}}
-      {{ $ttsBlacklist := slice "/privacy/" "/note-legali/" "/accessibilita/" "/social-media-policy/" "/mappa-sito/" "/attribuzioni-pittogrammi/" "/cerca/" "/comunicazioni/" }}
+      {{/* ── TEMPO DI LETTURA + PULSANTE TTS + GLOSSARIO INLINE ── */}}
+      {{ $ttsBlacklist := slice "/privacy/" "/note-legali/" "/accessibilita/" "/social-media-policy/" "/mappa-sito/" "/attribuzioni-pittogrammi/" "/cerca/" "/comunicazioni/" "/glossario/" }}
       {{ $isBlacklisted := false }}
       {{ range $ttsBlacklist }}{{ if eq $.RelPermalink . }}{{ $isBlacklisted = true }}{{ end }}{{ end }}
       {{ $ttsEnabled := and (ne .Params.tts false) (not $isBlacklisted) }}
@@ -41,6 +41,7 @@
       </div>
       {{ partial "leggi-ad-alta-voce.html" (dict "selector" ".list-intro-content") }}
       <div class="list-intro-content">{{ .Content }}</div>
+      {{ partial "glossario-inline.html" . }}
       {{ else }}
       {{ .Content }}
       {{ end }}

--- a/themes/flavour-pcgenzano/layouts/_default/list.html
+++ b/themes/flavour-pcgenzano/layouts/_default/list.html
@@ -24,7 +24,26 @@
         </details>
       </div>
       {{ end }}
+
+      {{/* ── TEMPO DI LETTURA + PULSANTE TTS ── */}}
+      {{ $ttsBlacklist := slice "/privacy/" "/note-legali/" "/accessibilita/" "/social-media-policy/" "/mappa-sito/" "/attribuzioni-pittogrammi/" "/cerca/" "/comunicazioni/" }}
+      {{ $isBlacklisted := false }}
+      {{ range $ttsBlacklist }}{{ if eq $.RelPermalink . }}{{ $isBlacklisted = true }}{{ end }}{{ end }}
+      {{ $ttsEnabled := and (ne .Params.tts false) (not $isBlacklisted) }}
+
+      {{ if and $ttsEnabled (gt .WordCount 30) }}
+      <div class="reading-meta d-flex flex-wrap align-items-center gap-2 mb-3" aria-label="Informazioni di lettura">
+        <span class="reading-time" title="Tempo di lettura stimato (200 parole al minuto)">
+          <i class="bi bi-clock me-1" aria-hidden="true"></i>
+          Lettura: <strong>~{{ .ReadingTime }} {{ if eq .ReadingTime 1 }}minuto{{ else }}minuti{{ end }}</strong>
+          <span class="visually-hidden">— tempo di lettura stimato</span>
+        </span>
+      </div>
+      {{ partial "leggi-ad-alta-voce.html" (dict "selector" ".list-intro-content") }}
+      <div class="list-intro-content">{{ .Content }}</div>
+      {{ else }}
       {{ .Content }}
+      {{ end }}
       {{ range .Paginator.Pages }}
       <article class="card card-notizia mb-3">
         <div class="row g-0">

--- a/themes/flavour-pcgenzano/layouts/_default/single.html
+++ b/themes/flavour-pcgenzano/layouts/_default/single.html
@@ -80,11 +80,13 @@
       </div>
       {{ end }}
 
-      {{/* ── TEMPO DI LETTURA + PULSANTE TTS ── */}}
-      {{/* Opt-out: TTS attivo di default su tutte le pagine, escluse legali/tecniche.
-           Per disattivare su una specifica pagina: tts: false nel frontmatter.
-           Blacklist hard-coded: pagine legali + tecniche (regola 03-accessibility.md). */}}
-      {{ $ttsBlacklist := slice "/privacy/" "/note-legali/" "/accessibilita/" "/social-media-policy/" "/mappa-sito/" "/attribuzioni-pittogrammi/" "/cerca/" }}
+      {{/* ── TEMPO DI LETTURA + PULSANTE TTS + GLOSSARIO INLINE ── */}}
+      {{/* Opt-out: TTS e glossario attivi di default su tutte le pagine,
+           escluse legali/tecniche. Per disattivare su pagina specifica:
+           tts: false nel frontmatter (vale anche per glossario inline).
+           Blacklist hard-coded: pagine legali + tecniche + /glossario/
+           stesso (regola 03-accessibility.md). */}}
+      {{ $ttsBlacklist := slice "/privacy/" "/note-legali/" "/accessibilita/" "/social-media-policy/" "/mappa-sito/" "/attribuzioni-pittogrammi/" "/cerca/" "/glossario/" }}
       {{ $isBlacklisted := false }}
       {{ range $ttsBlacklist }}{{ if eq $.RelPermalink . }}{{ $isBlacklisted = true }}{{ end }}{{ end }}
       {{ $ttsEnabled := and (ne .Params.tts false) (not $isBlacklisted) }}
@@ -102,6 +104,14 @@
 
       {{/* ── CONTENUTO ── */}}
       <article class="article-body">{{ .Content }}</article>
+
+      {{/* ── GLOSSARIO INLINE (popover sui termini PC) ── */}}
+      {{/* Stesso opt-out del TTS: tts:false esclude anche il glossario.
+           Si carica dopo il contenuto per scansionare l'.article-body
+           già renderizzato. */}}
+      {{ if and $ttsEnabled (gt .WordCount 30) }}
+      {{ partial "glossario-inline.html" . }}
+      {{ end }}
 
       {{/* ── ALLEGATI (solo comunicazioni) ── */}}
       {{ if eq .Section "comunicazioni" }}

--- a/themes/flavour-pcgenzano/layouts/_default/single.html
+++ b/themes/flavour-pcgenzano/layouts/_default/single.html
@@ -80,9 +80,23 @@
       </div>
       {{ end }}
 
-      {{/* ── PULSANTE LEGGI AD ALTA VOCE (TTS Web Speech API) ── */}}
-      {{/* Opt-in: solo pagine con tts:true nel frontmatter (essenziali emergenza) */}}
-      {{ if .Params.tts }}
+      {{/* ── TEMPO DI LETTURA + PULSANTE TTS ── */}}
+      {{/* Opt-out: TTS attivo di default su tutte le pagine, escluse legali/tecniche.
+           Per disattivare su una specifica pagina: tts: false nel frontmatter.
+           Blacklist hard-coded: pagine legali + tecniche (regola 03-accessibility.md). */}}
+      {{ $ttsBlacklist := slice "/privacy/" "/note-legali/" "/accessibilita/" "/social-media-policy/" "/mappa-sito/" "/attribuzioni-pittogrammi/" "/cerca/" }}
+      {{ $isBlacklisted := false }}
+      {{ range $ttsBlacklist }}{{ if eq $.RelPermalink . }}{{ $isBlacklisted = true }}{{ end }}{{ end }}
+      {{ $ttsEnabled := and (ne .Params.tts false) (not $isBlacklisted) }}
+
+      {{ if and $ttsEnabled (gt .WordCount 30) }}
+      <div class="reading-meta d-flex flex-wrap align-items-center gap-2 mb-3" aria-label="Informazioni di lettura">
+        <span class="reading-time" title="Tempo di lettura stimato (200 parole al minuto)">
+          <i class="bi bi-clock me-1" aria-hidden="true"></i>
+          Lettura: <strong>~{{ .ReadingTime }} {{ if eq .ReadingTime 1 }}minuto{{ else }}minuti{{ end }}</strong>
+          <span class="visually-hidden">— tempo di lettura stimato</span>
+        </span>
+      </div>
       {{ partial "leggi-ad-alta-voce.html" (dict "selector" ".article-body") }}
       {{ end }}
 

--- a/themes/flavour-pcgenzano/layouts/partials/glossario-inline.html
+++ b/themes/flavour-pcgenzano/layouts/partials/glossario-inline.html
@@ -1,0 +1,39 @@
+{{- /*
+  Partial: glossario-inline
+  Inietta i dati di data/glossario.yaml come JSON globale
+  (window.PCGENZANO_GLOSSARIO) e carica static/js/glossario-inline.js.
+
+  Il JS al DOMContentLoaded scansiona .article-body e .list-intro-content
+  e sostituisce la prima occorrenza di ogni termine con un <button> +
+  popover accessibile (definizione + link al glossario completo).
+
+  Cross-baseURL: i link nel YAML iniziano con `/`, qui passano per
+  relURL così il subpath di GitHub Pages funziona uniformemente con
+  Aruba (root). Strip del leading `/` prima del relURL come fa il
+  render-link hook del tema.
+
+  Inclusione raccomandata: dentro single.html e list.html, con stessa
+  condizione del TTS (default ON, blacklist pagine legali/tecniche).
+  La logica di blacklist resta nei template chiamanti, non qui.
+*/ -}}
+{{- $glossario := site.Data.glossario -}}
+{{- if $glossario -}}
+{{- $entries := slice -}}
+{{- range $glossario -}}
+  {{- $rawLink := .link | default "" -}}
+  {{- $relLink := strings.TrimPrefix "/" $rawLink -}}
+  {{- $absLink := cond (eq $rawLink "") "" ($relLink | relURL) -}}
+  {{- $entry := dict
+      "id" .id
+      "termine" .termine
+      "varianti" .varianti
+      "definizione" .definizione
+      "link" $absLink -}}
+  {{- $entries = $entries | append $entry -}}
+{{- end -}}
+<script>
+/* Glossario inline — dati statici dal build Hugo */
+window.PCGENZANO_GLOSSARIO = {{ $entries | jsonify | safeJS }};
+</script>
+<script src="{{ "js/glossario-inline.js" | relURL }}" defer></script>
+{{- end -}}

--- a/themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html
+++ b/themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html
@@ -1,26 +1,28 @@
 {{- /*
-  Partial: leggi-ad-alta-voce (v2.0)
-  Bottone "Leggi ad alta voce" con Web Speech API + selettore velocità
-  (lento 0.75x / normale 0.95x / veloce 1.15x). Preferenza persistita
-  in localStorage (chiave: pcgenzano-tts-rate).
+  Partial: leggi-ad-alta-voce (v2.1)
+  Bottone "Leggi ad alta voce" con Web Speech API.
+  - Velocità regolabile (lento 0.75x / normale 0.95x / veloce 1.15x)
+  - Highlight della parola in lettura (toggle, default OFF)
+  Preferenze persistite in localStorage:
+    pcgenzano-tts-rate    (0.75 | 0.95 | 1.15)
+    pcgenzano-tts-follow  ("1" se attivo highlight, default "")
 
-  Uso (in qualsiasi template):
+  Uso:
     {{ partial "leggi-ad-alta-voce.html" (dict "selector" ".article-body") }}
-
-  Parametri:
-    selector  CSS selector dell'elemento da leggere. Default: ".article-body"
 
   Accessibilità:
     - Bottone con role=button, aria-pressed, aria-label dinamico
-    - Stato "in lettura" annunciato a screen reader (aria-live)
-    - Funziona con tastiera (Enter/Space) sui bottoni di velocità (radio)
-    - Fallback graceful se Web Speech API non supportata (wrapper nascosto)
+    - aria-live=polite per stato lettura
+    - Tastiera: bottoni e radio nativi
+    - Highlight rispetta prefers-reduced-motion (rimosse animazioni morbide)
+    - Highlight ha varianti CSS per contrasto invertito + scala grigi (toolbar a11y)
+    - Fallback graceful: se onboundary non spara entro 2s, highlight si auto-disattiva
 
-  Default attivo su tutte le pagine (single.html + list.html) con possibilità
-  di opt-out via frontmatter `tts: false` o blacklist hard-coded (legali, tecniche).
+  Default attivo su tutte le pagine (single.html + list.html), opt-out via
+  frontmatter `tts: false` o blacklist hard-coded (legali, tecniche).
 */ -}}
 {{- $selector := .selector | default ".article-body" -}}
-<div class="tts-wrapper" role="region" aria-label="Strumenti di lettura ad alta voce">
+<div class="tts-wrapper" role="region" aria-label="Strumenti di lettura ad alta voce" data-tts-target="{{ $selector }}">
   <div class="tts-controls">
     <button type="button"
             class="tts-button btn btn-outline-primary btn-sm"
@@ -48,6 +50,13 @@
         <span class="visually-hidden">Velocità veloce</span>
       </label>
     </fieldset>
+    <label class="tts-follow-toggle" title="Evidenzia la parola che la voce sta leggendo. Aiuta dislessici e parlanti italiano L2.">
+      <input type="checkbox" class="tts-follow-input">
+      <span class="tts-follow-label">
+        <i class="bi bi-cursor-text me-1" aria-hidden="true"></i>
+        Segui parole
+      </span>
+    </label>
   </div>
   <span class="tts-status visually-hidden" aria-live="polite" aria-atomic="true"></span>
 </div>
@@ -60,19 +69,22 @@
   }
 
   var synth = window.speechSynthesis;
-  var STORAGE_KEY = 'pcgenzano-tts-rate';
+  var RATE_KEY = 'pcgenzano-tts-rate';
+  var FOLLOW_KEY = 'pcgenzano-tts-follow';
 
   function getSavedRate() {
     try {
-      var v = parseFloat(localStorage.getItem(STORAGE_KEY) || '');
+      var v = parseFloat(localStorage.getItem(RATE_KEY) || '');
       if (v === 0.75 || v === 0.95 || v === 1.15) return v;
     } catch (e) {}
     return 0.95;
   }
+  function saveRate(v) { try { localStorage.setItem(RATE_KEY, String(v)); } catch (e) {} }
 
-  function saveRate(v) {
-    try { localStorage.setItem(STORAGE_KEY, String(v)); } catch (e) {}
+  function getSavedFollow() {
+    try { return localStorage.getItem(FOLLOW_KEY) === '1'; } catch (e) { return false; }
   }
+  function saveFollow(v) { try { localStorage.setItem(FOLLOW_KEY, v ? '1' : ''); } catch (e) {} }
 
   function findItalianVoice() {
     var voices = synth.getVoices();
@@ -90,6 +102,113 @@
     clone.querySelectorAll('br').forEach(function(n){ n.replaceWith('\n'); });
     var text = clone.innerText || clone.textContent || '';
     return text.replace(/[ \t]+/g, ' ').replace(/\n{3,}/g, '\n\n').trim();
+  }
+
+  /*
+   * Highlight follow: pre-mappa le parole del DOM target ai loro indici nel
+   * testo passato a SpeechSynthesisUtterance. Quando arriva onboundary
+   * (charIndex), trova il TextNode che contiene quel carattere e avvolge
+   * solo la parola corrente in <mark class="tts-word-mark">.
+   *
+   * Strategia: passa una sola volta sui TextNode discendenti del target,
+   * ignorando script/style/pre/code/.visually-hidden/[aria-hidden=true]/
+   * .pittogramma/.pittogramma-figure/.tts-wrapper. Costruisce un array
+   * di "chunk" {node, start, end} corrispondenti al testo estratto.
+   */
+  function buildTextMap(targetEl) {
+    if (!targetEl) return { fullText: '', chunks: [] };
+    var SKIP = ['SCRIPT', 'STYLE', 'PRE', 'CODE'];
+    var SKIP_CLASS = ['visually-hidden', 'pittogramma', 'pittogramma-figure', 'tts-wrapper'];
+    var fullText = '';
+    var chunks = [];
+    function shouldSkip(node) {
+      if (!node) return true;
+      if (node.nodeType !== 1) return false;
+      if (SKIP.indexOf(node.tagName) !== -1) return true;
+      if (node.getAttribute && node.getAttribute('aria-hidden') === 'true') return true;
+      if (node.classList) {
+        for (var i = 0; i < SKIP_CLASS.length; i++) {
+          if (node.classList.contains(SKIP_CLASS[i])) return true;
+        }
+      }
+      return false;
+    }
+    function walk(node) {
+      if (shouldSkip(node)) return;
+      if (node.nodeType === 3) { // TEXT_NODE
+        var t = node.nodeValue;
+        if (t && t.length) {
+          // Stessa normalizzazione approssimativa di extractText (compatta whitespace)
+          chunks.push({ node: node, start: fullText.length, end: fullText.length + t.length });
+          fullText += t;
+        }
+        return;
+      }
+      if (node.nodeType === 1) {
+        // Aggiungi spazio ai blocchi tipici per imitare innerText
+        var isBlock = /^(P|DIV|LI|UL|OL|H[1-6]|TABLE|TR|TD|TH|SECTION|ARTICLE|HEADER|FOOTER|ASIDE|FIGURE|FIGCAPTION|BLOCKQUOTE|HR|BR)$/.test(node.tagName);
+        var children = node.childNodes;
+        for (var i = 0; i < children.length; i++) walk(children[i]);
+        if (isBlock && fullText.length && fullText.charAt(fullText.length - 1) !== '\n') {
+          fullText += '\n';
+          // chunk fittizio per il newline (no node)
+          chunks.push({ node: null, start: fullText.length - 1, end: fullText.length });
+        }
+      }
+    }
+    walk(targetEl);
+    return { fullText: fullText, chunks: chunks };
+  }
+
+  // Trova il TextNode + offset per un dato charIndex nel fullText della mappa
+  function findNodeAt(map, charIndex) {
+    for (var i = 0; i < map.chunks.length; i++) {
+      var c = map.chunks[i];
+      if (c.node && charIndex >= c.start && charIndex < c.end) {
+        return { node: c.node, offset: charIndex - c.start };
+      }
+    }
+    return null;
+  }
+
+  // Avvolge una parola (da charIndex per charLength) in un <mark>.
+  // Ritorna il <mark> creato (per eventuale unwrap successivo).
+  function highlightWord(map, charIndex, charLength) {
+    if (!charLength || charLength < 1) return null;
+    var startInfo = findNodeAt(map, charIndex);
+    if (!startInfo) return null;
+    var node = startInfo.node;
+    var startOff = startInfo.offset;
+    var endOff = startOff + charLength;
+    // Se la parola supera il TextNode (raro, succede solo se il target ha markup molto frammentato), troncala al nodo.
+    if (endOff > node.nodeValue.length) endOff = node.nodeValue.length;
+    if (endOff <= startOff) return null;
+    try {
+      var range = document.createRange();
+      range.setStart(node, startOff);
+      range.setEnd(node, endOff);
+      var mark = document.createElement('mark');
+      mark.className = 'tts-word-mark';
+      mark.setAttribute('aria-hidden', 'true');
+      range.surroundContents(mark);
+      // Scroll progressivo (centra la parola, rispetta reduced-motion)
+      var prefersReduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      try {
+        mark.scrollIntoView({ block: 'center', inline: 'nearest', behavior: prefersReduced ? 'auto' : 'smooth' });
+      } catch (e) { /* Safari iOS old */ }
+      return mark;
+    } catch (e) {
+      // surroundContents fallisce se il range attraversa nodi diversi
+      return null;
+    }
+  }
+
+  function unhighlight(mark) {
+    if (!mark || !mark.parentNode) return;
+    var parent = mark.parentNode;
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+    parent.removeChild(mark);
+    parent.normalize(); // ricuce TextNode adiacenti
   }
 
   function setButtonState(btn, state) {
@@ -119,7 +238,7 @@
     }
   }
 
-  // Sincronizza i radio button con la preferenza salvata
+  // Sincronizza i radio della velocità con la preferenza salvata
   var savedRate = getSavedRate();
   document.querySelectorAll('.tts-wrapper input[name="tts-rate"]').forEach(function(input){
     input.checked = (parseFloat(input.value) === savedRate);
@@ -127,15 +246,12 @@
       if (this.checked) {
         var newRate = parseFloat(this.value);
         saveRate(newRate);
-        // Se sta leggendo, riavvia con la nuova velocità dal punto attuale (semplice: dall'inizio)
         if (synth.speaking || synth.paused) {
           var btn = this.closest('.tts-wrapper').querySelector('.tts-button');
           synth.cancel();
           setButtonState(btn, 'idle');
-          // Trigger immediato per ripartire alla nuova velocità
           btn.dispatchEvent(new Event('click'));
         }
-        // Sincronizza altri eventuali wrapper TTS sulla pagina
         document.querySelectorAll('.tts-wrapper input[name="tts-rate"][value="' + this.value + '"]').forEach(function(other){
           if (other !== this) other.checked = true;
         }, this);
@@ -143,15 +259,52 @@
     });
   });
 
+  // Sincronizza il toggle "Segui parole" con la preferenza salvata
+  var followEnabled = getSavedFollow();
+  document.querySelectorAll('.tts-wrapper .tts-follow-input').forEach(function(input){
+    input.checked = followEnabled;
+    input.addEventListener('change', function(){
+      followEnabled = this.checked;
+      saveFollow(followEnabled);
+      // Sincronizza eventuali altri toggle sulla pagina
+      document.querySelectorAll('.tts-wrapper .tts-follow-input').forEach(function(other){
+        if (other !== this) other.checked = followEnabled;
+      }, this);
+    });
+  });
+
   document.querySelectorAll('.tts-button').forEach(function(btn){
     var state = 'idle';
     var utterance = null;
+    var currentMark = null;
+    var textMap = null;
+    var boundaryHeard = false;
+    var fallbackTimer = null;
+
+    function clearMark() {
+      if (currentMark) {
+        unhighlight(currentMark);
+        currentMark = null;
+      }
+    }
 
     btn.addEventListener('click', function(){
+      var wrapper = btn.closest('.tts-wrapper');
       var target = document.querySelector(btn.getAttribute('data-tts-target'));
       if (state === 'idle') {
-        var text = extractText(target);
-        if (!text) {
+        if (followEnabled && target) {
+          // Costruisci la mappa testo↔nodi prima di passare il testo al sintetizzatore.
+          // Importante: il testo passato al SpeechSynthesisUtterance deve corrispondere
+          // ESATTAMENTE al fullText della mappa, altrimenti i charIndex di onboundary
+          // non puntano alla parola giusta.
+          textMap = buildTextMap(target);
+          if (!textMap.fullText.trim()) { textMap = null; }
+        } else {
+          textMap = null;
+        }
+
+        var text = textMap ? textMap.fullText : extractText(target);
+        if (!text || !text.trim()) {
           alert('Nessun testo da leggere su questa pagina.');
           return;
         }
@@ -163,8 +316,43 @@
         utterance.rate = getSavedRate();
         utterance.pitch = 1;
         utterance.volume = 1;
-        utterance.onend = function(){ state = 'idle'; setButtonState(btn, 'idle'); };
-        utterance.onerror = function(){ state = 'idle'; setButtonState(btn, 'idle'); };
+
+        boundaryHeard = false;
+        if (textMap) {
+          utterance.onboundary = function(ev){
+            if (ev.name && ev.name !== 'word') return;
+            boundaryHeard = true;
+            clearMark();
+            var len = ev.charLength;
+            if (!len) {
+              // Alcuni browser non forniscono charLength: stima fino allo spazio successivo
+              var slice = textMap.fullText.substr(ev.charIndex);
+              var m = slice.match(/^\S+/);
+              len = m ? m[0].length : 0;
+            }
+            currentMark = highlightWord(textMap, ev.charIndex, len);
+          };
+          // Fallback: se in 2.5s nessun evento word arriva, disattiva l'highlight
+          // per questa sessione (Safari iOS bug noto). Il TTS continua a leggere.
+          fallbackTimer = setTimeout(function(){
+            if (!boundaryHeard) {
+              clearMark();
+              textMap = null;
+            }
+          }, 2500);
+        }
+        utterance.onend = function(){
+          state = 'idle';
+          setButtonState(btn, 'idle');
+          clearMark();
+          if (fallbackTimer) { clearTimeout(fallbackTimer); fallbackTimer = null; }
+        };
+        utterance.onerror = function(){
+          state = 'idle';
+          setButtonState(btn, 'idle');
+          clearMark();
+          if (fallbackTimer) { clearTimeout(fallbackTimer); fallbackTimer = null; }
+        };
         synth.speak(utterance);
         state = 'reading';
         setButtonState(btn, 'reading');

--- a/themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html
+++ b/themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html
@@ -1,7 +1,8 @@
 {{- /*
-  Partial: leggi-ad-alta-voce
-  Bottone "Leggi ad alta voce" che usa Web Speech API (window.speechSynthesis).
-  Cross-browser, voce italiana di default, pause/stop accessibili da tastiera.
+  Partial: leggi-ad-alta-voce (v2.0)
+  Bottone "Leggi ad alta voce" con Web Speech API + selettore velocità
+  (lento 0.75x / normale 0.95x / veloce 1.15x). Preferenza persistita
+  in localStorage (chiave: pcgenzano-tts-rate).
 
   Uso (in qualsiasi template):
     {{ partial "leggi-ad-alta-voce.html" (dict "selector" ".article-body") }}
@@ -12,38 +13,69 @@
   Accessibilità:
     - Bottone con role=button, aria-pressed, aria-label dinamico
     - Stato "in lettura" annunciato a screen reader (aria-live)
-    - Funziona con tastiera (Enter/Space)
-    - Fallback graceful se Web Speech API non supportata (bottone nascosto)
+    - Funziona con tastiera (Enter/Space) sui bottoni di velocità (radio)
+    - Fallback graceful se Web Speech API non supportata (wrapper nascosto)
 
-  Pagine target consigliate: cosa-fare-adesso, numeri-utili, facile-da-leggere,
-  rischi-prevenzione/*, allerte-meteo, comunicazioni con priorita urgente.
+  Default attivo su tutte le pagine (single.html + list.html) con possibilità
+  di opt-out via frontmatter `tts: false` o blacklist hard-coded (legali, tecniche).
 */ -}}
 {{- $selector := .selector | default ".article-body" -}}
 <div class="tts-wrapper" role="region" aria-label="Strumenti di lettura ad alta voce">
-  <button type="button"
-          class="tts-button btn btn-outline-primary btn-sm"
-          data-tts-target="{{ $selector }}"
-          aria-pressed="false"
-          aria-label="Leggi ad alta voce il contenuto della pagina">
-    <i class="bi bi-volume-up-fill me-2" aria-hidden="true"></i>
-    <span class="tts-label">Leggi ad alta voce</span>
-  </button>
+  <div class="tts-controls">
+    <button type="button"
+            class="tts-button btn btn-outline-primary btn-sm"
+            data-tts-target="{{ $selector }}"
+            aria-pressed="false"
+            aria-label="Leggi ad alta voce il contenuto della pagina">
+      <i class="bi bi-volume-up-fill me-2" aria-hidden="true"></i>
+      <span class="tts-label">Leggi ad alta voce</span>
+    </button>
+    <fieldset class="tts-rate" aria-label="Velocità di lettura">
+      <legend class="visually-hidden">Velocità di lettura</legend>
+      <label class="tts-rate-option" title="Lento — utile per anziani, bambini, italiano L2">
+        <input type="radio" name="tts-rate" value="0.75">
+        <span aria-hidden="true">Lento</span>
+        <span class="visually-hidden">Velocità lenta</span>
+      </label>
+      <label class="tts-rate-option" title="Normale">
+        <input type="radio" name="tts-rate" value="0.95" checked>
+        <span aria-hidden="true">Normale</span>
+        <span class="visually-hidden">Velocità normale</span>
+      </label>
+      <label class="tts-rate-option" title="Veloce — per chi conosce bene il testo">
+        <input type="radio" name="tts-rate" value="1.15">
+        <span aria-hidden="true">Veloce</span>
+        <span class="visually-hidden">Velocità veloce</span>
+      </label>
+    </fieldset>
+  </div>
   <span class="tts-status visually-hidden" aria-live="polite" aria-atomic="true"></span>
 </div>
 
 <script>
 (function(){
   if (!('speechSynthesis' in window)) {
-    // Browser senza supporto: nasconde il bottone
     document.querySelectorAll('.tts-wrapper').forEach(function(w){ w.style.display = 'none'; });
     return;
   }
 
   var synth = window.speechSynthesis;
+  var STORAGE_KEY = 'pcgenzano-tts-rate';
+
+  function getSavedRate() {
+    try {
+      var v = parseFloat(localStorage.getItem(STORAGE_KEY) || '');
+      if (v === 0.75 || v === 0.95 || v === 1.15) return v;
+    } catch (e) {}
+    return 0.95;
+  }
+
+  function saveRate(v) {
+    try { localStorage.setItem(STORAGE_KEY, String(v)); } catch (e) {}
+  }
 
   function findItalianVoice() {
     var voices = synth.getVoices();
-    // Priorita: it-IT, poi qualsiasi voce italiana, poi default
     return voices.find(function(v){ return v.lang === 'it-IT'; })
         || voices.find(function(v){ return v.lang && v.lang.startsWith('it'); })
         || voices.find(function(v){ return v.default; })
@@ -53,20 +85,17 @@
 
   function extractText(el) {
     if (!el) return '';
-    // Clona e rimuove elementi non parlabili (script, style, code blocks, link icone, pittogrammi)
     var clone = el.cloneNode(true);
-    clone.querySelectorAll('script, style, .visually-hidden, [aria-hidden="true"], pre, code.language-, .pittogramma, .pittogramma-figure').forEach(function(n){ n.remove(); });
-    // Sostituisce <br> con newline per pause naturali
+    clone.querySelectorAll('script, style, .visually-hidden, [aria-hidden="true"], pre, code.language-, .pittogramma, .pittogramma-figure, .tts-wrapper').forEach(function(n){ n.remove(); });
     clone.querySelectorAll('br').forEach(function(n){ n.replaceWith('\n'); });
     var text = clone.innerText || clone.textContent || '';
-    // Compatta whitespace, preserva paragrafi
     return text.replace(/[ \t]+/g, ' ').replace(/\n{3,}/g, '\n\n').trim();
   }
 
   function setButtonState(btn, state) {
     var label = btn.querySelector('.tts-label');
     var icon = btn.querySelector('i');
-    var status = btn.parentElement.querySelector('.tts-status');
+    var status = btn.closest('.tts-wrapper').querySelector('.tts-status');
     btn.setAttribute('aria-pressed', state === 'reading' ? 'true' : 'false');
     if (state === 'reading') {
       label.textContent = 'Pausa lettura';
@@ -90,6 +119,30 @@
     }
   }
 
+  // Sincronizza i radio button con la preferenza salvata
+  var savedRate = getSavedRate();
+  document.querySelectorAll('.tts-wrapper input[name="tts-rate"]').forEach(function(input){
+    input.checked = (parseFloat(input.value) === savedRate);
+    input.addEventListener('change', function(){
+      if (this.checked) {
+        var newRate = parseFloat(this.value);
+        saveRate(newRate);
+        // Se sta leggendo, riavvia con la nuova velocità dal punto attuale (semplice: dall'inizio)
+        if (synth.speaking || synth.paused) {
+          var btn = this.closest('.tts-wrapper').querySelector('.tts-button');
+          synth.cancel();
+          setButtonState(btn, 'idle');
+          // Trigger immediato per ripartire alla nuova velocità
+          btn.dispatchEvent(new Event('click'));
+        }
+        // Sincronizza altri eventuali wrapper TTS sulla pagina
+        document.querySelectorAll('.tts-wrapper input[name="tts-rate"][value="' + this.value + '"]').forEach(function(other){
+          if (other !== this) other.checked = true;
+        }, this);
+      }
+    });
+  });
+
   document.querySelectorAll('.tts-button').forEach(function(btn){
     var state = 'idle';
     var utterance = null;
@@ -102,13 +155,12 @@
           alert('Nessun testo da leggere su questa pagina.');
           return;
         }
-        // Cancella eventuale lettura precedente
         synth.cancel();
         utterance = new SpeechSynthesisUtterance(text);
         var voice = findItalianVoice();
         if (voice) utterance.voice = voice;
         utterance.lang = 'it-IT';
-        utterance.rate = 0.95;   // poco più lento del default per chiarezza
+        utterance.rate = getSavedRate();
         utterance.pitch = 1;
         utterance.volume = 1;
         utterance.onend = function(){ state = 'idle'; setButtonState(btn, 'idle'); };
@@ -128,7 +180,6 @@
     });
   });
 
-  // Stop globale quando si cambia pagina (evita lettura "fantasma" su SPA)
   window.addEventListener('beforeunload', function(){ synth.cancel(); });
 })();
 </script>

--- a/themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html
+++ b/themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html
@@ -98,7 +98,7 @@
   function extractText(el) {
     if (!el) return '';
     var clone = el.cloneNode(true);
-    clone.querySelectorAll('script, style, .visually-hidden, [aria-hidden="true"], pre, code.language-, .pittogramma, .pittogramma-figure, .tts-wrapper').forEach(function(n){ n.remove(); });
+    clone.querySelectorAll('script, style, .visually-hidden, [aria-hidden="true"], pre, code.language-, .pittogramma, .pittogramma-figure, .tts-wrapper, .gloss-popover, .gloss-icon').forEach(function(n){ n.remove(); });
     clone.querySelectorAll('br').forEach(function(n){ n.replaceWith('\n'); });
     var text = clone.innerText || clone.textContent || '';
     return text.replace(/[ \t]+/g, ' ').replace(/\n{3,}/g, '\n\n').trim();
@@ -118,7 +118,7 @@
   function buildTextMap(targetEl) {
     if (!targetEl) return { fullText: '', chunks: [] };
     var SKIP = ['SCRIPT', 'STYLE', 'PRE', 'CODE'];
-    var SKIP_CLASS = ['visually-hidden', 'pittogramma', 'pittogramma-figure', 'tts-wrapper'];
+    var SKIP_CLASS = ['visually-hidden', 'pittogramma', 'pittogramma-figure', 'tts-wrapper', 'gloss-popover', 'gloss-icon'];
     var fullText = '';
     var chunks = [];
     function shouldSkip(node) {

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -3169,6 +3169,195 @@ html.a11y-contrast-high .list-intro-content mark.tts-word-mark {
 }
 
 /* ============================================================
+   GLOSSARIO INLINE — termini cliccabili con popover (v1.0)
+   La prima occorrenza di ogni termine PC nelle pagine viene
+   sostituita da un <button> con popover che mostra una breve
+   definizione e linka al glossario completo. Pattern WAI-ARIA:
+   button con aria-expanded + popover role=tooltip.
+
+   Beneficiari: cittadini non tecnici che incontrano sigle
+   specialistiche (DPC, COC, AeDES, IT-alert…). Aiuta italiano
+   L2, anziani e persone in stress da emergenza che non si
+   ricordano cosa significhi una sigla.
+   ============================================================ */
+.gloss-wrap {
+  position: relative;
+  display: inline;
+  white-space: normal;
+}
+.gloss-term {
+  /* Reset bottone → look "termine sottolineato tratteggiato" */
+  display: inline;
+  background: transparent;
+  border: 0;
+  padding: 0 1px;
+  margin: 0;
+  font: inherit;
+  color: #003366;
+  cursor: help;
+  text-decoration: underline dotted #003366;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 3px;
+  border-radius: 2px;
+  transition: background-color 0.15s ease;
+}
+.gloss-term:hover,
+.gloss-term[aria-expanded="true"] {
+  background: #eaf1fb;
+  text-decoration-style: solid;
+  text-decoration-thickness: 2px;
+}
+.gloss-term:focus-visible {
+  outline: 3px solid #ffbe2e;
+  outline-offset: 2px;
+  background: #eaf1fb;
+}
+.gloss-icon {
+  display: inline-block;
+  font-size: 0.78em;
+  color: #003366;
+  margin-left: 1px;
+  vertical-align: super;
+  line-height: 1;
+  opacity: 0.75;
+}
+.gloss-term:hover .gloss-icon,
+.gloss-term[aria-expanded="true"] .gloss-icon {
+  opacity: 1;
+}
+
+/* Popover: sotto al button by default, flip sopra se overflow */
+.gloss-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 1080; /* sopra header/cookie banner */
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 240px;
+  max-width: min(360px, 90vw);
+  padding: 0.7rem 0.85rem;
+  background: #fff;
+  border: 1px solid #c9d3e3;
+  border-left: 4px solid #003366;
+  border-radius: 6px;
+  box-shadow: 0 6px 24px rgba(0, 51, 102, 0.18);
+  font-size: 0.92rem;
+  line-height: 1.45;
+  color: #1a1a1a;
+  /* L'elemento è inline-flex content all'interno: serve normalize */
+  white-space: normal;
+  text-align: left;
+  text-decoration: none;
+  /* Triangolo che punta al termine */
+}
+.gloss-popover::before {
+  content: "";
+  position: absolute;
+  top: -7px;
+  left: 14px;
+  width: 12px;
+  height: 12px;
+  background: #fff;
+  border-left: 1px solid #c9d3e3;
+  border-top: 1px solid #c9d3e3;
+  transform: rotate(45deg);
+}
+.gloss-popover.is-flipped-up {
+  top: auto;
+  bottom: calc(100% + 6px);
+}
+.gloss-popover.is-flipped-up::before {
+  top: auto;
+  bottom: -7px;
+  border-left: 0;
+  border-top: 0;
+  border-right: 1px solid #c9d3e3;
+  border-bottom: 1px solid #c9d3e3;
+}
+.gloss-popover-def {
+  display: block;
+  color: #1a1a1a;
+}
+.gloss-popover-link {
+  display: inline-block;
+  margin-top: 0.2rem;
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: #003366;
+  text-decoration: underline;
+  align-self: flex-start;
+}
+.gloss-popover-link:hover,
+.gloss-popover-link:focus {
+  text-decoration: underline;
+  color: #002952;
+}
+
+/* Mobile: il popover diventa più compatto */
+@media (max-width: 576px) {
+  .gloss-popover {
+    min-width: 200px;
+    max-width: calc(100vw - 32px);
+    font-size: 0.88rem;
+  }
+}
+
+/* Stampa: rimuove il bottone-stile e il popover, lascia solo il termine
+   come testo normale (la pagina stampata non ha tooltip interattivi) */
+@media print {
+  .gloss-term {
+    color: inherit !important;
+    text-decoration: none !important;
+    background: transparent !important;
+    cursor: text !important;
+  }
+  .gloss-icon { display: none !important; }
+  .gloss-popover { display: none !important; }
+}
+
+/* Toolbar a11y: contrasto invertito (sfondo nero) */
+html.a11y-contrast-invert .gloss-term {
+  color: #ffd700;
+  text-decoration-color: #ffd700;
+}
+html.a11y-contrast-invert .gloss-popover {
+  background: #1a1a1a;
+  color: #fff;
+  border-color: #ffd700;
+  border-left-color: #ffd700;
+}
+html.a11y-contrast-invert .gloss-popover::before {
+  background: #1a1a1a;
+  border-color: #ffd700;
+}
+html.a11y-contrast-invert .gloss-popover-def {
+  color: #fff;
+}
+html.a11y-contrast-invert .gloss-popover-link {
+  color: #ffd700;
+}
+
+/* Toolbar a11y: alto contrasto (giallo su nero) */
+html.a11y-contrast-high .gloss-term {
+  color: #000;
+  text-decoration: underline solid #000;
+  text-decoration-thickness: 2px;
+}
+html.a11y-contrast-high .gloss-popover {
+  background: #fffbcf;
+  border: 2px solid #000;
+  border-left: 4px solid #000;
+  color: #000;
+}
+
+/* prefers-reduced-motion: niente transizioni */
+@media (prefers-reduced-motion: reduce) {
+  .gloss-term { transition: none; }
+}
+
+/* ============================================================
    TEMPO DI LETTURA — meta info sopra l'articolo (v1.0)
    Etichetta discreta che riduce l'ansia da "muro di testo"
    per anziani, dislessici, italiano L2. Usa Hugo .ReadingTime

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -2972,14 +2972,20 @@ html.a11y-grayscale  img.pittogramma { filter: contrast(1.2); }
 }
 
 /* ============================================================
-   TTS — Pulsante "Leggi ad alta voce" (Web Speech API) v1.0
-   Per pagine con frontmatter tts:true. Posizionato in alto al
-   contenuto, accessibile da tastiera, stati visivi distinti
-   (idle / reading / paused).
+   TTS — Pulsante "Leggi ad alta voce" (Web Speech API) v2.0
+   Default attivo su tutte le pagine (single + list), escluse
+   legali/tecniche via blacklist nel template. Selettore di
+   velocità (lento/normale/veloce) persistito in localStorage.
    ============================================================ */
 .tts-wrapper {
   margin: 0 0 1rem 0;
-  text-align: right;
+}
+.tts-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem 0.75rem;
 }
 .tts-button {
   font-size: 0.92rem;
@@ -2997,11 +3003,123 @@ html.a11y-grayscale  img.pittogramma { filter: contrast(1.2); }
   0%, 100% { opacity: 1; }
   50% { opacity: 0.55; }
 }
+
+/* Selettore velocità lettura: gruppo radio stilizzato come segmented control */
+.tts-rate {
+  display: inline-flex;
+  border: 1px solid #003366;
+  border-radius: 6px;
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
+  background: #fff;
+}
+.tts-rate-option {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  cursor: pointer;
+}
+.tts-rate-option input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.tts-rate-option > span[aria-hidden="true"] {
+  display: inline-block;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.82rem;
+  color: #003366;
+  border-right: 1px solid #003366;
+  transition: background 0.15s ease, color 0.15s ease;
+  user-select: none;
+}
+.tts-rate-option:last-child > span[aria-hidden="true"] {
+  border-right: 0;
+}
+.tts-rate-option input[type="radio"]:checked + span[aria-hidden="true"] {
+  background: #003366;
+  color: #fff;
+  font-weight: 600;
+}
+.tts-rate-option input[type="radio"]:focus-visible + span[aria-hidden="true"] {
+  outline: 3px solid #ffbe2e;
+  outline-offset: 2px;
+  z-index: 1;
+}
+.tts-rate-option:hover > span[aria-hidden="true"] {
+  background: #f4f7fb;
+}
+.tts-rate-option input[type="radio"]:checked + span[aria-hidden="true"]:hover {
+  background: #002952;
+}
+
+@media (max-width: 576px) {
+  .tts-controls { justify-content: stretch; flex-direction: column; align-items: stretch; }
+  .tts-rate { align-self: flex-end; }
+}
 @media print {
   .tts-wrapper { display: none !important; }
 }
 @media (prefers-reduced-motion: reduce) {
   .tts-button.btn-primary i { animation: none; }
+}
+
+/* ============================================================
+   TEMPO DI LETTURA — meta info sopra l'articolo (v1.0)
+   Etichetta discreta che riduce l'ansia da "muro di testo"
+   per anziani, dislessici, italiano L2. Usa Hugo .ReadingTime
+   (200 parole/min). Mostrata solo se WordCount > 30.
+   ============================================================ */
+.reading-meta {
+  margin-bottom: 0.75rem;
+  font-size: 0.88rem;
+  color: #555;
+}
+.reading-time {
+  display: inline-flex;
+  align-items: center;
+  background: #f4f7fb;
+  border: 1px solid #d6dde8;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  color: #003366;
+}
+.reading-time strong {
+  color: #003366;
+  font-weight: 600;
+  margin-left: 0.15rem;
+}
+@media print {
+  .reading-meta { display: none !important; }
+}
+
+/* ============================================================
+   SILLABAZIONE AUTOMATICA — corpo articolo (v1.0)
+   Spezza le parole lunghe a fine riga (regole italiane via
+   lang="it" del <html>). Beneficio cognitivo per dislessici
+   e parlanti italiano L2: meno scoglioni a fine riga, ritmo
+   di lettura più uniforme. Solo testo flow, mai tabelle/code.
+   ============================================================ */
+.article-body,
+.list-intro-content {
+  -webkit-hyphens: auto;
+      -ms-hyphens: auto;
+          hyphens: auto;
+  hyphenate-limit-chars: 6 3 3; /* min word len, min chars before, min chars after */
+}
+.article-body pre,
+.article-body code,
+.article-body table,
+.article-body .no-hyphens,
+.list-intro-content pre,
+.list-intro-content code,
+.list-intro-content table,
+.list-intro-content .no-hyphens {
+  -webkit-hyphens: none;
+      -ms-hyphens: none;
+          hyphens: none;
 }
 
 /* ============================================================

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -3055,15 +3055,117 @@ html.a11y-grayscale  img.pittogramma { filter: contrast(1.2); }
   background: #002952;
 }
 
+/* Toggle "Segui parole" — checkbox stilizzata come pillola */
+.tts-follow-toggle {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  font-size: 0.82rem;
+  color: #003366;
+  border: 1px solid #003366;
+  border-radius: 999px;
+  padding: 0.25rem 0.7rem;
+  user-select: none;
+  background: #fff;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.tts-follow-toggle:hover { background: #f4f7fb; }
+.tts-follow-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.tts-follow-input:focus-visible + .tts-follow-label {
+  outline: 3px solid #ffbe2e;
+  outline-offset: 3px;
+  border-radius: 999px;
+}
+.tts-follow-input:checked ~ .tts-follow-label,
+.tts-follow-input:checked + .tts-follow-label {
+  /* Quando attivo: stile pieno blu istituzionale */
+}
+.tts-follow-toggle:has(.tts-follow-input:checked) {
+  background: #003366;
+  color: #fff;
+  font-weight: 600;
+}
+
 @media (max-width: 576px) {
   .tts-controls { justify-content: stretch; flex-direction: column; align-items: stretch; }
-  .tts-rate { align-self: flex-end; }
+  .tts-rate, .tts-follow-toggle { align-self: flex-end; }
 }
 @media print {
   .tts-wrapper { display: none !important; }
 }
 @media (prefers-reduced-motion: reduce) {
   .tts-button.btn-primary i { animation: none; }
+}
+
+/* ============================================================
+   TTS WORD HIGHLIGHT — evidenziazione parola in lettura (v1.0)
+   <mark class="tts-word-mark"> avvolge la parola corrente quando
+   il toggle "Segui parole" è attivo. L'elemento è temporaneo e
+   viene rimosso non appena la parola successiva entra in lettura.
+
+   Beneficiari: dislessici, parlanti italiano L2, anziani che si
+   distraggono, bambini in lettura lenta. La sincronizzazione
+   audio-visiva è il principio dei software didattici come
+   ClaroRead/Read&Write.
+
+   Compat: usa <mark> nativo HTML5. Override di colore/sfondo
+   per non confondersi con altre evidenziazioni (es. risultato
+   ricerca interna, che non usa <mark>).
+   ============================================================ */
+.article-body mark.tts-word-mark,
+.list-intro-content mark.tts-word-mark,
+mark.tts-word-mark {
+  background: #fff3cd;
+  color: inherit;
+  border-bottom: 2px solid #ffbe2e;
+  padding: 0 1px;
+  border-radius: 2px;
+  /* Animazione morbida: niente flicker brusco quando si sposta */
+  transition: background-color 0.12s ease;
+  /* Importante: niente box-shadow né transform che causino reflow */
+}
+@media (prefers-reduced-motion: reduce) {
+  mark.tts-word-mark { transition: none; }
+}
+
+/* Variante per toolbar a11y "Contrasto invertito" (sfondo nero) */
+html.a11y-contrast-invert mark.tts-word-mark,
+html.a11y-contrast-invert .article-body mark.tts-word-mark,
+html.a11y-contrast-invert .list-intro-content mark.tts-word-mark {
+  background: #ffd700;
+  color: #000;
+  border-bottom-color: #ff8c00;
+}
+
+/* Variante per toolbar a11y "Scala di grigi" (mantiene contrasto) */
+html.a11y-grayscale mark.tts-word-mark,
+html.a11y-grayscale .article-body mark.tts-word-mark,
+html.a11y-grayscale .list-intro-content mark.tts-word-mark {
+  background: #d9d9d9;
+  border-bottom-color: #666;
+}
+
+/* Variante per toolbar a11y "Alto contrasto" (giallo su nero) */
+html.a11y-contrast-high mark.tts-word-mark,
+html.a11y-contrast-high .article-body mark.tts-word-mark,
+html.a11y-contrast-high .list-intro-content mark.tts-word-mark {
+  background: #ffeb3b;
+  color: #000;
+  border-bottom: 3px solid #000;
+}
+
+/* In stampa il <mark> potrebbe essere sopravvissuto se l'utente
+   stampa mentre il TTS sta leggendo: forziamo il reset. */
+@media print {
+  mark.tts-word-mark {
+    background: transparent !important;
+    border-bottom: none !important;
+    color: inherit !important;
+  }
 }
 
 /* ============================================================


### PR DESCRIPTION
## Sommario

Pacchetto di accessibilità cognitiva per anziani, dislessici, parlanti italiano L2, bambini in lettura lenta, persone in stress da emergenza. Tre commit, additivi, zero regressioni note.

### Commit 1 — TTS dappertutto + tempo lettura + sillabazione + velocità (`5c14bc8`)
- **TTS default ON su tutte le pagine Hugo** (single + list con WordCount > 30). Logica invertita da opt-in (`tts: true`) a opt-out (`tts: false`).
- **Blacklist** legali e tecniche: privacy, note-legali, accessibilità, social-media-policy, mappa-sito, attribuzioni-pittogrammi, cerca, comunicazioni list.
- **Selettore velocità** (lento 0.75x / normale 0.95x / veloce 1.15x), persistito in `localStorage`.
- **Tempo di lettura stimato** (`~N minuti`) sopra ogni articolo via `.ReadingTime` Hugo.
- **Sillabazione automatica** `hyphens: auto` su `.article-body` e `.list-intro-content` con regole italiane.

### Commit 2 — TTS word highlight (`73b966b`)
- Toggle "Segui parole" accanto al selettore velocità (default OFF).
- Sincronizzazione audio-visiva via `SpeechSynthesisUtterance.onboundary`: la parola attualmente pronunciata si evidenzia in giallo (palette istituzionale).
- **Fallback graceful**: se l'evento `word` non arriva entro 2.5s (Safari iOS bug noto), highlight si auto-disattiva e TTS continua puro.
- Varianti CSS per toolbar a11y (contrasto invertito, alto contrasto, scala grigi).
- Auto-scroll centrato sulla parola con `prefers-reduced-motion` fallback.

### Commit 3 — Glossario inline con popover (`4aaa322`)
- Nuovo `data/glossario.yaml` con **61 voci** PC (sigle e termini specialistici), definizioni nostre AGID-compliant, parafrasi originali. **Zero copia da Treccani** o altre opere protette: solo glossario interno + glossario DPC pubblico.
- `static/js/glossario-inline.js` sostituisce alla **prima occorrenza** in pagina ogni termine con `<button class="gloss-term">termine ⓘ</button>` + popover accessibile (definizione breve + link al glossario completo).
- Popover **WAI-ARIA non-modal**: Enter/Space apre, ESC chiude (focus al button), Tab esce, click-outside chiude, scroll chiude. `aria-expanded`, `aria-describedby`, `role=tooltip`.
- Mega-regex unica scansione **O(N)** sulla lunghezza del testo.
- Esclusioni: `<a>`, `<button>`, `<code>`, `<pre>`, `<h1>`, `<kbd>`, `[aria-hidden=true]`, `.no-gloss`, `.tts-wrapper`, `.gloss-term`.
- Stessa blacklist del TTS, più `/glossario/` stesso (auto-esclusa per non popolare popover sui termini del glossario).
- Hover desktop solo con `pointer:fine` (no touch).
- **Interazione TTS↔Glossario fixata**: il sintetizzatore vocale non legge il testo dei popover hidden né l'icona ⓘ.

## File modificati
- `data/glossario.yaml` (nuovo, 61 voci)
- `static/js/glossario-inline.js` (nuovo)
- `themes/flavour-pcgenzano/layouts/partials/glossario-inline.html` (nuovo)
- `themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html` (v2.1 con velocità + word highlight)
- `themes/flavour-pcgenzano/layouts/_default/single.html` (blacklist + tempo lettura + glossario)
- `themes/flavour-pcgenzano/layouts/_default/list.html` (idem)
- `themes/flavour-pcgenzano/static/css/custom.css` (nuove sezioni: TTS v2.0, TTS WORD HIGHLIGHT v1.0, TEMPO DI LETTURA v1.0, SILLABAZIONE v1.0, GLOSSARIO INLINE v1.0)
- `.claude/rules/03-accessibility.md` (3 nuove sezioni: highlight, sillabazione + tempo lettura, glossario)

## Test plan
- [ ] Verifica visiva su `/cosa-fare-adesso/`: TTS, velocità, sigla "DPC" con popover
- [ ] Verifica su `/rischi-prevenzione/rischio-sismico/`: parole evidenziate durante lettura
- [ ] Verifica blacklist: `/privacy/` non mostra TTS né popover glossario
- [ ] Verifica `/glossario/` stesso: niente popover (auto-esclusa)
- [ ] Verifica tastiera: Tab → bottone TTS → Enter → lettura parte; ESC su popover chiude
- [ ] Verifica toolbar a11y: contrasto invertito mantiene leggibilità highlight + popover
- [ ] Verifica mobile: bottoni stack verticale, popover fitta lo schermo
- [ ] Verifica stampa: nessun bottone, glossario torna testo normale

https://claude.ai/code/session_01UosCaNMneqDtABB2dnkR1n

---
_Generated by [Claude Code](https://claude.ai/code/session_01UosCaNMneqDtABB2dnkR1n)_