### PR TITLE
Audit ChatGPT: fix 4 criticità testuali puntuali (C.O.I., facile-da-leggere, AM)

### DIFF
--- a/content/allerte-meteo/_index.md
+++ b/content/allerte-meteo/_index.md
@@ -75,10 +75,10 @@ Mosaico radar nazionale del **Dipartimento della Protezione Civile**, aggiornato
 
 ## Previsione meteo per Genzano di Roma — Aeronautica Militare
 
-Previsione ufficiale emessa dall'**Aeronautica Militare — Servizio Meteorologico**. È la previsione meteorologica istituzionale italiana: accurata, aggiornata, scientificamente autorevole, pensata per il cittadino.
+Consulta la previsione del **Servizio Meteorologico dell'Aeronautica Militare** per Genzano di Roma. È la previsione meteorologica del Servizio Meteorologico Nazionale italiano.
 
-<div class="alert alert-success" role="note">
-<p class="mb-0"><i class="bi bi-patch-check-fill me-2" aria-hidden="true"></i><strong>Fonte istituzionale italiana:</strong> l'Aeronautica Militare è l'ente ufficiale per il Servizio Meteorologico Nazionale. Le previsioni qui mostrate sono quelle ufficiali italiane.</p>
+<div class="alert alert-light" role="note">
+<p class="mb-0"><i class="bi bi-patch-check-fill me-2" aria-hidden="true"></i><strong>Fonte istituzionale:</strong> l'Aeronautica Militare gestisce il Servizio Meteorologico Nazionale italiano.</p>
 </div>
 
 {{< external-widget

--- a/content/facile-da-leggere/_index.md
+++ b/content/facile-da-leggere/_index.md
@@ -157,7 +157,7 @@ sitemap:
 <ul class="facile-elenco no">
 <li>Non andare in cantina</li>
 <li>Non passare nei sottopassaggi</li>
-<li>Non bere l'acqua del rubinetto</li>
+<li>Non bere l'acqua del rubinetto se le autorità dicono che non è sicura</li>
 </ul>
 </div>
 

--- a/static/app-shared/site-chrome.js
+++ b/static/app-shared/site-chrome.js
@@ -170,7 +170,7 @@
               '<h2 class="h4 text-white">Protezione Civile</h2>' +
               '<p class="text-white">Gruppo Comunale Volontari di Genzano di Roma</p>' +
               '<p style="color:rgba(255,255,255,0.85);"><strong>Sede:</strong> Via Sicilia, 13-15 - 00045 Genzano Di Roma (RM)<br><strong>Telefono:</strong> <a href="tel:+39069362600" class="text-white fw-bold">+39 06 9362600</a><br><strong>Email:</strong> <a href="mailto:segreteria@protezionecivilegenzano.it" class="text-white fw-bold">segreteria@protezionecivilegenzano.it</a></p>' +
-              '<p class="small" style="color:rgba(255,255,255,0.75);">15&deg; C.O.I. Prov. di Roma &mdash; Registro Regionale P.C. n.184<br>Iscritta al RUNTS sez. &laquo;Altri Enti del Terzo Settore&raquo; con determina n. G14230 del 28/10/2024<br>Aderente al Coordinamento FEPIVOL</p>' +
+              '<p class="small" style="color:rgba(255,255,255,0.75);">14&deg; C.O.I. Prov. di Roma &mdash; Registro Regionale P.C. n.184<br>Iscritta al RUNTS sez. &laquo;Altri Enti del Terzo Settore&raquo; con determina n. G14230 del 28/10/2024<br>Aderente al Coordinamento FEPIVOL</p>' +
             '</div>' +
             '<div class="col-lg-4 col-md-4 pb-2">' +
               '<h2 class="h4 text-white">Servizi</h2>' +

--- a/themes/flavour-pcgenzano/layouts/assistente/list.html
+++ b/themes/flavour-pcgenzano/layouts/assistente/list.html
@@ -562,7 +562,7 @@
     info_volontariato_chi: {
       kind: 'answer',
       title: 'Chi è il Gruppo Comunale di Genzano',
-      body: ['Il Gruppo Comunale di Volontari di Protezione Civile di Genzano di Roma è iscritto al COI di Roma (15° Centro Operativo Intercomunale) e opera sul territorio dei Castelli Romani con attività di prevenzione, formazione e intervento in emergenza.'],
+      body: ['Il Gruppo Comunale di Volontari di Protezione Civile di Genzano di Roma fa parte del 14° Centro Operativo Intercomunale (COI) della Provincia di Roma — Castelli Romani Sud, e opera sul territorio dei Castelli Romani con attività di prevenzione, formazione e intervento in emergenza.'],
       links: [
         { text: 'Chi siamo (storia, sedi, settori)', url: '/chi-siamo/' },
         { text: 'Comunicazioni recenti', url: '/comunicazioni/' }


### PR DESCRIPTION
## Origine

Audit esterno ChatGPT del 6 maggio 2026 sul sito. Verificate 4 criticità testuali puntuali, tutte confermate nel repo. Sistemate qui.

## Modifiche (4 file, 6 righe)

### 1) C.O.I. coerente "14°" ovunque

Erano residui stantii con `15°` in:
- `themes/flavour-pcgenzano/layouts/assistente/list.html:565` — body dell'assistente virtuale
- `static/app-shared/site-chrome.js:173` — footer di ~50 pagine statiche (Giochi, Schede stampabili, Abili a Proteggere, ecc.)

Il valore canonico è `14°` in `hugo.toml`, `data/glossario.yaml`, `content/glossario/_index.md`, `content/piano-emergenza/_index.md`. Allineamento completato.

### 2) Facile da leggere — softening "non bere l'acqua del rubinetto"

`content/facile-da-leggere/_index.md:160` — aggiunta condizione *"se le autorità dicono che non è sicura"*. Evita allarmismo non necessario senza perdere semplicità per L2/anziani/bambini. Coerente con il resto del sito (`rischio-idrogeologico.md`, `kit-scuola-primaria.md`, ecc.) che già usavano questa formulazione.

### 3) Allerte Meteo — rimosso linguaggio promozionale Aeronautica Militare

`content/allerte-meteo/_index.md:78` — rimosso *"accurata, aggiornata, scientificamente autorevole, pensata per il cittadino"*. Violava `01-governance-pa.md` § "Divieti assoluti" (no linguaggio enfatico/promozionale per la PA). Sostituito con formulazione sobria istituzionale.

## NON incluso (decisione utente, non bug)

- **activepager.com link** — `aria-label` già accessibile, ma manca segnale visivo per vedenti. Decisione di design.
- Riprogetto homepage, ricerca globale, card scuola/formazione, CTA generiche — scelte UX maggiori da discutere a parte.

## Test

- JS validato: `node -e "new Function(fs.readFileSync('static/app-shared/site-chrome.js'))"` OK
- Grep di residui `15°.*COI` su tutto il repo: 0 occorrenze
- Hugo build locale: non disponibile in ambiente CI agent, validato a mano
- I cambi sono testuali surgici (1-2 righe per file)

## Test plan post-merge

- [ ] `deploy.yml` parte e finisce in verde (~2-3 min)
- [ ] Footer pagine statiche (es. `/giochi/`, `/abili-a-proteggere/`) mostra `14° C.O.I.`
- [ ] `/assistente/` → "Chi siamo" → testo dice `14° Centro Operativo Intercomunale`
- [ ] `/facile-da-leggere/` mostra la frase aggiornata sull'acqua
- [ ] `/allerte-meteo/` mostra il testo Aeronautica Militare sobrio

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbbrfCCggdk5i17pzgnWVF)_