### PR TITLE
Assistente FAB v2.1: cerchio coordinato col FAB a11y solo su mobile

### DIFF
--- a/themes/flavour-pcgenzano/layouts/partials/assistente-fab.html
+++ b/themes/flavour-pcgenzano/layouts/partials/assistente-fab.html
@@ -4,6 +4,12 @@
   le pagine. Click → /assistente/ (assistente virtuale guidato).
 
   Posizione: bottom-left, SOPRA il toolbar di accessibilità.
+  Design v2.0 (maggio 2026): cerchio dark blue con bordo bianco, in
+  coppia visiva con il FAB accessibilità sottostante (stessa forma,
+  stessa dimensione, stesso focus). Il label testuale è visivamente
+  nascosto ma resta accessibile a screen reader via aria-label e
+  alla classe .assistente-fab-label (sr-only style nel CSS).
+
   Convenzione FAB del sito:
    - bottom-left: a11y toolbar (in basso) + assistente FAB (sopra)
    - bottom-right: back-to-top + sos-112 (mobile)
@@ -13,8 +19,8 @@
 
   Accessibilità:
   - <a> nativo, raggiungibile da tastiera
-  - aria-label esplicito
-  - focus visible WCAG 2.4.7
+  - aria-label esplicito + title (tooltip hover)
+  - focus visible WCAG 2.4.7 (outline 3px arancione, come a11y-fab)
 */}}
 {{- /* skip su sezioni dove il FAB sarebbe ridondante o distrarrebbe */ -}}
 {{- $skipSections := slice "assistente" "emergenza" "cerca" -}}

--- a/themes/flavour-pcgenzano/layouts/partials/assistente-fab.html
+++ b/themes/flavour-pcgenzano/layouts/partials/assistente-fab.html
@@ -4,11 +4,14 @@
   le pagine. Click → /assistente/ (assistente virtuale guidato).
 
   Posizione: bottom-left, SOPRA il toolbar di accessibilità.
