### PR TITLE
TTS: fallback browser privacy-first + doc Tor + doc bug Safari iOS word highlight

### DIFF
--- a/content/accessibilita/_index.md
+++ b/content/accessibilita/_index.md
@@ -2,7 +2,7 @@
 title: "Dichiarazione di Accessibilità"
 description: "Dichiarazione di accessibilità del sito web della Protezione Civile di Genzano di Roma."
 layout: "single"
-dataUltimaRevisione: "2026-04-26"
+dataUltimaRevisione: "2026-05-02"
 aliases:
   - /dichiarazione-accessibilita.html
 ---
@@ -40,6 +40,62 @@ Le scelte vengono **ricordate sul tuo dispositivo** (tramite `localStorage`): ch
 Il pannello stesso è interamente accessibile da tastiera: si apre con `Invio`, si naviga con `Tab`, si chiude con `Esc` o cliccando fuori. Tutti i comandi hanno descrizioni per gli screen reader.
 
 > **Nota importante.** Questi strumenti sono un **aiuto in più** sopra a un sito **progettato secondo i principi delle Linee guida AGID sull'accessibilità e delle WCAG 2.2 livello AA**. Sono in corso verifiche periodiche per migliorare continuamente l'esperienza di utilizzo. Questi strumenti non sostituiscono gli strumenti di accessibilità del tuo sistema operativo o del tuo browser, che restano la soluzione più potente e completa: vedi la sezione successiva.
