### PR TITLE
Auto-gate AGID obbligato prima del commit + eccezione registro su richiesta utente

### DIFF
--- a/.claude/rules/02-content-design-pa.md
+++ b/.claude/rules/02-content-design-pa.md
@@ -227,6 +227,16 @@ Quando una fonte cambia, il workflow apre automaticamente un'issue di label `man
 
 **Per batch di revisione ≥5 articoli**: applicare il checkpoint pre-batch (`07-proattivita-coerenza.md`), ottenere conferma esplicita, lavorare in serie con commit a tappe (≈30-50 articoli per commit) per mantenere la cronologia git navigabile.
 
+### Auto-gate AGID prima del commit (sintesi operativa)
+
+La regola completa è in `CLAUDE.md` § "Auto-gate AGID prima del commit di un nuovo articolo". Sintesi:
+
+1. **Quando generi un articolo nuovo** in `content/comunicazioni/`, **prima del `git add`** invochi `pc-article-reviewer` su quel file.
+2. Solo dopo il via libera dell'agent (o dopo aver applicato i suoi fix) procedi al commit.
+3. Il gate è **obbligato**, non opzionale. Vale anche su singolo articolo.
+
+**Eccezione — registro non-AGID solo su richiesta esplicita dell'utente.** Se l'utente chiede di redigere un documento in registro diverso (comunicato stampa, lettera istituzionale, paper scientifico, relazione tecnica, memoria, bando, delibera, ordinanza, scheda accademica, **o qualunque altro documento per cui chiede esplicitamente uno stile diverso**), sospendi il gate AGID per quel documento e applica le **convenzioni di genere** del settore di appartenenza (piramide rovesciata + 5W per il comunicato stampa; intestazione + protocollo per la lettera; IMRaD per il paper; ecc.). Diventa il miglior professionista di quel genere. L'eccezione vale solo per il documento richiesto: il prossimo articolo per `content/comunicazioni/` ricade nel gate AGID standard. **L'eccezione la decide l'utente, non tu.**
+
 ## Frontmatter obbligatorio per gli articoli (comunicazioni/)
 
 Ogni articolo deve avere tutti i campi previsti dall'archetipo:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,39 @@ Esiste perché il 4 maggio 2026 l'utente ha scoperto che 50+ commit accumulati s
 
 ---
 
