### PR TITLE
fix(settings): rimuove campi non-schema da .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,3 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "_comment": "Settings condivisi del repo (committati). Per settings personali usa .claude/settings.local.json (gitignored). Vedi rule 08-claude-code-setup.md.",
-
-  "_history": "Maggio 2026: rimosso l'hook PostToolUse che invocava scripts/verifica-conteggi.sh dopo ogni Write/Edit/MultiEdit. L'hook serviva a segnalare drift fra conteggi inventario dichiarati sul sito (es. '127 schede', '33 giochi') e cartelle reali. Decisione editoriale: i conteggi sono stati rimossi da tutto il sito e sostituiti con descrizioni qualitative, quindi non c'è più drift da inseguire."
+  "$schema": "https://json.schemastore.org/claude-code-settings.json"
 }


### PR DESCRIPTION
## Summary

I campi `_comment` e `_history` non sono nello schema ufficiale di Claude Code e in alcune versioni vengono interpretati erroneamente come hook event, generando un warning all'avvio della sessione (`Unknown hook event "_comment" was ignored`).

Rimossi entrambi: la documentazione resta in `.claude/rules/08-claude-code-setup.md` e lo storico è preservato in git.

## Test plan

- [x] `python3 -m json.tool .claude/settings.json` valido
- [x] Nessun impatto su build, deploy o contenuti del sito (file di sola configurazione Claude Code)
- [ ] Dopo il merge: nessun warning all'avvio di Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01JGAobgUfKuZMYCnACtjCga)_