### PR TITLE
Fix accenti 2 articoli + fallback noscript pagina /cerca/

### DIFF
--- a/content/comunicazioni/2026-05-05-persone-fragili-aiutare-vicini-anziani-emergenza.md
+++ b/content/comunicazioni/2026-05-05-persone-fragili-aiutare-vicini-anziani-emergenza.md
@@ -1,12 +1,12 @@
 ---
 title: "Aiutare i vicini fragili in emergenza: un gesto di comunità che salva vite"
 date: 2026-05-05T00:01:00+02:00
-description: "Anziani soli, persone con disabilita, famiglie in difficolta: in emergenza la rete di prossimita e spesso la prima a fare la differenza. Come prepararsi."
+description: "Anziani soli, persone con disabilità, famiglie in difficoltà: in emergenza la rete di prossimità è spesso la prima a fare la differenza. Come prepararsi."
 badge: "Prevenzione"
 priorita: "normale"
 autore: "Gruppo Comunale Volontari PC Genzano"
 image: "/images/2026-05-05-persone-fragili-aiutare-vicini-anziani-emergenza.webp"
-image_alt: "Cover dell'articolo: Aiutare i vicini fragili in emergenza: un gesto di comunita che salva vite"
+image_alt: "Cover dell'articolo: Aiutare i vicini fragili in emergenza: un gesto di comunità che salva vite"
 scadenza: ""
 area: "Genzano di Roma"
 allegati: []

--- a/content/comunicazioni/2026-05-07-zone-allerta-lazio-come-leggere-bollettino.md
+++ b/content/comunicazioni/2026-05-07-zone-allerta-lazio-come-leggere-bollettino.md
@@ -1,12 +1,12 @@
 ---
-title: "Le zone di allerta del Lazio: come leggere il bollettino di criticita"
+title: "Le zone di allerta del Lazio: come leggere il bollettino di criticità"
 date: 2026-05-07
-description: "Il Lazio e suddiviso in sette zone di allerta. Sapere in quale zona si trova Genzano e capire il bollettino di criticita significa leggere correttamente un'allerta meteo."
+description: "Il Lazio è suddiviso in sette zone di allerta. Sapere in quale zona si trova Genzano e capire il bollettino di criticità significa leggere correttamente un'allerta meteo."
 badge: "Informazione"
 priorita: "normale"
 autore: "Gruppo Comunale Volontari PC Genzano"
 image: "/images/2026-05-07-zone-allerta-lazio-come-leggere-bollettino.webp"
-image_alt: "Cover dell'articolo: Le zone di allerta del Lazio: come leggere il bollettino di criticita"
+image_alt: "Cover dell'articolo: Le zone di allerta del Lazio: come leggere il bollettino di criticità"
 scadenza: ""
 area: "Genzano di Roma"
 allegati: []

--- a/themes/flavour-pcgenzano/layouts/cerca/list.html
+++ b/themes/flavour-pcgenzano/layouts/cerca/list.html
@@ -19,6 +19,28 @@
         <div id="search-count" class="mt-2 small text-muted"></div>
         <div id="search-results" class="mt-3" role="region" aria-live="polite"></div>
       </div>
