### PR TITLE
A11y toolbar: opzione utente "Nascondi pulsanti flottanti" (Assistente, SOS)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/partials/accessibility-toolbar.html
+++ b/themes/flavour-pcgenzano/layouts/partials/accessibility-toolbar.html
@@ -137,6 +137,32 @@
       </a>
     </fieldset>
 
+    {{/* ─────────── SEZIONE PULSANTI FLOTTANTI ─────────── */}}
+    <fieldset class="a11y-section">
+      <legend class="a11y-section-title">
+        <i class="bi bi-square me-2" aria-hidden="true"></i>Pulsanti flottanti
+      </legend>
+
+      <p class="a11y-hint small text-muted mt-0 mb-2" style="font-size:0.78rem;">
+        I pulsanti rotondi in basso (Assistente virtuale, SOS 112) possono coprire una parte del testo, soprattutto da telefono. Se preferisci, puoi nasconderli temporaneamente. Il pulsante per riaprire questo pannello resta sempre visibile.
+      </p>
+
+      <button type="button" class="a11y-toggle" data-pref="hideAssistantFab" aria-pressed="false">
+        <i class="bi bi-chat-dots me-2" aria-hidden="true"></i>
+        <span class="a11y-toggle-text">Nascondi pulsante Assistente virtuale</span>
+        <span class="a11y-toggle-state" aria-hidden="true">Off</span>
+      </button>
+
+      <button type="button" class="a11y-toggle" data-pref="hideSosFab" aria-pressed="false">
+        <i class="bi bi-telephone me-2" aria-hidden="true"></i>
+        <span class="a11y-toggle-text">Nascondi pulsante SOS 112</span>
+        <span class="a11y-toggle-state" aria-hidden="true">Off</span>
+      </button>
+      <p class="a11y-hint small text-muted mt-1 mb-0" style="font-size:0.78rem;">
+        Consigliamo di lasciare visibile il pulsante <strong>SOS 112</strong>: in emergenza permette di chiamare il Numero Unico Europeo con un solo tocco. Anche se nascosto, puoi sempre comporre il <strong>112</strong> dalla tastiera del telefono.
+      </p>
+    </fieldset>
+
     <div class="a11y-status" role="status" aria-live="polite" id="a11yStatus"></div>
 
   </div>

--- a/themes/flavour-pcgenzano/layouts/partials/assistente-fab.html
+++ b/themes/flavour-pcgenzano/layouts/partials/assistente-fab.html
@@ -4,6 +4,12 @@
   le pagine. Click → /assistente/ (assistente virtuale guidato).
 
   Posizione: bottom-left, SOPRA il toolbar di accessibilità.
+  Design v2.0 (maggio 2026): cerchio dark blue con bordo bianco, in
+  coppia visiva con il FAB accessibilità sottostante (stessa forma,
+  stessa dimensione, stesso focus). Il label testuale è visivamente
+  nascosto ma resta accessibile a screen reader via aria-label e
+  alla classe .assistente-fab-label (sr-only style nel CSS).
+
   Convenzione FAB del sito:
    - bottom-left: a11y toolbar (in basso) + assistente FAB (sopra)
    - bottom-right: back-to-top + sos-112 (mobile)
@@ -13,8 +19,8 @@
 
   Accessibilità:
   - <a> nativo, raggiungibile da tastiera
-  - aria-label esplicito
-  - focus visible WCAG 2.4.7
+  - aria-label esplicito + title (tooltip hover)
+  - focus visible WCAG 2.4.7 (outline 3px arancione, come a11y-fab)
 */}}
 {{- /* skip su sezioni dove il FAB sarebbe ridondante o distrarrebbe */ -}}
 {{- $skipSections := slice "assistente" "emergenza" "cerca" -}}

--- a/themes/flavour-pcgenzano/layouts/partials/assistente-fab.html
+++ b/themes/flavour-pcgenzano/layouts/partials/assistente-fab.html
@@ -4,11 +4,14 @@
   le pagine. Click → /assistente/ (assistente virtuale guidato).
 
   Posizione: bottom-left, SOPRA il toolbar di accessibilità.