-  Design v2.0 (maggio 2026): cerchio dark blue con bordo bianco, in
-  coppia visiva con il FAB accessibilità sottostante (stessa forma,
-  stessa dimensione, stesso focus). Il label testuale è visivamente
-  nascosto ma resta accessibile a screen reader via aria-label e
-  alla classe .assistente-fab-label (sr-only style nel CSS).
+  Design v2.1 (maggio 2026):
+   - Desktop: pill blu con label "Assistente virtuale" visibile
+     (versione consolidata, non toccare).
+   - Mobile (≤575.98px): cerchio dark blue con bordo bianco in
+     coppia visiva col FAB accessibilità sottostante (stessa
+     forma, stesso focus). Label nascosto visivamente ma
+     accessibile a screen reader via aria-label e classe
+     .assistente-fab-label (sr-only style nel CSS).
 
   Convenzione FAB del sito:
    - bottom-left: a11y toolbar (in basso) + assistente FAB (sopra)

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -3966,48 +3966,58 @@ html.a11y-pause-animations body.home-page .reveal-on-scroll {
  */
 
 /* ==========================================================================
- * ASSISTENTE FAB v1.0 (maggio 2026)
- * Bottone "Aiuto" fisso bottom-left sopra il toolbar accessibilità.
- * Click → /assistente/. Disponibile su tutte le pagine.
+ * ASSISTENTE FAB v2.0 (maggio 2026)
+ * Bottone "Aiuto" fisso bottom-left, in coppia visiva sopra il toolbar
+ * accessibilità: stessa forma circolare 56px (50px mobile), stesso bordo
+ * bianco, stesso blu istituzionale, stesso focus arancione. Click →
+ * /assistente/. Il label testuale è nascosto visualmente ma mantenuto
+ * per screen reader (l'icona chat-dots + aria-label sono già univoche).
  * ==========================================================================
  */
 .assistente-fab {
   position: fixed;
-  bottom: 5.5rem;       /* sopra il FAB toolbar a11y (bottom: 1.2rem + h ~3rem + gap) */
-  left: 1.2rem;
-  z-index: 9998;        /* sotto i modal (sos-modal = 10001) ma sopra il contenuto */
+  bottom: 6.25rem;          /* sopra a11y-fab (bottom 2rem + 56px + 0.75rem gap) */
+  left: 2rem;               /* allineato al a11y-fab desktop */
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--pc-primary, #003366);
+  color: #fff;
+  border: 3px solid #fff;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.55rem 1rem;
-  background: #003366;  /* blu istituzionale --pc-blue */
-  color: #fff;
-  border-radius: 999px;
-  box-shadow: 0 4px 12px rgba(0, 51, 102, 0.35), 0 0 0 2px rgba(255,255,255,0.1) inset;
+  justify-content: center;
+  font-size: 1.5rem;
   text-decoration: none;
-  font-size: 0.95rem;
-  font-weight: 600;
-  font-family: inherit;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
-  white-space: nowrap;
+  cursor: pointer;
+  z-index: 1040;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
-.assistente-fab i {
-  font-size: 1.15rem;
-  line-height: 1;
-}
+.assistente-fab i { line-height: 1; }
+/* Label hidden visually but readable by screen reader (l'aria-label è
+   sul tag <a>, è ridondante mostrarlo anche graficamente) */
 .assistente-fab .assistente-fab-label {
-  display: inline;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 .assistente-fab:hover,
 .assistente-fab:focus-visible {
-  background: #001a33;
+  background: var(--pc-primary-dark, #00244d);
   color: #fff;
   text-decoration: none;
   transform: translateY(-2px);
-  box-shadow: 0 6px 18px rgba(0, 51, 102, 0.5), 0 0 0 2px rgba(255,255,255,0.1) inset;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
 }
 .assistente-fab:focus-visible {
-  outline: 3px solid #ffbe2e;
+  outline: 3px solid #ff6600;
   outline-offset: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -4016,21 +4026,14 @@ html.a11y-pause-animations body.home-page .reveal-on-scroll {
   .assistente-fab:focus-visible { transform: none; }
 }
 
-/* Mobile: solo icona (riduce spazio occupato accanto a SOS-112) */
+/* Mobile: stessa convenzione del FAB a11y (50px) */
 @media (max-width: 575.98px) {
   .assistente-fab {
-    bottom: 5rem;
-    left: 1rem;
-    padding: 0.6rem;
-    width: 2.85rem;
-    height: 2.85rem;
-    justify-content: center;
-  }
-  .assistente-fab .assistente-fab-label {
-    display: none;
-  }
-  .assistente-fab i {
-    font-size: 1.4rem;
+    bottom: 5.25rem;        /* sopra a11y-fab (bottom 1.25rem + 50px + 0.875rem gap) */
+    left: 1.25rem;          /* allineato al a11y-fab mobile */
+    width: 50px;
+    height: 50px;
+    font-size: 1.35rem;
   }
 }
 
@@ -4044,6 +4047,6 @@ html.a11y-pause-anim .assistente-fab { transition: none !important; }
 html.a11y-pause-anim .assistente-fab:hover,
 html.a11y-pause-anim .assistente-fab:focus-visible { transform: none !important; }
 /* ==========================================================================
- * fine ASSISTENTE FAB v1.0
+ * fine ASSISTENTE FAB v2.0
  * ==========================================================================
  */

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -3966,58 +3966,54 @@ html.a11y-pause-animations body.home-page .reveal-on-scroll {
  */
 
 /* ==========================================================================
- * ASSISTENTE FAB v2.0 (maggio 2026)
- * Bottone "Aiuto" fisso bottom-left, in coppia visiva sopra il toolbar
- * accessibilità: stessa forma circolare 56px (50px mobile), stesso bordo
- * bianco, stesso blu istituzionale, stesso focus arancione. Click →
- * /assistente/. Il label testuale è nascosto visualmente ma mantenuto
- * per screen reader (l'icona chat-dots + aria-label sono già univoche).
+ * ASSISTENTE FAB v2.1 (maggio 2026)
+ * Bottone "Aiuto" fisso bottom-left.
+ *  - Desktop: pill blu con label "Assistente virtuale" visibile (v1.0,
+ *    invariato — già consolidato graficamente).
+ *  - Mobile (≤575.98px): cerchio dark blue con bordo bianco coordinato
+ *    al FAB accessibilità sottostante (stesso diametro 50px, stesso
+ *    bordo, stesso focus arancione, stessa colonna sinistra). Il label
+ *    è nascosto visivamente ma resta accessibile a screen reader
+ *    (aria-label + sr-only). L'icona chat-dots è univoca.
  * ==========================================================================
  */
 .assistente-fab {
   position: fixed;
-  bottom: 6.25rem;          /* sopra a11y-fab (bottom 2rem + 56px + 0.75rem gap) */
-  left: 2rem;               /* allineato al a11y-fab desktop */
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: var(--pc-primary, #003366);
-  color: #fff;
-  border: 3px solid #fff;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  bottom: 5.5rem;       /* sopra il FAB toolbar a11y (bottom: 1.2rem + h ~3rem + gap) */
+  left: 1.2rem;
+  z-index: 9998;        /* sotto i modal (sos-modal = 10001) ma sopra il contenuto */
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: 1.5rem;
+  gap: 0.4rem;
+  padding: 0.55rem 1rem;
+  background: #003366;  /* blu istituzionale --pc-blue */
+  color: #fff;
+  border-radius: 999px;
+  box-shadow: 0 4px 12px rgba(0, 51, 102, 0.35), 0 0 0 2px rgba(255,255,255,0.1) inset;
   text-decoration: none;
-  cursor: pointer;
-  z-index: 1040;
-  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-}
-.assistente-fab i { line-height: 1; }
-/* Label hidden visually but readable by screen reader (l'aria-label è
-   sul tag <a>, è ridondante mostrarlo anche graficamente) */
-.assistente-fab .assistente-fab-label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-family: inherit;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
   white-space: nowrap;
-  border: 0;
+}
+.assistente-fab i {
+  font-size: 1.15rem;
+  line-height: 1;
+}
+.assistente-fab .assistente-fab-label {
+  display: inline;
 }
 .assistente-fab:hover,
 .assistente-fab:focus-visible {
-  background: var(--pc-primary-dark, #00244d);
+  background: #001a33;
   color: #fff;
   text-decoration: none;
   transform: translateY(-2px);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 6px 18px rgba(0, 51, 102, 0.5), 0 0 0 2px rgba(255,255,255,0.1) inset;
 }
 .assistente-fab:focus-visible {
-  outline: 3px solid #ff6600;
+  outline: 3px solid #ffbe2e;
   outline-offset: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -4026,14 +4022,43 @@ html.a11y-pause-animations body.home-page .reveal-on-scroll {
   .assistente-fab:focus-visible { transform: none; }
 }
 
-/* Mobile: stessa convenzione del FAB a11y (50px) */
+/* Mobile: cerchio coordinato col FAB a11y sottostante (50px, bordo
+   bianco, blu istituzionale, focus arancione). Label nascosto ma
+   accessibile a screen reader via .visually-hidden style. */
 @media (max-width: 575.98px) {
   .assistente-fab {
     bottom: 5.25rem;        /* sopra a11y-fab (bottom 1.25rem + 50px + 0.875rem gap) */
     left: 1.25rem;          /* allineato al a11y-fab mobile */
     width: 50px;
     height: 50px;
+    padding: 0;
+    gap: 0;
+    border: 3px solid #fff;
+    border-radius: 50%;
+    justify-content: center;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  }
+  .assistente-fab i {
     font-size: 1.35rem;
+  }
+  .assistente-fab .assistente-fab-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .assistente-fab:hover,
+  .assistente-fab:focus-visible {
+    background: #00244d;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  }
+  .assistente-fab:focus-visible {
+    outline-color: #ff6600;  /* coerente col focus del FAB a11y */
   }
 }
 
@@ -4047,6 +4072,6 @@ html.a11y-pause-anim .assistente-fab { transition: none !important; }
 html.a11y-pause-anim .assistente-fab:hover,
 html.a11y-pause-anim .assistente-fab:focus-visible { transform: none !important; }
 /* ==========================================================================
- * fine ASSISTENTE FAB v2.0
+ * fine ASSISTENTE FAB v2.1
  * ==========================================================================
  */


### PR DESCRIPTION
## Cosa cambia

Il bottone Assistente virtuale (FAB bottom-left) su **mobile** (≤575.98px) ora è un cerchio dark blue con bordo bianco, in coppia visiva col FAB accessibilità sottostante: stesso diametro 50px, stesso bordo, stesso focus arancione, allineato sulla stessa colonna sinistra.

Su **desktop** la pill blu con label "Assistente virtuale" visibile resta invariata (versione consolidata, non toccata).

## Dettagli

**Mobile (≤575.98px):**
- Cerchio 50px con `border: 3px solid #fff`
- Posizione `bottom: 5.25rem`, `left: 1.25rem` (allineato a `.a11y-fab`)
- Hover/focus background `#00244d`, focus outline `#ff6600`
- Label `Assistente virtuale` nascosto via sr-only style (resta accessibile a screen reader via `aria-label` sul `<a>` + classe `.assistente-fab-label`)

**Desktop (>575.98px):** invariato — pill blu con label visibile.

## Files

- `themes/flavour-pcgenzano/static/css/custom.css` — sezione **ASSISTENTE FAB v2.1** (era v1.0)
- `themes/flavour-pcgenzano/layouts/partials/assistente-fab.html` — commento aggiornato

Nessuna modifica a logica template, JS, accessibilità struttura. Conformità WCAG 2.4.7 (focus visible) e 4.1.2 (name, role, value via aria-label) preservata.


---
_Generated by [Claude Code](https://claude.ai/code/session_016YZkLwjX5dnVnGUmBbd43F)_