### PR TITLE
Invito iscrizione canali social: Telegram in primo piano

### DIFF
--- a/themes/flavour-pcgenzano/layouts/_default/single.html
+++ b/themes/flavour-pcgenzano/layouts/_default/single.html
@@ -155,6 +155,7 @@
       {{ if eq .Section "comunicazioni" }}
       {{ partial "articoli-correlati.html" . }}
       {{ partial "articolo-navigazione.html" . }}
+      {{ partial "iscriviti-canali.html" . }}
       <hr class="mt-4">
       <a href="{{ "comunicazioni/" | relURL }}" class="notizia-link"><i class="bi bi-arrow-left me-1" aria-hidden="true"></i> Torna a tutte le comunicazioni</a>
       {{ end }}

--- a/themes/flavour-pcgenzano/layouts/comunicazioni/list.html
+++ b/themes/flavour-pcgenzano/layouts/comunicazioni/list.html
@@ -115,52 +115,7 @@
         <i class="bi bi-info-circle" aria-hidden="true"></i> Nessun articolo in questa categoria.
       </p>
 
-      <section class="canali-social-block mt-5 pt-4" aria-labelledby="seguici-social">
-        <h2 id="seguici-social" class="h4 mb-3"><i class="bi bi-broadcast" aria-hidden="true"></i> Seguici anche sui canali social</h2>
-        <p class="mb-4">Resta in contatto con il Gruppo anche sui canali ufficiali per avvisi rapidi, foto delle attività sul campo e comunicazioni in tempo reale.</p>
-        <div class="row g-3">
-          <div class="col-md-6 col-lg-3">
-            <div class="card shadow-sm h-100 text-center">
-              <div class="card-body p-3">
-                <i class="bi bi-facebook fs-1 text-primary mb-2 d-block" aria-hidden="true"></i>
-                <h3 class="h6">Facebook</h3>
-                <p class="small mb-3">Avvisi, notizie e resoconti dettagliati delle attività.</p>
-                <a href="https://www.facebook.com/protezionecivilegenzanodiroma" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-primary">Vai a Facebook</a>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-3">
-            <div class="card shadow-sm h-100 text-center">
-              <div class="card-body p-3">
-                <i class="bi bi-instagram fs-1 text-danger mb-2 d-block" aria-hidden="true"></i>
-                <h3 class="h6">Instagram</h3>
-                <p class="small mb-3">Storie e post dalle attività sul campo.</p>
-                <a href="https://www.instagram.com/protezionecivilegenzano/" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-danger">Vai a Instagram</a>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-3">
-            <div class="card shadow-sm h-100 text-center">
-              <div class="card-body p-3">
-                <i class="bi bi-twitter-x fs-1 mb-2 d-block" aria-hidden="true"></i>
-                <h3 class="h6">X (Twitter)</h3>
-                <p class="small mb-3">Aggiornamenti rapidi e allerte in tempo reale.</p>
-                <a href="https://x.com/alfagenzano" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-dark">Vai a X</a>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-3">
-            <div class="card shadow-sm h-100 text-center">
-              <div class="card-body p-3">
-                <i class="bi bi-telegram fs-1 text-info mb-2 d-block" aria-hidden="true"></i>
-                <h3 class="h6">Telegram</h3>
-                <p class="small mb-3">Notifiche push delle comunicazioni più importanti.</p>
-                <a href="https://t.me/pcalfagenzano" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-info">Vai a Telegram</a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
+      {{ partial "iscriviti-canali.html" . }}
     </div>
 
     <aside class="col-lg-4" aria-label="Archivio e categorie">

--- a/themes/flavour-pcgenzano/layouts/partials/iscriviti-canali.html
+++ b/themes/flavour-pcgenzano/layouts/partials/iscriviti-canali.html
@@ -1,0 +1,54 @@
+{{/* Invito a iscriversi ai canali social del Gruppo Comunale.
+     Telegram in primo piano: invia notifiche automatiche al cambio di livello
+     di allerta meteo e in caso di comunicazioni di emergenza sul territorio.
+
+     Pilotato da data/social_links.yaml per gli URL.
+     Usato in: comunicazioni/list.html, _default/single.html (per /comunicazioni/). */}}
+{{ $social := .Site.Data.social_links }}
+{{ $telegramUrl := "https://t.me/pcalfagenzano" }}
+{{ if $social }}
+  {{ range $social.canali }}{{ if eq .nome "Telegram" }}{{ $telegramUrl = .url }}{{ end }}{{ end }}
+{{ end }}
+<section class="canali-social-block iscriviti-canali mt-5 pt-4" aria-labelledby="iscriviti-canali-heading">
+  <h2 id="iscriviti-canali-heading" class="h4 mb-3">
+    <i class="bi bi-broadcast" aria-hidden="true"></i> Resta aggiornato sulle allerte
+  </h2>
+
+  {{/* Chiamata principale: Telegram */}}
+  <div class="card border-info iscriviti-telegram mb-3">
+    <div class="card-body p-4">
+      <div class="d-flex flex-column flex-md-row align-items-md-center gap-3">
+        <div class="iscriviti-telegram-icon flex-shrink-0" aria-hidden="true">
+          <i class="bi bi-telegram"></i>
+        </div>
+        <div class="flex-grow-1">
+          <h3 class="h5 mb-2">Iscriviti al canale Telegram</h3>
+          <p class="mb-2">Ricevi sul telefono una notifica automatica quando cambia il <strong>livello di allerta meteo</strong> per Genzano di Roma e — augurandoci di non doverle mai inviare — le <strong>comunicazioni di emergenza</strong> sul territorio.</p>
+          <p class="small text-muted mb-0">Niente spam: solo cambiamenti significativi dello stato. L'iscrizione è anonima e puoi disiscriverti in qualsiasi momento dal canale stesso.</p>
+        </div>
+        <div class="text-md-end flex-shrink-0">
+          <a href="{{ $telegramUrl }}" target="_blank" rel="noopener noreferrer" class="btn btn-info text-white" aria-label="Iscriviti al canale Telegram del Gruppo Comunale (si apre in una nuova finestra)">
+            <i class="bi bi-telegram me-1" aria-hidden="true"></i> Iscriviti al canale
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{/* Altri canali, in fila compatta */}}
+  <p class="mb-2 small text-muted">Ci trovi anche su:</p>
+  <div class="d-flex flex-wrap gap-2 mb-2">
+    {{ if $social }}
+    {{ range $social.canali }}
+    {{ if ne .nome "Telegram" }}
+    <a href="{{ .url }}" target="_blank" rel="noopener noreferrer" class="btn btn-outline-secondary btn-sm" aria-label="{{ .aria_label }} — apri in una nuova finestra">
+      <i class="bi {{ .icona }} me-1" aria-hidden="true"></i> {{ .nome }}
+    </a>
+    {{ end }}
+    {{ end }}
+    {{ end }}
+  </div>
+  <p class="small text-muted mb-0">
+    Modalità di pubblicazione e tempi di risposta nella <a href="{{ "social-media-policy/" | relURL }}">Social Media Policy</a>.
+  </p>
+</section>

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -1572,7 +1572,7 @@ article:not(.card) .galleria img {
     display: none;
   }
 }
