### PR TITLE
Revisione AGID gennaio 2026 — fix-up cucina da campo

### DIFF
--- a/content/comunicazioni/2026-01-20-cucina-campo-zone-protocollo-operativo.md
+++ b/content/comunicazioni/2026-01-20-cucina-campo-zone-protocollo-operativo.md
@@ -26,7 +26,7 @@ Fin dai primi momenti l'area destinata all'alimentazione si suddivide in quattro
 
 ### 1. Zona depositi
 
-Serve per stoccare le materie prime e dividerla ulteriormente in sottozone aiuta a mantenere l'igiene:
+Serve a stoccare le materie prime. Suddividerla in sottozone aiuta a mantenere l'igiene:
 
 - **apertura imballaggi** — all'esterno delle altre zone, vicino alle aree di smaltimento rifiuti;
 - **zona lavaggio prodotti per la pulizia** — con armadiatura chiusa, senza mai travasare da un contenitore all'altro;
@@ -91,7 +91,7 @@ Il manuale riporta le temperature previste dal DPR 327/80 e dai Regolamenti CE 8
 | Frattaglie | +3 °C |
 | Carni macinate | +2 °C |
 
-Nei container frigo si suddividono le aree: carne e pesce vicino al fan-coil (zona più fredda), verdure ben coperte nella zona meno fredda. All'esterno dei container si espone una **tabella aggiornata** con i prodotti dentro (lotto e scadenza), così non serve aprire la cella per verificarne il contenuto — evitando sbalzi di temperatura.
+Nei container frigo si suddividono le aree: carne e pesce vicino al fan-coil (zona più fredda), verdure ben coperte nella zona meno fredda. All'esterno dei container si espone una **tabella aggiornata** con i prodotti presenti (lotto e scadenza). In questo modo non serve aprire la cella per verificarne il contenuto, evitando sbalzi di temperatura.
 
 ### Lavorazione e cottura
 
@@ -118,7 +118,7 @@ Ogni fase ha i suoi rischi, le sue misure di prevenzione e i suoi DPI.
 
 ## Perché riguarda anche il Gruppo di Genzano
 
-Il Gruppo Comunale Volontari di Protezione Civile di Genzano aderisce a **FEPIVOL** ed è iscritto all'Elenco territoriale regionale. Nelle attivazioni in supporto ad altri comuni può essere chiamato a contribuire al servizio di ristorazione di un campo. Sapere come è organizzata una cucina conforme, quali rischi esistono e quali procedure rispettare è parte integrante della preparazione di chi entra in turno.
+Il Gruppo Comunale Volontari di Protezione Civile di Genzano aderisce a **FEPIVOL** (Federazione Provinciale Volontari di Protezione Civile) ed è iscritto all'Elenco territoriale regionale. Nelle attivazioni in supporto ad altri comuni può essere chiamato a contribuire al servizio di ristorazione di un campo. Sapere come è organizzata una cucina conforme, quali rischi esistono e quali procedure rispettare è parte integrante della preparazione di chi entra in turno.
 
 ## Riferimenti
 


### PR DESCRIPTION
## Sommario

Mini-PR di rifinitura su `2026-01-20-cucina-campo-zone-protocollo-operativo.md`, emersa dal completamento ritardato dell'agent gennaio batch A dopo il merge di PR #156.

## Modifiche (3)

- **Grammatica**: `"Serve per stoccare le materie prime e dividerla ulteriormente"` → due soggetti diversi in una sola proposizione. Spezzata in due frasi corrette.
- **Frase >20 parole**: periodo da 30 parole sul tabellone esterno ai container frigo, spezzato in due con punto fermo.
- **Sigla AGID**: **FEPIVOL** sciolta alla prima occorrenza → "Federazione Provinciale Volontari di Protezione Civile".

## Vincoli rispettati

- 🔴 Anti-pattern `image:` rispettato (0 hit).
- YAML frontmatter valido.

---
_Generated by [Claude Code](https://claude.ai/code/session_01994Zx5QNm5ZHn18X6Yfp2p)_