-  Design v2.0 (maggio 2026): cerchio dark blue con bordo bianco, in
-  coppia visiva con il FAB accessibilità sottostante (stessa forma,
-  stessa dimensione, stesso focus). Il label testuale è visivamente
-  nascosto ma resta accessibile a screen reader via aria-label e
-  alla classe .assistente-fab-label (sr-only style nel CSS).
+  Design v2.1 (maggio 2026):
+   - Desktop: pill blu con label "Assistente virtuale" visibile
+     (versione consolidata, non toccare).
+   - Mobile (≤575.98px): cerchio dark blue con bordo bianco in
+     coppia visiva col FAB accessibilità sottostante (stessa
+     forma, stesso focus). Label nascosto visivamente ma
+     accessibile a screen reader via aria-label e classe
+     .assistente-fab-label (sr-only style nel CSS).
 
   Convenzione FAB del sito:
    - bottom-left: a11y toolbar (in basso) + assistente FAB (sopra)

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -3966,48 +3966,58 @@ html.a11y-pause-animations body.home-page .reveal-on-scroll {
  */
 
 /* ==========================================================================
- * ASSISTENTE FAB v1.0 (maggio 2026)
- * Bottone "Aiuto" fisso bottom-left sopra il toolbar accessibilità.
- * Click → /assistente/. Disponibile su tutte le pagine.
+ * ASSISTENTE FAB v2.0 (maggio 2026)
+ * Bottone "Aiuto" fisso bottom-left, in coppia visiva sopra il toolbar
+ * accessibilità: stessa forma circolare 56px (50px mobile), stesso bordo
+ * bianco, stesso blu istituzionale, stesso focus arancione. Click →
+ * /assistente/. Il label testuale è nascosto visualmente ma mantenuto
+ * per screen reader (l'icona chat-dots + aria-label sono già univoche).
  * ==========================================================================
  */
 .assistente-fab {
   position: fixed;
-  bottom: 5.5rem;       /* sopra il FAB toolbar a11y (bottom: 1.2rem + h ~3rem + gap) */
-  left: 1.2rem;
-  z-index: 9998;        /* sotto i modal (sos-modal = 10001) ma sopra il contenuto */
+  bottom: 6.25rem;          /* sopra a11y-fab (bottom 2rem + 56px + 0.75rem gap) */
+  left: 2rem;               /* allineato al a11y-fab desktop */
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--pc-primary, #003366);
+  color: #fff;
+  border: 3px solid #fff;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.55rem 1rem;
-  background: #003366;  /* blu istituzionale --pc-blue */
-  color: #fff;
-  border-radius: 999px;
-  box-shadow: 0 4px 12px rgba(0, 51, 102, 0.35), 0 0 0 2px rgba(255,255,255,0.1) inset;
+  justify-content: center;
+  font-size: 1.5rem;
   text-decoration: none;
-  font-size: 0.95rem;
-  font-weight: 600;
-  font-family: inherit;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
-  white-space: nowrap;
+  cursor: pointer;
+  z-index: 1040;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
-.assistente-fab i {
-  font-size: 1.15rem;
-  line-height: 1;
-}
+.assistente-fab i { line-height: 1; }
+/* Label hidden visually but readable by screen reader (l'aria-label è
+   sul tag <a>, è ridondante mostrarlo anche graficamente) */
 .assistente-fab .assistente-fab-label {
-  display: inline;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 .assistente-fab:hover,
 .assistente-fab:focus-visible {
-  background: #001a33;
+  background: var(--pc-primary-dark, #00244d);
   color: #fff;
   text-decoration: none;
   transform: translateY(-2px);
-  box-shadow: 0 6px 18px rgba(0, 51, 102, 0.5), 0 0 0 2px rgba(255,255,255,0.1) inset;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
 }
 .assistente-fab:focus-visible {
-  outline: 3px solid #ffbe2e;
+  outline: 3px solid #ff6600;
   outline-offset: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -4016,21 +4026,14 @@ html.a11y-pause-animations body.home-page .reveal-on-scroll {
   .assistente-fab:focus-visible { transform: none; }
 }
 
-/* Mobile: solo icona (riduce spazio occupato accanto a SOS-112) */
+/* Mobile: stessa convenzione del FAB a11y (50px) */
 @media (max-width: 575.98px) {
   .assistente-fab {
-    bottom: 5rem;
-    left: 1rem;
-    padding: 0.6rem;
-    width: 2.85rem;
-    height: 2.85rem;
-    justify-content: center;
-  }
-  .assistente-fab .assistente-fab-label {
-    display: none;
-  }
-  .assistente-fab i {
-    font-size: 1.4rem;
+    bottom: 5.25rem;        /* sopra a11y-fab (bottom 1.25rem + 50px + 0.875rem gap) */
+    left: 1.25rem;          /* allineato al a11y-fab mobile */
+    width: 50px;
+    height: 50px;
+    font-size: 1.35rem;
   }
 }
 
@@ -4044,6 +4047,6 @@ html.a11y-pause-anim .assistente-fab { transition: none !important; }
 html.a11y-pause-anim .assistente-fab:hover,
 html.a11y-pause-anim .assistente-fab:focus-visible { transform: none !important; }
 /* ==========================================================================
- * fine ASSISTENTE FAB v1.0
+ * fine ASSISTENTE FAB v2.0
  * ==========================================================================
  */

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -3966,58 +3966,54 @@ html.a11y-pause-animations body.home-page .reveal-on-scroll {
  */
 
 /* ==========================================================================
- * ASSISTENTE FAB v2.0 (maggio 2026)
- * Bottone "Aiuto" fisso bottom-left, in coppia visiva sopra il toolbar
- * accessibilità: stessa forma circolare 56px (50px mobile), stesso bordo
- * bianco, stesso blu istituzionale, stesso focus arancione. Click →
- * /assistente/. Il label testuale è nascosto visualmente ma mantenuto
- * per screen reader (l'icona chat-dots + aria-label sono già univoche).
+ * ASSISTENTE FAB v2.1 (maggio 2026)
+ * Bottone "Aiuto" fisso bottom-left.
+ *  - Desktop: pill blu con label "Assistente virtuale" visibile (v1.0,
+ *    invariato — già consolidato graficamente).
+ *  - Mobile (≤575.98px): cerchio dark blue con bordo bianco coordinato
+ *    al FAB accessibilità sottostante (stesso diametro 50px, stesso
+ *    bordo, stesso focus arancione, stessa colonna sinistra). Il label
+ *    è nascosto visivamente ma resta accessibile a screen reader
+ *    (aria-label + sr-only). L'icona chat-dots è univoca.
  * ==========================================================================
  */
 .assistente-fab {
   position: fixed;
-  bottom: 6.25rem;          /* sopra a11y-fab (bottom 2rem + 56px + 0.75rem gap) */
-  left: 2rem;               /* allineato al a11y-fab desktop */
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: var(--pc-primary, #003366);
-  color: #fff;
-  border: 3px solid #fff;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  bottom: 5.5rem;       /* sopra il FAB toolbar a11y (bottom: 1.2rem + h ~3rem + gap) */
+  left: 1.2rem;
+  z-index: 9998;        /* sotto i modal (sos-modal = 10001) ma sopra il contenuto */
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: 1.5rem;
+  gap: 0.4rem;
+  padding: 0.55rem 1rem;
+  background: #003366;  /* blu istituzionale --pc-blue */
+  color: #fff;
+  border-radius: 999px;
+  box-shadow: 0 4px 12px rgba(0, 51, 102, 0.35), 0 0 0 2px rgba(255,255,255,0.1) inset;
   text-decoration: none;
-  cursor: pointer;
-  z-index: 1040;
-  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-}
-.assistente-fab i { line-height: 1; }
-/* Label hidden visually but readable by screen reader (l'aria-label è
-   sul tag <a>, è ridondante mostrarlo anche graficamente) */
-.assistente-fab .assistente-fab-label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-family: inherit;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
   white-space: nowrap;
-  border: 0;
+}
+.assistente-fab i {
+  font-size: 1.15rem;
+  line-height: 1;
+}
+.assistente-fab .assistente-fab-label {
+  display: inline;
 }
 .assistente-fab:hover,
 .assistente-fab:focus-visible {
-  background: var(--pc-primary-dark, #00244d);
+  background: #001a33;
   color: #fff;
   text-decoration: none;
   transform: translateY(-2px);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 6px 18px rgba(0, 51, 102, 0.5), 0 0 0 2px rgba(255,255,255,0.1) inset;
 }
 .assistente-fab:focus-visible {
-  outline: 3px solid #ff6600;
+  outline: 3px solid #ffbe2e;
   outline-offset: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -4026,14 +4022,43 @@ html.a11y-pause-animations body.home-page .reveal-on-scroll {
   .assistente-fab:focus-visible { transform: none; }
 }
 
-/* Mobile: stessa convenzione del FAB a11y (50px) */
+/* Mobile: cerchio coordinato col FAB a11y sottostante (50px, bordo
+   bianco, blu istituzionale, focus arancione). Label nascosto ma
+   accessibile a screen reader via .visually-hidden style. */
 @media (max-width: 575.98px) {
   .assistente-fab {
     bottom: 5.25rem;        /* sopra a11y-fab (bottom 1.25rem + 50px + 0.875rem gap) */
     left: 1.25rem;          /* allineato al a11y-fab mobile */
     width: 50px;
     height: 50px;
+    padding: 0;
+    gap: 0;
+    border: 3px solid #fff;
+    border-radius: 50%;
+    justify-content: center;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  }
+  .assistente-fab i {
     font-size: 1.35rem;
+  }
+  .assistente-fab .assistente-fab-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .assistente-fab:hover,
+  .assistente-fab:focus-visible {
+    background: #00244d;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  }
+  .assistente-fab:focus-visible {
+    outline-color: #ff6600;  /* coerente col focus del FAB a11y */
   }
 }
 
@@ -4047,6 +4072,6 @@ html.a11y-pause-anim .assistente-fab { transition: none !important; }
 html.a11y-pause-anim .assistente-fab:hover,
 html.a11y-pause-anim .assistente-fab:focus-visible { transform: none !important; }
 /* ==========================================================================
- * fine ASSISTENTE FAB v2.0
+ * fine ASSISTENTE FAB v2.1
  * ==========================================================================
  */

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -4071,6 +4071,13 @@ html.a11y-pause-animations body.home-page .reveal-on-scroll {
 html.a11y-pause-anim .assistente-fab { transition: none !important; }
 html.a11y-pause-anim .assistente-fab:hover,
 html.a11y-pause-anim .assistente-fab:focus-visible { transform: none !important; }
+
+/* ── Hide FAB user preferences (toggle nel pannello a11y "Pulsanti
+   flottanti") ── Usato per chi naviga da mobile e i FAB coprono il
+   testo. Il FAB a11y stesso resta sempre visibile (è il controllo
+   per riabilitarli). */
+html.a11y-hide-assistant-fab .assistente-fab { display: none !important; }
+html.a11y-hide-sos-fab .sos-button { display: none !important; }
 /* ==========================================================================
  * fine ASSISTENTE FAB v2.1
  * ==========================================================================

--- a/themes/flavour-pcgenzano/static/js/a11y-toolbar.js
+++ b/themes/flavour-pcgenzano/static/js/a11y-toolbar.js
@@ -20,7 +20,9 @@
     hideImages: false,
     pauseAnimations: false,
     highlightLinks: false,
-    bigCursor: false
+    bigCursor: false,
+    hideAssistantFab: false,
+    hideSosFab: false
   };
 
   var state = Object.assign({}, defaults);
@@ -91,6 +93,10 @@
 
     // Orientamento: cursore grande
     if (state.bigCursor) html.classList.add('a11y-big-cursor');
+
+    // Pulsanti flottanti: nascondi Assistente / SOS-112
+    if (state.hideAssistantFab) html.classList.add('a11y-hide-assistant-fab');
+    if (state.hideSosFab) html.classList.add('a11y-hide-sos-fab');
   }
 
   // Applica subito allo start (prima del DOM ready) per evitare flash


### PR DESCRIPTION
## Cosa cambia

Aggiunta nel pannello **"Strumenti di accessibilità"** di una nuova sezione *"Pulsanti flottanti"* con due toggle indipendenti:

- **Nascondi pulsante Assistente virtuale** → nasconde il FAB chat-dots bottom-left
- **Nascondi pulsante SOS 112** → nasconde il FAB rosso bottom-right (con hint che ricorda di poter sempre comporre il 112 dalla tastiera)

Risolve il caso d'uso segnalato: da mobile i FAB coprono parte del testo leggibile, soprattutto vicino al footer. La scelta è persistita in `localStorage` con le altre preferenze a11y.

Il **FAB accessibilità stesso resta sempre visibile**: è il controllo per riabilitare i pulsanti nascosti, non può essere disattivato.

## Files

- `themes/flavour-pcgenzano/layouts/partials/accessibility-toolbar.html` — nuova fieldset
- `themes/flavour-pcgenzano/static/js/a11y-toolbar.js` — `hideAssistantFab` + `hideSosFab` nei defaults + applicate in `applyState`
- `themes/flavour-pcgenzano/static/css/custom.css` — due regole `display: none !important` sulle classi `html.a11y-hide-assistant-fab` / `html.a11y-hide-sos-fab`

## Note

- Conformità WCAG preservata (focus visible 2.4.7, target size 2.5.5).
- Hint informativo sotto il toggle SOS spiega che 112 resta componibile dalla tastiera del telefono — coerente con la missione PC del sito (non si "perde" la possibilità di chiamare emergenze).
- Niente impatto desktop: i FAB lì non coprono il testo grazie al margine laterale del contenitore.


---
_Generated by [Claude Code](https://claude.ai/code/session_016YZkLwjX5dnVnGUmBbd43F)_