+## Auto-gate AGID prima del commit di un nuovo articolo
+
+🟢 **Ogni volta che generi un articolo nuovo in `content/comunicazioni/`, prima del `git add` invochi l'agent `pc-article-reviewer` su quel file.** Solo dopo il via libera dell'agent (o dopo aver applicato i suoi fix) procedi al commit. Vale anche su un singolo articolo. **Il gate è obbligato, non opzionale.**
+
+**Trigger:** creazione/modifica sostanziale di un file in `content/comunicazioni/AAAA-MM-GG-*.md`. Vale per articoli generati da te, da workflow CI, da altre AI esterne le cui bozze passano da una tua sessione, e da editing manuale dell'utente quando ti chiede una rilettura.
+
+**Workflow obbligato:**
+
+1. Scrivi/modifichi il file.
+2. **Invochi `pc-article-reviewer`** sul file appena scritto.
+3. L'agent applica i fix AGID o dichiara *"Articolo conforme AGID, nessuna modifica necessaria"*.
+4. **Solo a quel punto** `git add` + commit.
+5. Se l'utente ha detto «pubblica» o equivalente, prosegui con push + PR + merge come da regola «Pubblica».
+
+**Eccezione — modalità non-AGID solo su richiesta esplicita dell'utente:**
+
+Se l'utente ti chiede esplicitamente di redigere un documento in un **registro diverso** dal linguaggio AGID per il cittadino (esempi non esaustivi: **comunicato stampa**, **lettera istituzionale formale**, **articolo scientifico**, **paper di ricerca**, **relazione tecnica**, **memoria difensiva**, **risposta a interrogazione**, **studio di prefattibilità**, **bando pubblico**, **delibera**, **ordinanza**, **scheda accademica**), in quel caso:
+
+- **Sospendi il gate AGID** per quel documento specifico.
+- **Diventa il miglior professionista del settore** di scrittura per quel genere: stile, lessico, struttura, citazioni, registro, lunghezza adeguati al pubblico target del documento (giornalisti per il comunicato stampa, controparti istituzionali per la lettera formale, peer-reviewer per il paper scientifico, ecc.).
+- Cita le **convenzioni di genere**: comunicato stampa = piramide rovesciata + lead 5W + boilerplate finale; lettera istituzionale = intestazione + protocollo + formula di apertura/chiusura; paper scientifico = abstract + IMRaD; ecc.
+- L'eccezione vale **solo** per quel documento specifico richiesto. Il prossimo articolo generato per `content/comunicazioni/` ricade nel gate AGID standard.
+
+**L'eccezione la decide l'utente, non tu.** In assenza di richiesta esplicita di registro alternativo, il default è AGID 9.5/10 con gate obbligato.
+
+**Why esiste questa regola:**
+
+Le rules `02-content-design-pa.md` § "Livello qualitativo della redazione" e `CLAUDE.md` punto 4 («qualità ChatGPT 9.5/10») definivano già lo standard atteso. Il problema era che vivevano come **contesto di lettura**, non come **passo obbligato del flusso di pubblicazione**. Tra "ho generato il testo" e "lo committo" non c'era nulla che mi forzasse a rileggerlo da UX writer. L'agent `pc-article-reviewer` era pensato per essere invocato proattivamente, ma di fatto veniva attivato solo quando l'utente lo chiedeva esplicitamente, in revisione retroattiva.
+
+Risultato: il **9 maggio 2026** l'utente ha chiesto di rivedere AGID tutti gli articoli storici. Sono usciti **43 articoli rivisti** (2024 + 2025 + Q1 2026 + 2027 calendarizzati) in 8 PR consecutive, con interventi che andavano dal cosmetico al bloccante (badge `Allerta` improprio su campagna AIB stagionale, sigle mai sciolte, lede retorici, fonti istituzionali mai citate). Tutti debiti che si potevano evitare con un gate al momento della generazione. Da maggio 2026 il gate è obbligato per impedire che il debito si riformi.
+
+---
+
 ## Regole di dettaglio (file separati)
 
 @.claude/rules/01-governance-pa.md


### PR DESCRIPTION
## Sommario

Codifica una nuova **regola obbligante** in `CLAUDE.md` (peso uguale a "Pubblica" e "Checkpoint pre-batch"): ogni volta che Claude genera un articolo nuovo in `content/comunicazioni/`, **prima del `git add`** invoca l'agent `pc-article-reviewer` su quel file. Solo dopo il via libera dell'agent procede al commit.

## Eccezione — registro non-AGID

Su **richiesta esplicita dell'utente** Claude sospende il gate AGID per documenti di altro genere e diventa il miglior professionista del settore di appartenenza:

- Comunicato stampa (piramide rovesciata + 5W + boilerplate)
- Lettera istituzionale (intestazione + protocollo + formule)
- Paper scientifico (abstract + IMRaD)
- Relazione tecnica, memoria difensiva, bando, delibera, ordinanza, scheda accademica
- **Qualunque altro genere** per cui l'utente chiede esplicitamente uno stile diverso

L'eccezione la decide l'utente, non Claude. Vale solo per il documento richiesto: il prossimo articolo per `content/comunicazioni/` ricade nel gate AGID standard.

## File modificati

- `CLAUDE.md` — nuova sezione top-level "Auto-gate AGID prima del commit di un nuovo articolo" tra "Fine sessione" e "Regole di dettaglio"
- `.claude/rules/02-content-design-pa.md` § "Livello qualitativo della redazione" — sintesi operativa del gate + eccezione (per coerenza obbligatoria CLAUDE.md ↔ rules)

## Why

Senza un gate al momento della generazione, la qualità AGID 9.5/10 attesa da `CLAUDE.md` punto 4 restava un **contesto di lettura**, non un **passo obbligato**. Risultato: il 9 maggio 2026 sono usciti 43 articoli rivisti retroattivamente in 8 PR consecutive (2024 + 2025 + Q1 2026 + 2027 calendarizzati) per ripianare il debito. Da ora il gate impedisce che il debito si riformi.

## Test plan

- [x] CLAUDE.md aggiornato
- [x] Rule 02 sincronizzata
- [ ] Verifica al prossimo articolo generato: l'agent viene invocato prima del commit

---
_Generated by [Claude Code](https://claude.ai/code/session_01994Zx5QNm5ZHn18X6Yfp2p)_