### PR TITLE
Schede kit bambini 48-80: fix layout sfalsato in stampa

### DIFF
--- a/static/formazione/kit-calamita-bambini/48-codici-colore-allerta.html
+++ b/static/formazione/kit-calamita-bambini/48-codici-colore-allerta.html
@@ -13,7 +13,7 @@
   .livello-nome{padding:2mm 4mm;font-weight:700;font-size:13pt;color:#003366;border-right:1.5px solid #1a1a1a;height:100%;display:flex;align-items:center}
   .livello-cosa{padding:2mm 4mm;font-size:11pt;line-height:1.3}
   .colora-qui{border:2px dashed #1a1a1a;background:#fff;color:#666;font-style:italic;font-size:10pt}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/49-chiamata-112-copione.html
+++ b/static/formazione/kit-calamita-bambini/49-chiamata-112-copione.html
@@ -11,7 +11,7 @@
   .battuta-line{border-bottom:1.5px solid #1a1a1a;height:8mm;margin-top:1mm}
   .nota-importante{border-left:5px solid #c1121f;background:#fff5f5;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:4mm}
   .esempio-box{background:#fff;border:1.5px dashed #1a1a1a;border-radius:4px;padding:3mm;margin-top:2mm;font-size:11pt;line-height:1.4;font-style:italic;color:#444}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/50-zainetto-emergenza.html
+++ b/static/formazione/kit-calamita-bambini/50-zainetto-emergenza.html
@@ -14,7 +14,7 @@
   .disegno-area{border:2px dashed #1a1a1a;border-radius:6px;padding:4mm;display:flex;flex-direction:column}
   .disegno-area h3{margin:0 0 2mm 0;font-size:13pt;color:#003366}
   .disegno-spazio{flex:1;min-height:90mm;background:repeating-linear-gradient(45deg,transparent 0,transparent 8mm,#f4f7fb 8mm,#f4f7fb 9mm);border:1px solid #ccc;border-radius:3px}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/51-tre-adulti-fiducia.html
+++ b/static/formazione/kit-calamita-bambini/51-tre-adulti-fiducia.html
@@ -13,7 +13,7 @@
   .campo-line{border-bottom:1.5px solid #1a1a1a;height:7mm}
   .campo-line.tall{height:14mm}
   .disegno-mini{flex:1;min-height:30mm;border:1.5px dashed #1a1a1a;border-radius:4px;background:#fff;display:flex;align-items:flex-end;justify-content:center;font-size:9pt;color:#888;font-style:italic;padding:1mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/52-terremoto-4-mosse.html
+++ b/static/formazione/kit-calamita-bambini/52-terremoto-4-mosse.html
@@ -16,7 +16,7 @@
   .g{fill:#f7f7f7;stroke:#1a1a1a;stroke-width:2}
   .head{fill:#003366}
   .nota-non-fare{border-left:5px solid #c1121f;background:#fff5f5;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:4mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/53-pregrafismo-identita.html
+++ b/static/formazione/kit-calamita-bambini/53-pregrafismo-identita.html
@@ -10,7 +10,7 @@
   .riga-scrittura{border-bottom:2px solid #1a1a1a;height:11mm;margin-bottom:2mm;display:flex;align-items:flex-end;padding:0 3mm 1mm 3mm;font-size:24pt;color:#bbb;letter-spacing:2mm;font-weight:600}
   .riga-scrittura.vuota{color:transparent}
   .nota-fasce{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/54-cerchia-pericoli-campo.html
+++ b/static/formazione/kit-calamita-bambini/54-cerchia-pericoli-campo.html
@@ -15,7 +15,7 @@
   .s{fill:none;stroke:#1a1a1a;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
   .g{fill:#f7f7f7;stroke:#1a1a1a;stroke-width:1.8}
   .testo-svg{font-family:'URW Gothic L',sans-serif;font-size:7px;font-weight:700;fill:#1a1a1a;text-anchor:middle}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/55-termometro-emotivo.html
+++ b/static/formazione/kit-calamita-bambini/55-termometro-emotivo.html
@@ -14,7 +14,7 @@
   .istruzioni-lato p{margin:0;font-size:11.5pt;line-height:1.4}
   .scrittura-line{border-bottom:1.5px solid #1a1a1a;height:8mm;margin-top:2mm}
   .istruzioni-lato .domanda{border:2px dashed #1a1a1a;border-radius:6px;padding:3mm;background:#fff}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/56-mano-della-calma.html
+++ b/static/formazione/kit-calamita-bambini/56-mano-della-calma.html
@@ -15,7 +15,7 @@
   .dito-testo{font-size:10.5pt;line-height:1.35}
   .s{fill:none;stroke:#1a1a1a;stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
   .g{fill:#fff;stroke:#1a1a1a;stroke-width:2}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/57-respirazione-pancia.html
+++ b/static/formazione/kit-calamita-bambini/57-respirazione-pancia.html
@@ -16,7 +16,7 @@
   .g{fill:#f7f7f7;stroke:#1a1a1a;stroke-width:2}
   .pancia-piena{fill:#bcd2ea}
   .nota-conta{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:4mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/58-grounding-5-4-3-2-1.html
+++ b/static/formazione/kit-calamita-bambini/58-grounding-5-4-3-2-1.html
@@ -13,7 +13,7 @@
   .senso-content .domanda{font-size:11pt;line-height:1.35;margin:0 0 2mm 0}
   .righe{display:flex;flex-direction:column;gap:2mm}
   .riga{border-bottom:1.5px solid #1a1a1a;height:6mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/59-posto-sicuro.html
+++ b/static/formazione/kit-calamita-bambini/59-posto-sicuro.html
@@ -14,7 +14,7 @@
   .disegno-grande{border:2.5px solid #003366;border-radius:8px;background:#fff;padding:4mm;display:flex;flex-direction:column;min-height:130mm}
   .disegno-grande h3{margin:0 0 2mm 0;font-size:13pt;color:#003366}
   .disegno-spazio{flex:1;background:repeating-linear-gradient(90deg,transparent 0,transparent 10mm,#f4f7fb 10mm,#f4f7fb 11mm);border:1px dashed #ccc;border-radius:3px;display:flex;align-items:flex-end;justify-content:center;font-size:10pt;color:#888;font-style:italic;padding:2mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/60-e-normale-provare-questo.html
+++ b/static/formazione/kit-calamita-bambini/60-e-normale-provare-questo.html
@@ -13,7 +13,7 @@
   .nota-rassicurante{border:2.5px solid #003366;border-radius:8px;background:#f4f7fb;padding:4mm;font-size:11pt;line-height:1.4;margin-top:4mm}
   .nota-rassicurante strong{color:#003366}
   .quando-aiuto{border-left:5px solid #c1121f;background:#fff5f5;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/61-cosa-mi-serve-adesso.html
+++ b/static/formazione/kit-calamita-bambini/61-cosa-mi-serve-adesso.html
@@ -14,7 +14,7 @@
   .scrivi-altro{border:2px dashed #1a1a1a;border-radius:6px;padding:3mm;background:#fff;margin-top:3mm}
   .scrivi-altro h3{margin:0 0 2mm 0;font-size:12pt;color:#003366}
   .riga{border-bottom:1.5px solid #1a1a1a;height:8mm;margin-top:1.5mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/62-mappa-legami-famiglia.html
+++ b/static/formazione/kit-calamita-bambini/62-mappa-legami-famiglia.html
@@ -17,7 +17,7 @@
   .cerchio-tu{fill:#003366}
   .testo-svg{font-family:'URW Gothic L',sans-serif;font-size:9px;font-weight:700;fill:#1a1a1a;text-anchor:middle}
   .testo-bianco{fill:#fff}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/63-oggetti-conforto.html
+++ b/static/formazione/kit-calamita-bambini/63-oggetti-conforto.html
@@ -12,7 +12,7 @@
   .nome-line{border-bottom:1.5px solid #1a1a1a;height:7mm}
   .nome-label{font-size:10pt;color:#003366;font-weight:700;margin-bottom:1mm}
   .perche-line{border-bottom:1px dotted #999;height:5mm;margin-top:1.5mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/64-mappa-del-corpo.html
+++ b/static/formazione/kit-calamita-bambini/64-mappa-del-corpo.html
@@ -14,7 +14,7 @@
   .colore-testo{font-size:11pt;line-height:1.35}
   .colore-testo strong{display:block;color:#003366;font-size:12pt;margin-bottom:1mm}
   .nota-importante{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:4mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/65-scatola-preoccupazioni.html
+++ b/static/formazione/kit-calamita-bambini/65-scatola-preoccupazioni.html
@@ -15,7 +15,7 @@
   .riga{border-bottom:1.3px solid #1a1a1a;height:6mm}
   .riga-grande{border-bottom:1.3px solid #1a1a1a;height:8mm}
   .nota-rituale{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/66-albero-speranze.html
+++ b/static/formazione/kit-calamita-bambini/66-albero-speranze.html
@@ -9,7 +9,7 @@
   .albero-svg-box{border:2px solid #003366;border-radius:8px;background:#fafbfc;padding:4mm;display:flex;justify-content:center}
   .albero-svg-box svg{width:100%;max-width:170mm;height:auto;max-height:200mm}
   .nota{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/67-coperta-del-sonno.html
+++ b/static/formazione/kit-calamita-bambini/67-coperta-del-sonno.html
@@ -63,7 +63,7 @@
       <div class="routine-step"><div class="routine-num">2</div><div class="routine-testo">Il mio peluche o oggetto di conforto</div></div>
       <div class="routine-step"><div class="routine-num">3</div><div class="routine-testo">Una storia letta da un adulto</div></div>
       <div class="routine-step"><div class="routine-num">4</div><div class="routine-testo">Una canzone calma o suoni della natura</div></div>
-      <div class="routine-step"><div class="routine-num">5</div><div class="routine-testo">3 respiri lenti con la pancia (vedi scheda 57)</div></div>
+      <div class="routine-step"><div class="routine-num">5</div><div class="routine-testo">3 respiri lenti con la pancia (vedi la scheda sulla respirazione della pancia)</div></div>
     </div>
     <div class="nota-incubi">
       🌙 <strong>Se ti svegli per un brutto sogno</strong>: accendi la luce piccola, bevi un sorso d'acqua, abbraccia il tuo oggetto di conforto, fai 3 respiri lenti. Se ti spaventa molto, chiama un adulto vicino: non disturbi, è normale chiedere aiuto la notte.

--- a/static/formazione/kit-calamita-bambini/67-coperta-del-sonno.html
+++ b/static/formazione/kit-calamita-bambini/67-coperta-del-sonno.html
@@ -13,7 +13,7 @@
   .routine-num{background:#003366;color:#fff;width:10mm;height:10mm;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13pt}
   .routine-testo{font-size:11pt;line-height:1.3}
   .nota-incubi{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:10.5pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/68-coping-cards.html
+++ b/static/formazione/kit-calamita-bambini/68-coping-cards.html
@@ -27,12 +27,12 @@
   <div class="scheda-istruzione">🃏 <strong>Quando ti senti sopraffatto, scegli una carta</strong>. Ritagliale, mettile in tasca o in un sacchetto, pesca quando serve. Funzionano davvero: provale anche quando stai bene.</div>
   <section class="scheda-attivita">
     <div class="carte-grid">
-      <div class="carta"><div class="carta-icon">1</div><div><span class="carta-titolo">Respira</span><span class="carta-testo">Inspira 4 secondi, trattieni 4, espira 6. Ripeti 3 volte (vedi scheda 57).</span></div></div>
+      <div class="carta"><div class="carta-icon">1</div><div><span class="carta-titolo">Respira</span><span class="carta-testo">Inspira 4 secondi, trattieni 4, espira 6. Ripeti 3 volte (vedi la scheda sulla respirazione della pancia).</span></div></div>
       <div class="carta"><div class="carta-icon">2</div><div><span class="carta-titolo">Parla</span><span class="carta-testo">Cerca un adulto di fiducia. Digli come ti senti, anche poche parole bastano.</span></div></div>
       <div class="carta"><div class="carta-icon">3</div><div><span class="carta-titolo">Muoviti</span><span class="carta-testo">Cammina, salta, corri sul posto, balla per 2 minuti. Il corpo libera la tensione.</span></div></div>
       <div class="carta"><div class="carta-icon">4</div><div><span class="carta-titolo">Disegna</span><span class="carta-testo">Prendi carta e matita. Disegna ciò che senti, anche se è solo un groviglio.</span></div></div>
       <div class="carta"><div class="carta-icon">5</div><div><span class="carta-titolo">Bevi</span><span class="carta-testo">Un bicchiere d'acqua a piccoli sorsi. Aiuta il corpo a calmarsi.</span></div></div>
-      <div class="carta"><div class="carta-icon">6</div><div><span class="carta-titolo">Senti</span><span class="carta-testo">Cerca con i sensi: 5 cose che vedi, 4 che tocchi (vedi scheda 58).</span></div></div>
+      <div class="carta"><div class="carta-icon">6</div><div><span class="carta-titolo">Senti</span><span class="carta-testo">Cerca con i sensi: 5 cose che vedi, 4 che tocchi (vedi la scheda del gioco dei sensi).</span></div></div>
       <div class="carta"><div class="carta-icon">7</div><div><span class="carta-titolo">Abbraccia</span><span class="carta-testo">Stringi a te il tuo peluche, una coperta o una persona cara, se c'è.</span></div></div>
       <div class="carta"><div class="carta-icon">8</div><div><span class="carta-titolo">Aspetta</span><span class="carta-testo">L'emozione forte passa, sempre. Conta fino a 60 piano: a volte basta.</span></div></div>
     </div>

--- a/static/formazione/kit-calamita-bambini/68-coping-cards.html
+++ b/static/formazione/kit-calamita-bambini/68-coping-cards.html
@@ -11,7 +11,7 @@
   .carta-titolo{font-weight:700;font-size:12pt;color:#003366;display:block;margin-bottom:1mm}
   .carta-testo{font-size:10.5pt;line-height:1.3}
   .istruzioni-ritaglio{border:2px dashed #003366;border-radius:6px;padding:3mm 4mm;background:#f4f7fb;font-size:10.5pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/69-albero-delle-forze.html
+++ b/static/formazione/kit-calamita-bambini/69-albero-delle-forze.html
@@ -11,7 +11,7 @@
   .legenda{display:grid;grid-template-columns:1fr 1fr;gap:4mm;margin-top:3mm;font-size:11pt;line-height:1.4}
   .legenda-box{border:1.8px solid #1a1a1a;border-radius:6px;padding:3mm 4mm}
   .legenda-box strong{display:block;color:#003366;margin-bottom:1mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/70-timeline-passato-presente-futuro.html
+++ b/static/formazione/kit-calamita-bambini/70-timeline-passato-presente-futuro.html
@@ -16,7 +16,7 @@
   .domanda strong{color:#003366}
   .righe{display:flex;flex-direction:column;gap:1.5mm;margin-top:1mm}
   .riga{border-bottom:1.3px solid #1a1a1a;height:6mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/71-ruota-cura-di-se.html
+++ b/static/formazione/kit-calamita-bambini/71-ruota-cura-di-se.html
@@ -12,7 +12,7 @@
   .settore{border:1.5px solid #1a1a1a;border-radius:5px;padding:2.5mm 3mm;background:#fff}
   .settore strong{display:block;color:#003366;margin-bottom:1mm;font-size:11pt}
   .nota{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/72-a-chi-chiedo-aiuto.html
+++ b/static/formazione/kit-calamita-bambini/72-a-chi-chiedo-aiuto.html
@@ -13,7 +13,7 @@
   .matrice-chi{padding:3mm 4mm;font-size:11pt;line-height:1.4}
   .nota-112{border:2.5px solid #c1121f;background:#fff5f5;border-radius:6px;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:4mm}
   .nota-112 strong{color:#c1121f}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/73-mappa-luoghi-sicuri-campo.html
+++ b/static/formazione/kit-calamita-bambini/73-mappa-luoghi-sicuri-campo.html
@@ -16,7 +16,7 @@
   .rosso h3{color:#c1121f}
   .rosso{border-color:#c1121f;background:#fff5f5}
   .istruzione{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-bottom:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/74-emozioni-grandi.html
+++ b/static/formazione/kit-calamita-bambini/74-emozioni-grandi.html
@@ -14,7 +14,7 @@
   .nota{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:4mm}
   .s{fill:none;stroke:#1a1a1a;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round}
   .occhio{fill:#1a1a1a}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/74-emozioni-grandi.html
+++ b/static/formazione/kit-calamita-bambini/74-emozioni-grandi.html
@@ -85,7 +85,7 @@
       </div>
     </div>
     <div class="nota">
-      💡 <strong>Tutte le emozioni sono giuste</strong>. Anche le emozioni grandi e brutte fanno parte di te. Quando senti un'emozione grande, prova a respirare con la pancia (vedi scheda 57) e a parlarne con un adulto di fiducia.
+      💡 <strong>Tutte le emozioni sono giuste</strong>. Anche le emozioni grandi e brutte fanno parte di te. Quando senti un'emozione grande, prova a respirare con la pancia (vedi la scheda sulla respirazione) e a parlarne con un adulto di fiducia.
     </div>
   </section>
   <footer class="scheda-footer">

--- a/static/formazione/kit-calamita-bambini/75-cosa-mi-aiuta-stare-meglio.html
+++ b/static/formazione/kit-calamita-bambini/75-cosa-mi-aiuta-stare-meglio.html
@@ -14,7 +14,7 @@
   .scrivi-tuo{border:2px dashed #003366;border-radius:6px;padding:4mm;background:#fff;margin-top:3mm}
   .scrivi-tuo h3{margin:0 0 2mm 0;font-size:12pt;color:#003366}
   .riga{border-bottom:1.5px solid #1a1a1a;height:8mm;margin-top:1.5mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/76-pensiero-coraggioso.html
+++ b/static/formazione/kit-calamita-bambini/76-pensiero-coraggioso.html
@@ -22,7 +22,7 @@
   .doppia-area{display:grid;grid-template-columns:1fr 1fr;gap:3mm}
   .righe{display:flex;flex-direction:column;gap:1.5mm}
   .riga{border-bottom:1.3px solid #1a1a1a;height:6mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/77-carta-del-conforto.html
+++ b/static/formazione/kit-calamita-bambini/77-carta-del-conforto.html
@@ -15,7 +15,7 @@
   .firma{border-top:1.5px dashed #003366;padding-top:3mm;text-align:center;font-size:11pt}
   .firma-line{display:inline-block;border-bottom:1.5px solid #1a1a1a;width:55mm;height:5mm;margin-left:3mm}
   .istruzione-uso{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:10.5pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/78-mio-spazio-di-apprendimento.html
+++ b/static/formazione/kit-calamita-bambini/78-mio-spazio-di-apprendimento.html
@@ -15,7 +15,7 @@
   .voce{display:grid;grid-template-columns:7mm 1fr;gap:2mm;align-items:center;font-size:11pt;line-height:1.3}
   .check{width:5mm;height:5mm;border:1.5px solid #1a1a1a;border-radius:2px}
   .nota{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/79-patto-del-campo.html
+++ b/static/formazione/kit-calamita-bambini/79-patto-del-campo.html
@@ -17,7 +17,7 @@
   .firma-line{border-bottom:1.5px solid #1a1a1a;height:7mm}
   .firma-label{font-size:9pt;color:#666;text-align:center}
   .nota{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:10.5pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>

--- a/static/formazione/kit-calamita-bambini/80-so-dire-cosa-mi-serve.html
+++ b/static/formazione/kit-calamita-bambini/80-so-dire-cosa-mi-serve.html
@@ -19,7 +19,7 @@
   .righe{display:flex;flex-direction:column;gap:1.5mm;margin-top:1mm}
   .riga{border-bottom:1.3px solid #1a1a1a;height:6mm}
   .nota{border-left:5px solid #003366;background:#f4f7fb;padding:3mm 4mm;font-size:11pt;line-height:1.4;margin-top:3mm}
-</style>
+.scheda-attivita{align-items:stretch}.scheda-attivita > *{max-width:100%;width:100%;box-sizing:border-box}</style>
 </head>
 <body>
 <button class="btn-stampa no-print" onclick="window.print()">🖨️ Stampa A4</button>


### PR DESCRIPTION
## Sintesi

Fix layout sfalsato in stampa sulle 33 schede del kit calamità bambini (48-80).

## Diagnosi

`print.css` condiviso ha `.scheda-attivita { align-items: center }`. I miei container grid/flex direct-child senza `width: 100%` esplicito si restringevano al contenuto invece di occupare tutta la larghezza, causando layout sfalsato in stampa A4 e testo che esce dai bordi delle card.

## Fix

Aggiunto in inline `<style>` di ognuna delle 33 schede:

```css
.scheda-attivita { align-items: stretch; }
.scheda-attivita > * { max-width: 100%; width: 100%; box-sizing: border-box; }
```

Zero impatto sulle schede pre-esistenti (non ne tocca i file).

https://claude.ai/code/session_01XvSRPbGtjPgAyRuzPvUiR8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvSRPbGtjPgAyRuzPvUiR8)_