### PR TITLE
23 settembre: festa di San Pio nel piano editoriale + articolo annuale

### DIFF
--- a/PIANO-EDITORIALE.md
+++ b/PIANO-EDITORIALE.md
@@ -139,6 +139,7 @@ Ogni data fissa si ripete ogni anno con aggiornamenti minimi. Preparare le bozze
 - **1 settembre** — Ripresa attività del Gruppo dopo la pausa estiva (badge: Comunicazione)
 - **13 settembre** — Giornata mondiale primo soccorso (sabato seconda settimana) (badge: Formazione)
 - **15 settembre** — Inizio scuole: programma kit didattici (badge: Formazione)
+- **23 settembre** — Festa di San Pio da Pietrelcina, patrono dei Volontari di Protezione Civile italiana (memoria liturgica, anniversario della morte 1968). Articolo annuale di ricorrenza con rimando alla pagina istituzionale `/san-pio-da-pietrelcina/` (badge: Volontariato)
 - Fine campagna AIB: bilancio stagione (badge: Aggiornamento)
 - Preparazione autunno: rischio idrogeologico (badge: Prevenzione)
 - **Infiorata di Genzano** se ricade a settembre: sicurezza evento (badge: Attività)

--- a/content/comunicazioni/2026-09-23-prevenzione-incendi-domestici-autunno.md
+++ b/content/comunicazioni/2026-09-23-prevenzione-incendi-domestici-autunno.md
@@ -1,6 +1,6 @@
 ---
 title: "Incendi domestici: la prevenzione prima dell'accensione del riscaldamento"
-date: 2026-09-23
+date: 2026-09-23T00:01:00+02:00
 description: "Stufe, camini, canne fumarie, impianti elettrici: prima di accendere il riscaldamento, controlli semplici evitano incendi domestici."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-09-23-san-pio-patrono-volontari-festa.md
+++ b/content/comunicazioni/2026-09-23-san-pio-patrono-volontari-festa.md
@@ -1,0 +1,47 @@
+---
+title: "23 settembre: la festa di San Pio, patrono dei Volontari di Protezione Civile"
+date: 2026-09-23T00:02:00+02:00
+description: "Oggi la Chiesa cattolica ricorda San Pio da Pietrelcina. Per i Volontari di Protezione Civile italiana è il giorno del patrono: una ricorrenza nata dal basso, con una petizione di 160 associazioni."
+badge: "Volontariato"
+priorita: "normale"
+autore: "Gruppo Comunale Volontari PC Genzano"
+image: ""
+image_alt: ""
+scadenza: ""
+area: "Italia"
+allegati: []
+draft: false
+---
+
+Il **23 settembre** è la **memoria liturgica** di San Pio da Pietrelcina nella Chiesa cattolica e l'anniversario della sua morte, avvenuta a San Giovanni Rotondo nel 1968. Per il **volontariato di Protezione Civile italiano** è anche il giorno del **patrono**.
+
+{{< foto src="/images/san-pio-da-pietrelcina-ritratto.webp"
+         alt="Ritratto fotografico di San Pio da Pietrelcina con il saio cappuccino, sormontato dalla fascia istituzionale blu del Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma"
+         caption="San Pio da Pietrelcina (1887-1968), proclamato patrono dei Volontari della Protezione Civile italiana il 21 febbraio 2004." >}}
+
+## Una ricorrenza nata dal basso
+
+San Pio è patrono dei Volontari di Protezione Civile dal **21 febbraio 2004**, data del decreto della **Congregazione per il Culto Divino e la Disciplina dei Sacramenti**.
+
+La proclamazione non è stata una decisione dall'alto: la richiesta era stata presentata alla **Conferenza Episcopale Italiana** nel settembre 2002 dal Capo del Dipartimento della Protezione Civile, sulla base di una **petizione firmata da circa 160 associazioni di volontariato** che rappresentavano oltre **novemila volontarie e volontari**.
+
+## Perché proprio lui
+
+I tratti della vita di Padre Pio che parlano al volontariato di Protezione Civile sono concreti, non simbolici:
+
+- la fondazione, nel 1956, della **Casa Sollievo della Sofferenza**: un ospedale operativo che ha trasformato la cura ai più fragili in **competenza, organizzazione, struttura** — gli stessi principi che la PC chiede ai propri volontari;
+- una vita di **servizio silenzioso e quotidiano**, fatta di ore in confessionale e in corsia, non di gesti pubblici eccezionali;
+- la **resistenza nella fatica**, lungo cinquant'anni di dolore fisico e incomprensioni;
+- **radici popolari italiane** profonde, che parlano la stessa lingua delle comunità in cui la PC opera.
+
+## Una giornata libera e personale
+
+La partecipazione a iniziative legate al patrono è **sempre libera e personale**. Il volontariato di Protezione Civile è un servizio pubblico, aperto a persone di ogni convinzione religiosa, di ogni orientamento politico, di ogni provenienza. Il patrono è una **figura di riferimento simbolica e culturale**, non un requisito di adesione.
+
+Per chi desidera approfondire — biografia, processo di canonizzazione, testo della **Preghiera del Volontario di Protezione Civile** — abbiamo dedicato a Padre Pio una **pagina istituzionale permanente** sul sito.
+
+→ [Il nostro patrono: San Pio da Pietrelcina](/san-pio-da-pietrelcina/)
+
+## Un pensiero ai volontari
+
+Il 23 settembre è anche un'occasione per ricordare i **volontari e le volontarie** di tutta Italia che nel corso dell'anno hanno servito le proprie comunità — durante un'allerta, un soccorso, una formazione, una serata in radio, un turno notturno in piazza durante un evento. È un mestiere fatto di poche luci e molte ore. A tutti loro, il pensiero del Gruppo Comunale di Genzano di Roma.