+
+      <noscript>
+        <div class="alert alert-warning mt-3" role="alert">
+          <p class="mb-2"><strong>La ricerca interna richiede JavaScript.</strong> Hai disabilitato gli script: usa i link qui sotto per raggiungere direttamente le pagine principali del sito.</p>
+        </div>
+        <section aria-labelledby="cerca-fallback-titolo" class="mt-4">
+          <h2 id="cerca-fallback-titolo" class="h4">Pagine principali</h2>
+          <ul class="list-unstyled">
+            <li class="mb-2"><a href="{{ "numeri-utili/" | relURL }}"><strong>Numeri utili e di emergenza</strong></a> — 112, Sala Operativa Lazio, Guardia Costiera</li>
+            <li class="mb-2"><a href="{{ "allerte-meteo/" | relURL }}"><strong>Allerte meteo</strong></a> — bollettini e codici colore della Regione Lazio</li>
+            <li class="mb-2"><a href="{{ "cosa-fare-adesso/" | relURL }}"><strong>Cosa fare adesso</strong></a> — comportamenti di autoprotezione</li>
+            <li class="mb-2"><a href="{{ "assistente/" | relURL }}"><strong>Assistente virtuale</strong></a> — guida passo passo per scegliere cosa fare</li>
+            <li class="mb-2"><a href="{{ "rischi-prevenzione/" | relURL }}"><strong>Rischi e prevenzione</strong></a> — sismico, idrogeologico, incendi, vento, temporali, blackout, calore</li>
+            <li class="mb-2"><a href="{{ "piano-familiare/" | relURL }}"><strong>Piano familiare di emergenza</strong></a> — strumento da compilare e stampare</li>
+            <li class="mb-2"><a href="{{ "comunicazioni/" | relURL }}"><strong>Archivio comunicazioni</strong></a> — articoli filtrabili per categoria e anno</li>
+            <li class="mb-2"><a href="{{ "formazione/" | relURL }}"><strong>Formazione e didattica</strong></a> — kit per scuole, giochi, schede stampabili</li>
+            <li class="mb-2"><a href="{{ "contatti/" | relURL }}"><strong>Contatti</strong></a> — sede, recapiti, modulo di contatto</li>
+            <li class="mb-2"><a href="{{ "mappa-sito/" | relURL }}"><strong>Mappa del sito</strong></a> — indice completo di tutte le pagine</li>
+          </ul>
+          <p class="mb-0"><a href="{{ "emergenza/" | relURL }}" class="btn btn-danger"><strong>Pagina Emergenza (versione lite)</strong></a></p>
+        </section>
+      </noscript>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Due fix di qualità emersi dalla verifica di un audit esterno sul sito:

- **Accenti mancanti nel frontmatter di 2 articoli** (su 375 totali): `criticita`/`disabilita`/`difficolta`/`prossimita`/`comunita` → con accenti corretti, e `Lazio e suddiviso`/`prossimita e spesso` → con `è` accentato (in `title`, `description`, `image_alt`).
- **Fallback `<noscript>` nella pagina `/cerca/`**: senza JavaScript la pagina mostrava solo il campo input lasciando l'utente in un vicolo cieco. Il blocco `<noscript>` ora avvisa esplicitamente e propone 10 link rapidi (numeri utili, allerte, cosa fare, assistente, rischi, piano familiare, comunicazioni, formazione, contatti, mappa-sito) + bottone evidenziato per `/emergenza/`.

L'audit esterno aveva segnalato 9 criticità: 5 erano allucinazioni del lettore (footer COI 14°/15° drift inesistente, voce menu "Standard ISO" inesistente, alt text "Comunicazioni e Notizie" non generato dal template, ecc.), 1 procedurale esterna (dichiarazione AGID da compilare su `form.agid.gov.it`), 1 cambio di design da discutere (pagina `/emergenza/` con chrome). Solo 2 punti sono stati portati a fix concreto.

## Test plan

- [x] `git status` pulito dopo i 2 commit
- [ ] Dopo merge: `deploy.yml` parte e completa (Aruba + GitHub Pages)
- [ ] `/cerca/` continua a funzionare con JS attivo (nessuna regressione)
- [ ] `/cerca/` con JS disattivato mostra il blocco `<noscript>` con i 10 link + bottone `/emergenza/`
- [ ] Card archivio comunicazioni: titoli/description renderizzati con accenti corretti

https://claude.ai/code/session_015fdYGUsmcxrU4HckGfkqhm

---
_Generated by [Claude Code](https://claude.ai/code/session_015fdYGUsmcxrU4HckGfkqhm)_