### PR TITLE
Schede kit bambini: rimuovi riferimenti "vedi scheda NN"

### DIFF
--- a/static/formazione/kit-calamita-bambini/67-coperta-del-sonno.html
+++ b/static/formazione/kit-calamita-bambini/67-coperta-del-sonno.html
@@ -63,7 +63,7 @@
       <div class="routine-step"><div class="routine-num">2</div><div class="routine-testo">Il mio peluche o oggetto di conforto</div></div>
       <div class="routine-step"><div class="routine-num">3</div><div class="routine-testo">Una storia letta da un adulto</div></div>
       <div class="routine-step"><div class="routine-num">4</div><div class="routine-testo">Una canzone calma o suoni della natura</div></div>
-      <div class="routine-step"><div class="routine-num">5</div><div class="routine-testo">3 respiri lenti con la pancia (vedi scheda 57)</div></div>
+      <div class="routine-step"><div class="routine-num">5</div><div class="routine-testo">3 respiri lenti con la pancia (vedi la scheda sulla respirazione della pancia)</div></div>
     </div>
     <div class="nota-incubi">
       🌙 <strong>Se ti svegli per un brutto sogno</strong>: accendi la luce piccola, bevi un sorso d'acqua, abbraccia il tuo oggetto di conforto, fai 3 respiri lenti. Se ti spaventa molto, chiama un adulto vicino: non disturbi, è normale chiedere aiuto la notte.

--- a/static/formazione/kit-calamita-bambini/68-coping-cards.html
+++ b/static/formazione/kit-calamita-bambini/68-coping-cards.html
@@ -27,12 +27,12 @@
   <div class="scheda-istruzione">🃏 <strong>Quando ti senti sopraffatto, scegli una carta</strong>. Ritagliale, mettile in tasca o in un sacchetto, pesca quando serve. Funzionano davvero: provale anche quando stai bene.</div>
   <section class="scheda-attivita">
     <div class="carte-grid">
-      <div class="carta"><div class="carta-icon">1</div><div><span class="carta-titolo">Respira</span><span class="carta-testo">Inspira 4 secondi, trattieni 4, espira 6. Ripeti 3 volte (vedi scheda 57).</span></div></div>
+      <div class="carta"><div class="carta-icon">1</div><div><span class="carta-titolo">Respira</span><span class="carta-testo">Inspira 4 secondi, trattieni 4, espira 6. Ripeti 3 volte (vedi la scheda sulla respirazione della pancia).</span></div></div>
       <div class="carta"><div class="carta-icon">2</div><div><span class="carta-titolo">Parla</span><span class="carta-testo">Cerca un adulto di fiducia. Digli come ti senti, anche poche parole bastano.</span></div></div>
       <div class="carta"><div class="carta-icon">3</div><div><span class="carta-titolo">Muoviti</span><span class="carta-testo">Cammina, salta, corri sul posto, balla per 2 minuti. Il corpo libera la tensione.</span></div></div>
       <div class="carta"><div class="carta-icon">4</div><div><span class="carta-titolo">Disegna</span><span class="carta-testo">Prendi carta e matita. Disegna ciò che senti, anche se è solo un groviglio.</span></div></div>
       <div class="carta"><div class="carta-icon">5</div><div><span class="carta-titolo">Bevi</span><span class="carta-testo">Un bicchiere d'acqua a piccoli sorsi. Aiuta il corpo a calmarsi.</span></div></div>
-      <div class="carta"><div class="carta-icon">6</div><div><span class="carta-titolo">Senti</span><span class="carta-testo">Cerca con i sensi: 5 cose che vedi, 4 che tocchi (vedi scheda 58).</span></div></div>
+      <div class="carta"><div class="carta-icon">6</div><div><span class="carta-titolo">Senti</span><span class="carta-testo">Cerca con i sensi: 5 cose che vedi, 4 che tocchi (vedi la scheda del gioco dei sensi).</span></div></div>
       <div class="carta"><div class="carta-icon">7</div><div><span class="carta-titolo">Abbraccia</span><span class="carta-testo">Stringi a te il tuo peluche, una coperta o una persona cara, se c'è.</span></div></div>
       <div class="carta"><div class="carta-icon">8</div><div><span class="carta-titolo">Aspetta</span><span class="carta-testo">L'emozione forte passa, sempre. Conta fino a 60 piano: a volte basta.</span></div></div>
     </div>

--- a/static/formazione/kit-calamita-bambini/74-emozioni-grandi.html
+++ b/static/formazione/kit-calamita-bambini/74-emozioni-grandi.html
@@ -85,7 +85,7 @@
       </div>
     </div>
     <div class="nota">
-      💡 <strong>Tutte le emozioni sono giuste</strong>. Anche le emozioni grandi e brutte fanno parte di te. Quando senti un'emozione grande, prova a respirare con la pancia (vedi scheda 57) e a parlarne con un adulto di fiducia.
+      💡 <strong>Tutte le emozioni sono giuste</strong>. Anche le emozioni grandi e brutte fanno parte di te. Quando senti un'emozione grande, prova a respirare con la pancia (vedi la scheda sulla respirazione) e a parlarne con un adulto di fiducia.
     </div>
   </section>
   <footer class="scheda-footer">


### PR DESCRIPTION
## Sintesi

Rimuove riferimenti numerici "vedi scheda NN" dalle schede del kit calamità bambini, sostituendoli con riferimenti descrittivi.

## Cosa cambia (3 file, 4 sostituzioni)

- `67-coperta-del-sonno.html` — "vedi scheda 57" → "vedi la scheda sulla respirazione della pancia"
- `68-coping-cards.html` — 2 occorrenze, simili
- `74-emozioni-grandi.html` — "vedi scheda 57" → "vedi la scheda sulla respirazione"

## Perché

Conformità alla regola **CLAUDE.md punto 16** "niente conteggi inventario": i numeri delle schede possono cambiare nel tempo (rinumerazioni, rimozioni, nuove inserzioni) ma le descrizioni tematiche restano stabili.

https://claude.ai/code/session_01XvSRPbGtjPgAyRuzPvUiR8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvSRPbGtjPgAyRuzPvUiR8)_