### PR DESCRIPTION
## Sommario

Ricorrenza annuale del **23 settembre** (festa di San Pio da Pietrelcina, patrono dei Volontari di PC italiana) inserita nel piano editoriale + articolo annuale calendarizzato per il 23/9/2026.

## File modificati

- **`PIANO-EDITORIALE.md`** — voce 23 settembre nella sezione Settembre (badge Volontariato, rimando alla pagina permanente).
- **`content/comunicazioni/2026-09-23-prevenzione-incendi-domestici-autunno.md`** — `date` da `2026-09-23` a `2026-09-23T00:01:00+02:00` (1° articolo del giorno per ordering Hugo, era già presente con questa data).
- **`content/comunicazioni/2026-09-23-san-pio-patrono-volontari-festa.md`** — nuovo articolo annuale, `date: 2026-09-23T00:02:00+02:00` (ultimo scritto = in cima all'archivio).

## Articolo San Pio — contenuti

Sobrio, istituzionale, AGID:

- Ricorrenza dal basso: petizione di **160 associazioni di volontariato** (~9000 volontari), decreto Congregazione per il Culto Divino del **21/2/2004**.
- 4 motivi della scelta del patrono: Casa Sollievo della Sofferenza (cura competente/organizzata), servizio silenzioso e quotidiano, resistenza nella fatica, radici popolari italiane.
- **Disclaimer di laicità**: partecipazione libera e personale, PC è servizio pubblico aperto a ogni convinzione.
- Rimando alla pagina permanente `/san-pio-da-pietrelcina/` per biografia completa + Preghiera del Volontario.
- Pensiero finale ai volontari di tutta Italia.

## Foto

Riusa `/images/san-pio-da-pietrelcina-ritratto.webp` (1200×1809px WebP, già nel repo dal PR #96 con fascia blu istituzionale + logo + testo PC Genzano). Filename **diverso dallo slug** dell'articolo → `genera-cover.py` non sovrascriverà la foto.

Banner cover dell'articolo: resta `image: ""` → `auto-cover-mancanti.py` genererà al deploy la cover tipografica blu col titolo (regola "BANNER COL TITOLO INTOCCABILE" CLAUDE.md punto 9).

## Date format multi-articolo

Regola CLAUDE.md punto 1: 2 articoli stesso giorno → orari crescenti. Hugo applica `Date desc` come ordering primario; senza orari distinti userebbe l'ordine alfabetico filename come tie-break. Schema applicato:

| Articolo | Data |
|---|---|
| Prevenzione incendi domestici (1° scritto) | `2026-09-23T00:01:00+02:00` |
| San Pio festa patrono (2° scritto, in cima) | `2026-09-23T00:02:00+02:00` |

## Pubblicazione automatica

L'articolo ha `draft: false` + `date` futura (23/9/2026). Verrà pubblicato automaticamente il giorno della festa dal workflow `pubblica-programmata.yml` (giornaliero 06:00 UTC).

## Test plan

- [x] YAML frontmatter validato su entrambi gli articoli
- [x] Foto referenziata esiste fisicamente in `static/images/`
- [x] Filename foto ≠ slug articolo (no sovrascrittura cover)
- [x] Voce piano editoriale coerente con altre ricorrenze del mese
- [ ] Hugo build pulito (verifica post-merge in CI via `validate-pr.yml`)
- [ ] Auto-pubblicazione il 23/9/2026 06:00 UTC

https://claude.ai/code/session_016a1yEe1vPcfjuoEroAc9kV

---
_Generated by [Claude Code](https://claude.ai/code/session_016a1yEe1vPcfjuoEroAc9kV)_