-/* CANALI SOCIAL BLOCK — fondo /comunicazioni/ */
+/* CANALI SOCIAL BLOCK — fondo /comunicazioni/ + invito iscrizione articoli */
 .canali-social-block {
   border-top: 1px solid #e5e7eb;
 }
@@ -1582,6 +1582,43 @@ article:not(.card) .galleria img {
 .canali-social-block h2 .bi {
   color: #003366;
   margin-right: 0.35rem;
+}
+
+/* ISCRIVITI CANALI v1.0 — card Telegram in evidenza
+   Usato dal partial iscriviti-canali.html (fine articolo + list comunicazioni).
+   Telegram è in primo piano per le notifiche automatiche di allerta meteo. */
+.iscriviti-canali .iscriviti-telegram {
+  background: linear-gradient(135deg, #ecfaff 0%, #f4f7fb 100%);
+}
+.iscriviti-canali .iscriviti-telegram-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: #0088cc;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  line-height: 1;
+}
+.iscriviti-canali .iscriviti-telegram h3 {
+  color: #003366;
+  font-weight: 700;
+}
+.iscriviti-canali .btn-info {
+  background-color: #0088cc;
+  border-color: #0088cc;
+}
+.iscriviti-canali .btn-info:hover,
+.iscriviti-canali .btn-info:focus {
+  background-color: #006da3;
+  border-color: #006da3;
+}
+
+/* In stampa: niente sfondo gradiente, niente bottoni colorati */
+@media print {
+  .iscriviti-canali { display: none; }
 }
 
 @media (max-width: 991.98px) {


### PR DESCRIPTION
## Cosa cambia

Aggiunge un invito esplicito a iscriversi ai canali social del Gruppo, con il **canale Telegram in primo piano** per il valore operativo: notifiche automatiche al cambio del livello di allerta meteo e — augurandoci di non doverle mai inviare — le comunicazioni di emergenza per il territorio di Genzano di Roma.

## Dove appare

- **A fine di ogni articolo `/comunicazioni/`** (~290 articoli): dopo articoli correlati e navigazione, prima del link "Torna a tutte le comunicazioni". È il momento di engagement massimo per chi ha appena finito di leggere un'allerta o un aggiornamento.
- **Sulla list `/comunicazioni/`**: sostituito il vecchio blocco a 4 card paritarie con la chiamata al nuovo partial → messaggio Telegram-first coerente list ↔ singolo articolo.

## File modificati

- ✨ `themes/flavour-pcgenzano/layouts/partials/iscriviti-canali.html` (nuovo)
- `themes/flavour-pcgenzano/layouts/_default/single.html` — include il partial per la sezione `/comunicazioni/`
- `themes/flavour-pcgenzano/layouts/comunicazioni/list.html` — usa il partial al posto del blocco inline
- `themes/flavour-pcgenzano/static/css/custom.css` — sezione "ISCRIVITI CANALI v1.0" (gradiente azzurrino, icona Telegram circolare 64px, hidden in stampa)

## Coerenza con le rules

- URL Telegram letto da `data/social_links.yaml` (singola fonte di verità).
- `target="_blank" rel="noopener noreferrer"` + `aria-label` esplicito (regola 03 — accessibilità link esterni).
- `relURL` per il link Social Media Policy (compatibilità Aruba/GitHub Pages).
- `@media print` nasconde la sezione (regola stampa CLAUDE.md punto 10).
- Niente conteggi inventario, niente dati fittizi, copy AGID-compliant (frasi brevi, voce attiva, "tu").

## Test plan

- [ ] Build Hugo pulita post-merge (verifica `deploy.yml`)
- [ ] Smoke test post-deploy: la CTA Telegram appare a fine di un articolo random su `/comunicazioni/`
- [ ] Smoke test post-deploy: la list `/comunicazioni/` mostra il nuovo blocco al posto delle 4 card
- [ ] Stampa di un articolo non include la sezione (regola stampa)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY6Corg6hNEMaP8cxqtZnC)_