+
+## Lettura ad alta voce, glossario e supporti cognitivi
+
+In cima a quasi tutte le pagine del sito trovi un piccolo gruppo di strumenti pensati per **anziani, persone dislessiche, parlanti italiano come seconda lingua, bambini in lettura lenta, persone in stress da emergenza**.
+
+### Bottone "Leggi ad alta voce"
+
+Premendo il bottone, il sito legge ad alta voce il contenuto della pagina con la **voce italiana installata sul tuo dispositivo**. È completamente **gratuito** e **non invia nulla a server esterni**: tutto avviene nel browser, sfruttando la **Web Speech API** prevista dagli standard W3C.
+
+Accanto al bottone trovi tre comandi:
+
+- **Velocità di lettura**: scegli fra **Lento** (per anziani, bambini, italiano L2), **Normale** (default) o **Veloce** (per chi conosce già il testo). La scelta resta memorizzata sul tuo dispositivo per le pagine successive.
+- **Segui parole**: quando attivo, la parola attualmente pronunciata si **evidenzia in giallo** mentre la voce legge. Aiuta chi si distrae o ha difficoltà di lettura: gli occhi seguono l'orecchio. Default disattivato (alcuni utenti lo trovano "rumoroso" su pagine lunghe).
+
+### Glossario inline: termini sottolineati con definizione
+
+Alla **prima occorrenza** in ogni pagina, le sigle e i termini specialistici di Protezione Civile (DPC, COC, AeDES, IT-alert, NUE, CFR, magnitudo, ipocentro…) sono **sottolineati con tratteggio blu** e affiancati da una piccola icona ⓘ. Toccando o cliccando il termine si apre un riquadro con la definizione breve in italiano semplice e un link al [glossario completo](/glossario/).
+
+### Tempo di lettura stimato
+
+Sopra ogni articolo trovi un'etichetta del tipo *"Lettura: ~3 minuti"*. Calcolata automaticamente, riduce l'ansia da "muro di testo": sai subito quanto tempo ti serve.
+
+### Sillabazione automatica
+
+Il sito usa la sillabazione automatica del browser (`hyphens: auto`) con regole italiane: le parole lunghe vengono spezzate in modo elegante a fine riga, migliorando il ritmo di lettura per chi ha dislessia o legge italiano come seconda lingua.
+
+## Browser e privacy: dove la lettura ad alta voce può non funzionare
+
+La sintesi vocale del sito sfrutta la **Web Speech API** del tuo browser, che a sua volta usa le voci installate sul tuo sistema operativo. Funziona **bene su tutti i browser principali**:
+
+- ✅ **Google Chrome** (desktop, Android)
+- ✅ **Mozilla Firefox** (desktop, Android)
+- ✅ **Apple Safari** (macOS, iPad, iPhone)
+- ✅ **Microsoft Edge** (desktop)
+- ✅ **Samsung Internet, Opera, Vivaldi** e altri browser standard
+
+In alcuni browser **orientati alla privacy** la lettura vocale è invece **disattivata di proposito**, per impedire a chi gestisce un sito di "riconoscere" un visitatore unico tramite la lista delle voci installate sul suo computer (è una tecnica di tracciamento chiamata *fingerprinting*). Questo riguarda in particolare:
+
+- ❌ **Tor Browser** — disattivata sempre, in tutte le versioni
+- ❌ **LibreWolf** — disattivata di default (configurabile dall'utente)
+- ❌ **Brave** con scudo (*Shields*) impostato al massimo livello di privacy
+- ❌ Modalità di navigazione anti-fingerprinting di alcuni browser sperimentali
+
+Se usi uno di questi browser, **al posto del bottone vedrai un avviso** che spiega la causa: **non è un difetto del nostro sito, è una scelta del tuo browser per proteggere il tuo anonimato.** Per usare la lettura vocale puoi semplicemente aprire la stessa pagina con un browser diverso (Chrome, Firefox, Safari, Edge), oppure rivolgerti agli strumenti di sistema descritti più sotto.
+
+### Funzione "Segui parole" — bug noto su Safari iOS (iPhone, iPad)
+
+Su **Safari per iPhone e iPad** il sistema operativo ha un **bug noto e documentato**: l'evento `onboundary` della Web Speech API, che permette al sito di sapere quale parola la voce sta pronunciando, **non viene sparato in modo affidabile**. Il problema è di Apple, non del nostro sito.
+
+Conseguenza pratica:
+
+- La lettura ad alta voce **funziona regolarmente** anche su iPhone e iPad
+- Ma se attivi il toggle **"Segui parole"** su Safari iOS, l'evidenziazione gialla potrebbe **non comparire** o partire e fermarsi a metà frase
+- Il nostro sito gestisce questa situazione automaticamente: se entro 2,5 secondi non riceve gli eventi attesi, **disattiva l'evidenziazione e continua la lettura normalmente**, senza errore visibile
+
+Se desideri usare anche l'evidenziazione delle parole, ti consigliamo di usare **Chrome, Firefox o Edge su iPhone/iPad**, oppure Safari su Mac (dove il bug non si presenta). Quando Apple correggerà il problema, la funzione tornerà attiva anche su Safari iOS senza modifiche da parte nostra.
 
 ## Strumenti di sistema (browser e sistema operativo)
 

--- a/manuale/parte-18-lettura-accessibile-maggio-2026.md
+++ b/manuale/parte-18-lettura-accessibile-maggio-2026.md
@@ -264,7 +264,94 @@ Comunale**, basate su:
 
 ---
 
-### 18.11 Compatibilità con la toolbar di accessibilità
+### 18.11 Compatibilità browser
+
+La sintesi vocale del sito sfrutta la **Web Speech API** del browser. Funziona
+su tutti i browser principali, ma alcuni browser orientati alla privacy la
+disattivano di proposito per impedire il fingerprinting (la lista delle voci
+installate sul SO è una superficie identificativa unica per ogni utente).
+
+| Browser | Lettura vocale | Note |
+|---|---|---|
+| Google Chrome (desktop, Android) | ✅ funziona | Voci di sistema |
+| Mozilla Firefox (desktop, Android) | ✅ funziona | Voci di sistema |
+| Apple Safari (macOS) | ✅ funziona | Voci di sistema |
+| Apple Safari (iPhone, iPad) | ✅ funziona, ma vedi § 18.12 | Bug noto su "Segui parole" |
+| Microsoft Edge | ✅ funziona | Voci di sistema |
+| Samsung Internet, Opera, Vivaldi | ✅ funziona | Comportamento Chromium |
+| **Tor Browser** | ❌ disabilitata sempre | Scelta di privacy del Tor Project |
+| **LibreWolf** | ❌ disabilitata di default | Configurabile dall'utente |
+| **Brave** con Shields al massimo | ❌ disabilitata | Scelta di privacy |
+
+**Comportamento del sito:** al caricamento, se `speechSynthesis.getVoices()`
+ritorna lista vuota dopo `voiceschanged` o entro 1,8 secondi, il bottone
+"Leggi ad alta voce" viene **sostituito automaticamente** da un riquadro
+informativo che spiega:
+
+> *"Lettura vocale non disponibile in questo browser. Alcuni browser
+> orientati alla privacy (Tor Browser, LibreWolf, Brave con scudo massimo)
+> disattivano la sintesi vocale per impedire il riconoscimento del visitatore.
+> La funzione resta attiva su Chrome, Firefox, Safari ed Edge."*
+
+Niente errore in console, niente alert popup. L'utente capisce subito che
+**non è un difetto del nostro sito** ma una scelta del suo browser. CSS
+scoped sezione **TTS FALLBACK v1.0** in `custom.css` (riquadro azzurrino
+istituzionale, coerente con popover glossario).
+
+**Per testare il fallback in locale**: aprire la pagina con Tor Browser
+oppure simulare disabilitando l'API in DevTools:
+```js
+Object.defineProperty(window, 'speechSynthesis', { get: () => undefined });
+location.reload();
+```
+
+---
+
+### 18.12 Bug Safari iOS sul "Segui parole"
+
+Su **Safari per iPhone e iPad** il sistema operativo ha un **bug noto e
+documentato**: l'evento `SpeechSynthesisUtterance.onboundary`
+(`event.name === 'word'`), che il sito usa per sapere quale parola la voce
+sta pronunciando, **non viene sparato in modo affidabile**:
+
+- A volte non spara mai
+- A volte spara solo eventi `sentence` (a livello di frase), non `word`
+- A volte spara con offset `charIndex` errato
+
+Il bug è di **WebKit/Apple**, non del nostro sito. È documentato sul
+WebKit Bugzilla e sui forum sviluppatori Apple da diversi anni.
+
+**Conseguenza pratica per il cittadino:**
+
+- La lettura ad alta voce **funziona regolarmente** anche su Safari iOS
+- Ma se l'utente attiva il toggle **"Segui parole"**, l'evidenziazione
+  gialla potrebbe **non comparire** o partire e fermarsi a metà frase
+
+**Cosa fa il sito automaticamente** (codice in
+`themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html`):
+
+1. Al click "Leggi ad alta voce" con "Segui parole" attivo, il JS attiva un
+   timer di **2,5 secondi**
+2. Se entro 2,5 secondi il primo evento `boundary` di tipo `word` non è
+   arrivato, il timer scatta e:
+   - Disattiva l'evidenziazione (rimuove il `<mark>` corrente, se esiste)
+   - **Non disattiva il TTS**, che continua a leggere normalmente
+3. L'utente sente la lettura completa, ma senza evidenziazione delle parole
+4. Nessun errore in console, nessun avviso visibile
+
+**Cosa è documentato pubblicamente al cittadino**: nella pagina
+`/accessibilita/` § "Funzione 'Segui parole' — bug noto su Safari iOS" il
+problema è spiegato chiaramente, con il consiglio operativo di usare Chrome,
+Firefox o Edge su iPhone/iPad oppure Safari su Mac (dove il bug non si
+manifesta).
+
+**Quando Apple correggerà il bug**: la funzione tornerà attiva su Safari iOS
+**senza modifiche da parte nostra**. Il codice è già pronto a usare gli
+eventi `word` quando arrivano.
+
+---
+
+### 18.13 Compatibilità con la toolbar di accessibilità
 
 Tutti e sei gli strumenti rispettano le preferenze utente della toolbar:
 
@@ -283,7 +370,7 @@ attiva** — in particolare contrasto invertito + reduced-motion.
 
 ---
 
-### 18.12 Comportamento in stampa
+### 18.14 Comportamento in stampa
 
 Tutti i controlli di lettura **scompaiono in stampa**:
 
@@ -297,7 +384,7 @@ Stampato, l'articolo è pulito come prima.
 
 ---
 
-### 18.13 File coinvolti (architettura tecnica)
+### 18.15 File coinvolti (architettura tecnica)
 
 | File | Ruolo |
 |---|---|
@@ -312,7 +399,7 @@ Stampato, l'articolo è pulito come prima.
 
 ---
 
-### 18.14 Quando NON usare questi strumenti
+### 18.16 Quando NON usare questi strumenti
 
 - **Pagine legali** (privacy, note legali, accessibilità, social-media-policy):
   hanno un linguaggio giuridico denso che non beneficia della lettura ad alta voce
@@ -325,7 +412,7 @@ Stampato, l'articolo è pulito come prima.
 
 ---
 
-### 18.15 Domande frequenti redazionali
+### 18.17 Domande frequenti redazionali
 
 **D: Devo aggiungere `tts: true` ai miei nuovi articoli?**
 R: No. Il TTS è ON di default. Il flag `tts: true` non serve più (e non fa danni

--- a/themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html
+++ b/themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html
@@ -72,6 +72,66 @@
   var RATE_KEY = 'pcgenzano-tts-rate';
   var FOLLOW_KEY = 'pcgenzano-tts-follow';
 
+  /*
+   * Detection "Tor Browser e simili": alcuni browser privacy-first
+   * (Tor, LibreWolf, Brave shield massimo) implementano speechSynthesis
+   * solo come stub — getVoices() ritorna [] e speak() non produce audio.
+   * È una scelta intenzionale per impedire fingerprinting (la lista delle
+   * voci installate sul SO è una superficie identificativa).
+   *
+   * Strategia: al load, attendi voiceschanged o un timeout di 1.8s.
+   * Se ancora getVoices() è vuoto, sostituisci la UI con un avviso
+   * elegante in italiano AGID che spiega la causa (privacy del browser),
+   * non un bug del sito.
+   */
+  function showTtsUnavailable() {
+    document.querySelectorAll('.tts-wrapper').forEach(function(w){
+      // Mantieni il wrapper per evitare reflow violenti, sostituisci il contenuto
+      w.classList.add('tts-unavailable');
+      w.innerHTML = '<div class="tts-fallback-msg" role="note">' +
+        '<i class="bi bi-info-circle me-2" aria-hidden="true"></i>' +
+        '<span><strong>Lettura vocale non disponibile in questo browser.</strong> ' +
+        'Alcuni browser orientati alla privacy (Tor Browser, LibreWolf, Brave con scudo massimo) ' +
+        'disattivano la sintesi vocale per impedire il riconoscimento del visitatore. ' +
+        'La funzione resta attiva su Chrome, Firefox, Safari ed Edge.</span>' +
+        '</div>';
+    });
+  }
+
+  var voicesReady = false;
+  function checkVoicesAvailability() {
+    if (voicesReady) return;
+    if (synth.getVoices().length > 0) {
+      voicesReady = true;
+      return;
+    }
+    // Voci ancora vuote: aspetta voiceschanged o timeout
+    var resolved = false;
+    var onVoicesChanged = function(){
+      if (resolved) return;
+      resolved = true;
+      synth.removeEventListener('voiceschanged', onVoicesChanged);
+      if (synth.getVoices().length > 0) {
+        voicesReady = true;
+      } else {
+        showTtsUnavailable();
+      }
+    };
+    synth.addEventListener('voiceschanged', onVoicesChanged);
+    setTimeout(function(){
+      if (resolved) return;
+      resolved = true;
+      synth.removeEventListener('voiceschanged', onVoicesChanged);
+      if (synth.getVoices().length > 0) {
+        voicesReady = true;
+      } else {
+        showTtsUnavailable();
+      }
+    }, 1800);
+  }
+  // Avvia la detection asincrona
+  checkVoicesAvailability();
+
   function getSavedRate() {
     try {
       var v = parseFloat(localStorage.getItem(RATE_KEY) || '');

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -3102,6 +3102,52 @@ html.a11y-grayscale  img.pittogramma { filter: contrast(1.2); }
 }
 
 /* ============================================================
+   TTS FALLBACK — messaggio "lettura vocale non disponibile" (v1.0)
+   Visualizzato quando il browser implementa speechSynthesis come
+   stub (Tor Browser, LibreWolf, Brave con scudo massimo) e
+   getVoices() resta vuoto. NON è un bug del sito: è una scelta
+   di privacy del browser che impedisce il fingerprinting.
+   ============================================================ */
+.tts-wrapper.tts-unavailable {
+  text-align: left;
+}
+.tts-fallback-msg {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.65rem 0.85rem;
+  background: #f4f7fb;
+  border: 1px solid #b3c6dd;
+  border-left: 4px solid #003366;
+  border-radius: 6px;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+}
+.tts-fallback-msg i {
+  color: #003366;
+  font-size: 1.1rem;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+.tts-fallback-msg strong {
+  color: #003366;
+}
+@media print {
+  .tts-fallback-msg { display: none !important; }
+}
+html.a11y-contrast-invert .tts-fallback-msg {
+  background: #1a1a1a;
+  color: #fff;
+  border-color: #ffd700;
+  border-left-color: #ffd700;
+}
+html.a11y-contrast-invert .tts-fallback-msg i,
+html.a11y-contrast-invert .tts-fallback-msg strong {
+  color: #ffd700;
+}
+
+/* ============================================================
    TTS WORD HIGHLIGHT — evidenziazione parola in lettura (v1.0)
    <mark class="tts-word-mark"> avvolge la parola corrente quando
    il toggle "Segui parole" è attivo. L'elemento è temporaneo e


### PR DESCRIPTION
## Sommario

Tre interventi coordinati dopo segnalazione utente che il TTS non produce audio su **Tor Browser** (comportamento atteso dei browser privacy-first, non bug del sito).

## Cosa cambia

### 1. Fallback UX automatico (codice)
- `themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html`: aggiunto `checkVoicesAvailability()` che attende `voiceschanged` o un timeout di 1.8s. Se `getVoices().length === 0`, sostituisce il contenuto di tutti i `.tts-wrapper` con un riquadro informativo elegante che spiega la causa (privacy del browser, non bug del sito) e suggerisce browser alternativi.
- `themes/flavour-pcgenzano/static/css/custom.css`: nuova sezione **TTS FALLBACK v1.0** (`.tts-fallback-msg`) con palette istituzionale azzurrina coerente al popover glossario, icona `bi-info-circle`, variante a11y contrasto invertito, hidden in stampa.

### 2. Documentazione pubblica `/accessibilita/`
- `dataUltimaRevisione` bumpata da `2026-04-26` → `2026-05-02`
- Nuova sezione **"Lettura ad alta voce, glossario e supporti cognitivi"** che descrive al cittadino i 5 strumenti aggiunti dalle PR #79 e #81 (TTS, velocità, Segui parole, glossario inline, tempo lettura, sillabazione)
- Nuova sezione **"Browser e privacy: dove la lettura ad alta voce può non funzionare"** con tabella browser supportati/non supportati (Tor, LibreWolf, Brave shield massimo)
- Sotto-sezione dedicata al **bug Safari iOS sul "Segui parole"** con spiegazione chiara che il problema è di Apple/WebKit, non del sito, e consiglio operativo (Chrome/Firefox/Edge su iPhone/iPad)

### 3. Documentazione operativa (manuale Parte 18)
- Rinumerate sezioni `18.11`-`18.15` → `18.13`-`18.17` per inserire 2 nuove sezioni a tema browser/privacy. Riferimenti incrociati controllati: solo § 18.9 e § 18.10 sono linkate da `MANUALE-SITO.md` (intoccate). Le sezioni rinumerate non erano referenziate da nessun altro file.
- Nuovo **§ 18.11 "Compatibilità browser"** con tabella browser supportati/non supportati + spiegazione fingerprinting + comando DevTools per testare il fallback in locale
- Nuovo **§ 18.12 "Bug Safari iOS sul 'Segui parole'"** con descrizione tecnica del bug WebKit/Apple, comportamento del fallback graceful a 2.5s, riferimento alla doc pubblica nella pagina `/accessibilita/`

## File modificati
- `themes/flavour-pcgenzano/layouts/partials/leggi-ad-alta-voce.html` (+60 righe)
- `themes/flavour-pcgenzano/static/css/custom.css` (+46 righe)
- `content/accessibilita/_index.md` (+58 righe)
- `manuale/parte-18-lettura-accessibile-maggio-2026.md` (+97 righe)

## Test plan
- [ ] Verifica visiva su Tor Browser: il bottone TTS è sostituito dal riquadro informativo entro ~2s dal caricamento
- [ ] Verifica su Chrome/Firefox/Safari/Edge: TTS continua a funzionare normalmente (regressione zero)
- [ ] Verifica `/accessibilita/`: nuove sezioni visibili, link funzionanti
- [ ] Verifica `dataUltimaRevisione`: appare il box "Pagina rivista il 2 maggio 2026"
- [ ] Verifica manuale Parte 18: numerazione sezioni 18.11-18.17 corretta

https://claude.ai/code/session_01UosCaNMneqDtABB2dnkR1n

---
_Generated by [Claude Code](https://claude.ai/code/session_01UosCaNMneqDtABB2dnkR1n)_