### PR TITLE
Propaga auto-gate AGID a manuale, agent docs, README, AGENTS

### DIFF
--- a/.claude/agents/pc-article-reviewer.md
+++ b/.claude/agents/pc-article-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: pc-article-reviewer
-description: Use this agent PROACTIVELY when the user creates a new article (file in content/comunicazioni/) or substantially edits an existing one. Reviews frontmatter completeness, applies AGID writing rules, verifies badge correctness, date format, internal links validity, photo conventions, and absence of fictitious data. Returns a punch list of issues to fix BEFORE the article is committed.
+description: 🔴 MANDATORY GATE — invoke this agent on EVERY new or substantially modified article in content/comunicazioni/ BEFORE the git add. Not optional, not "proactive when convenient": it is the obligated pre-commit step codified in CLAUDE.md § "Auto-gate AGID prima del commit di un nuovo articolo". Reviews frontmatter completeness, applies AGID writing rules at ChatGPT 9.5/10 level (sentences <20 words, active voice, no nominalizations, sigle sciolte, fonti istituzionali cited, internal linkography valued before external sources, badge correctness Allerta/Emergenza/Aggiornamento, date format, internal links validity, photo conventions, absence of fictitious data). Returns either applied fixes with rationale or "Articolo conforme AGID, nessuna modifica necessaria". EXCEPTION — register: if the user explicitly requested a non-AGID register (press release, formal letter, scientific paper, technical report, ordinance, or any other genre with explicit user request), this gate is suspended for that document only.
 tools: Read, Edit, Grep, Glob, Bash
 model: sonnet
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,9 @@ Se stai operando come **ChatGPT/Codex via GitHub connector**: hai solo questo `A
 
 ---
 
-## ⚡ Quickref — Le 3 regole operative non negoziabili (= i 3 vincoli operativi non negoziabili)
+## ⚡ Quickref — Le 4 regole operative non negoziabili (= i 4 vincoli operativi non negoziabili)
 
-Se ti viene chiesto **«quali sono le 3 regole operative non negoziabili di questo progetto?»** o **«quali sono i 3 vincoli operativi non negoziabili?»**, la risposta esatta — testuale, non filosofica — è:
+Se ti viene chiesto **«quali sono le 4 regole operative non negoziabili di questo progetto?»** o **«quali sono i 4 vincoli operativi non negoziabili?»**, la risposta esatta — testuale, non filosofica — è:
 
 1. **Checkpoint pre-operazione batch.** Prima di toccare ≥5 articoli o ≥5 file in una singola passata, fermati e dichiara all'utente in 3 righe: (a) cosa stai per fare, (b) quali rules `.claude/rules/0*.md` si applicano (cita nome + sezione), (c) perché l'operazione le rispetta. Poi aspetta conferma esplicita prima di procedere. Specifiche complete: sezione 3.1 sotto e `.claude/rules/07-proattivita-coerenza.md` § "Checkpoint pre-operazione batch".
 
@@ -47,7 +47,9 @@ Se ti viene chiesto **«quali sono le 3 regole operative non negoziabili di ques
 
 3. **Fine sessione su feature branch — proponi sempre il merge.** Se hai fatto commit pendenti rispetto a `origin/main`, prima di chiudere proponi esplicitamente: *"Sul branch ci sono N commit non ancora live (lista). Vuoi che apra PR + merge su main + verifica deploy?"* Non auto-mergiare, ma non lasciare che l'utente si convinca di aver pubblicato quando è solo a metà strada. Specifiche complete: sezione 3.3 sotto.
 
-**Queste tre regole sono comportamentali e operative**, non principi astratti. Sono nate da incidenti specifici (batch foto stock di aprile 2026 su 74 articoli; 50+ commit accumulati di maggio 2026 mai pubblicati). Non rispondere genericamente con "AGID + accessibilità + verità operativa": **quelle sono i principi di governance**, non i 3 vincoli operativi non negoziabili.
+4. **Auto-gate AGID prima del commit di un nuovo articolo.** Quando generi/modifichi sostanzialmente un articolo in `content/comunicazioni/`, **prima del `git add`** invochi (o emuli, se sei una sessione cloud OpenAI senza accesso a `pc-article-reviewer`) il check AGID livello ChatGPT 9.5/10 sul file: frasi <20 parole, voce attiva, niente nominalizzazioni, sigle sciolte alla prima occorrenza, fonti istituzionali citate, linkografia interna valorizzata prima di fonti esterne, badge `Allerta`/`Emergenza`/`Aggiornamento` corretto. Solo dopo la passata pulita procedi al commit. Vale anche per un singolo articolo. Eccezione: se l'utente chiede esplicitamente un **registro non-AGID** (comunicato stampa, lettera istituzionale, paper scientifico, relazione tecnica, ordinanza, **o qualsiasi altro genere a sua richiesta esplicita**), il gate è sospeso per quel documento e applichi le convenzioni del genere. Specifiche complete: sezione 3.4 sotto e `CLAUDE.md` § *"Auto-gate AGID prima del commit di un nuovo articolo"*.
+
+**Queste quattro regole sono comportamentali e operative**, non principi astratti. Sono nate da incidenti specifici (batch foto stock di aprile 2026 su 74 articoli; 50+ commit accumulati di maggio 2026 mai pubblicati; 43 articoli AGID rivisti retroattivamente il 9 maggio 2026 perché il gate non era esplicito). Non rispondere genericamente con "AGID + accessibilità + verità operativa": **quelle sono i principi di governance**, non i 4 vincoli operativi non negoziabili.
 
 ---
 
@@ -81,7 +83,7 @@ Quando lavori su questo repo agisci sempre come **task force multidisciplinare**
 
 ---
 
-## 3. Tre vincoli operativi che non si negoziano
+## 3. Quattro vincoli operativi che non si negoziano
 
 ### 3.1 Checkpoint pre-operazione batch
 
@@ -173,6 +175,36 @@ L'utente lavora **multi-device** (PC desktop, smartphone Android, agenti GitHub-
 **Cosa NON fare:**
 - Non auto-mergiare senza chiedere quando l'utente non ha detto "pubblica".
 - Non dire "fatto, pushato" come se fosse live: se sei su feature branch, il push è solo metà strada.
+
+### 3.4 Auto-gate AGID prima del commit di un nuovo articolo
+
+🟢 **Ogni volta che generi/modifichi sostanzialmente un articolo in `content/comunicazioni/`, prima del `git add` esegui il pre-commit AGID gate sul file.** In Claude Code l'agent dedicato è `pc-article-reviewer`. In sessione cloud OpenAI/ChatGPT (senza accesso a quell'agent) emuli lo stesso check applicando manualmente la checklist AGID livello ChatGPT 9.5/10 al file:
+
+- Frasi >20 parole → spezza
+- Nominalizzazioni → verbi attivi ("effettuazione del pagamento" → "pagare")
+- Passive ridondanti → voce attiva
+- Lede concreto, non retorico (no "è un'occasione per…", "è importante ricordare…")
+- Fonti istituzionali sempre citate (DPC, INGV, ISPRA, ARPA Lazio, ASL Roma 6, MIM, ecc.) per ogni claim tecnico
+- Linkografia interna valorizzata prima di fonti esterne
+- Bullet uniformi (tutti imperativo o tutti sostantivi)
+- H2 senza enfasi ridondante (no `**bold**` dentro H2, no emoji urlate)
+- Niente burocratese ("ad uopo", "giusta delibera", "nelle more di", "si prega di")
+- Distinzione `Allerta`/`Emergenza`/`Aggiornamento` corretta nel badge (regola 06)
+- Sigle sciolte alla prima occorrenza (HACCP, OdV, BLSD, AeDES, COC, COI, USAR, ecc.)
+- 🔴 **Anti-pattern `image:`**: `git diff <file> | grep -E '^[+-]image' | head -5`. Se trovi diff sul campo `image:` non richiesto, ripristina (banner intoccabile).
+
+Solo dopo la passata pulita procedi al commit. Vale anche per un singolo articolo. **Il gate è obbligato, non opzionale.**
+
+**Eccezione — registro non-AGID solo su richiesta esplicita dell'utente.** Se l'utente chiede esplicitamente un documento in registro diverso dal linguaggio AGID per il cittadino (esempi non esaustivi: **comunicato stampa**, **lettera istituzionale formale**, **articolo scientifico**, **paper di ricerca**, **relazione tecnica**, **memoria difensiva**, **risposta a interrogazione**, **studio di prefattibilità**, **bando pubblico**, **delibera**, **ordinanza**, **scheda accademica**), in quel caso:
+
+- Sospendi il gate AGID per quel documento specifico.
+- Diventa il miglior professionista del settore di scrittura per quel genere: stile, lessico, struttura, citazioni, registro, lunghezza adeguati al pubblico target del documento.
+- Cita le **convenzioni di genere**: comunicato stampa = piramide rovesciata + lead 5W + boilerplate finale; lettera istituzionale = intestazione + protocollo + formula apertura/chiusura; paper = abstract + IMRaD; ecc.
+- L'eccezione vale **solo** per quel documento richiesto. Il prossimo articolo per `content/comunicazioni/` ricade nel gate AGID standard.
+
+**L'eccezione la decide l'utente, non tu.** In assenza di richiesta esplicita di registro alternativo, il default è AGID 9.5/10 con gate obbligato.
+
+**Why esiste questa regola:** il 9 maggio 2026 sono usciti **43 articoli rivisti retroattivamente** in 8 PR consecutive (2024 + 2025 + Q1 2026 + 2027 calendarizzati) per ripianare il debito accumulato dalle sessioni che redigevano senza gate. Specifiche complete in `CLAUDE.md` § *"Auto-gate AGID prima del commit di un nuovo articolo"* e in `.claude/rules/02-content-design-pa.md` § *"Auto-gate AGID prima del commit"*. Per i comunicati stampa vedi `manuale/parte-12-comunicati-stampa-tempo-ordinario-e-tempo-emergenziale.md`.
 
 ---
 

--- a/MANUALE-MOBILE.md
+++ b/MANUALE-MOBILE.md
@@ -180,6 +180,8 @@ Specifiche complete: [`manuale/parte-14-...md` § 14.11](manuale/parte-14-config
 
 ## 2. Pubblicare un articolo nuovo da mobile
 
+> 🤖 **Auto-gate AGID — vale anche da mobile.** Da maggio 2026 ogni articolo nuovo in `content/comunicazioni/` deve passare per l'agent `pc-article-reviewer` PRIMA del commit. Se usi l'app Claude Code per Android (sessione cloud sul repo), la sessione è obbligata al gate dalla regola in `CLAUDE.md` § *"Auto-gate AGID prima del commit di un nuovo articolo"*: invoca l'agent automaticamente sull'articolo che ha appena scritto, applica i fix, **poi** committa. Se invece usi l'app Claude generica per Android (non collegata al repo), Step A qui sotto ti guida nel chiedere a mano lo stesso livello AGID 9.5/10. Se il documento è un comunicato stampa o altro registro non-AGID, il gate è sospeso (vedi *Parte 12* del manuale operativo).
+
 ### Step A — Chiedi a Claude (app Android) di scriverlo
 
 Apri Claude e scrivigli qualcosa tipo:

--- a/MANUALE-SITO.md
+++ b/MANUALE-SITO.md
@@ -54,6 +54,8 @@ Se non sai in quale Parte cercare:
 | Vuoi… | Vai a |
 |---|---|
 | Scrivere un nuovo articolo | [Parte 1](manuale/parte-01-scrivere-un-articolo-passo-per-passo.md) → [Parte 2](manuale/parte-02-le-regole-agid-in-dettaglio.md) → [Parte 3](manuale/parte-03-immagini-per-gli-articoli.md) → [Parte 5](manuale/parte-05-checklist-pre-pubblicazione.md) |
+| 🤖 Auto-gate AGID Claude Code (obbligato pre-commit) | [Parte 5](manuale/parte-05-checklist-pre-pubblicazione.md) → [Parte 19](manuale/parte-19-agenti-specializzati.md) § 19.1 + `CLAUDE.md` § *"Auto-gate AGID prima del commit"* |
+| Comunicato stampa o altro documento NON-AGID con Claude | [Parte 12](manuale/parte-12-comunicati-stampa-tempo-ordinario-e-tempo-emergenziale.md) — eccezione registro su richiesta esplicita |
 | Mettere la fascia blu su una foto | [Parte 3](manuale/parte-03-immagini-per-gli-articoli.md) § 3.8 Metodo 4 |
 | Pittogrammi ISO 7010 / ARASAAC | [Parte 3](manuale/parte-03-immagini-per-gli-articoli.md) § 3.16 |
 | Scaricare foto da Wikipedia/NASA/USGS/NOAA/Pexels/Pixabay/Unsplash | [Parte 3](manuale/parte-03-immagini-per-gli-articoli.md) + [Parte 14](manuale/parte-14-configurazione-ambiente-di-sviluppo-claude-code.md) |

--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ python3 scripts/auto-cover-mancanti.py
 git add . && git commit -m "..." && git push
 ```
 
+> 🤖 **Se redigi con Claude Code (CLI/mobile/cloud/agent):** il workflow ha un **gate AGID obbligato** prima del `git add` — Claude invoca automaticamente l'agent `pc-article-reviewer` sul file appena scritto e applica i fix di linguaggio AGID livello ChatGPT 9.5/10 (frasi <20 parole, voce attiva, sigle sciolte, fonti istituzionali, badge corretto). Eccezione: se chiedi esplicitamente un comunicato stampa, una lettera istituzionale, un paper scientifico o **qualsiasi altro documento in registro non-AGID**, il gate è sospeso e Claude applica le convenzioni di genere. Specifiche in `CLAUDE.md` § *"Auto-gate AGID prima del commit di un nuovo articolo"*.
+
 ### Foto
 
 ```bash

--- a/manuale/parte-01-scrivere-un-articolo-passo-per-passo.md
+++ b/manuale/parte-01-scrivere-un-articolo-passo-per-passo.md
@@ -399,6 +399,8 @@ Apri `http://localhost:1313` nel browser:
 
 Vai a **Parte 5** e spunta ogni voce. Se qualcosa non è a posto, torna indietro.
 
+> 🤖 **Se stai lavorando con Claude Code (CLI desktop, app mobile, sessione cloud, agent GitHub):** prima del `git add` Claude **deve obbligatoriamente** invocare l'agent `pc-article-reviewer` sul file appena scritto. Il gate è codificato in `CLAUDE.md` § *"Auto-gate AGID prima del commit di un nuovo articolo"* e in `.claude/rules/02-content-design-pa.md` § *"Auto-gate AGID prima del commit"*. Solo dopo il via libera dell'agent (o dopo l'applicazione dei suoi fix) si procede al commit. Il gate vale anche per un singolo articolo. Eccezione: se chiedi esplicitamente un **registro non-AGID** (comunicato stampa, lettera istituzionale, paper scientifico, qualsiasi altro genere a tua richiesta esplicita), il gate è sospeso per quel documento — vedi **Parte 12** per i comunicati stampa.
+
 ### Passo 1.14 — Commit e push
 
 ```bash

--- a/manuale/parte-05-checklist-pre-pubblicazione.md
+++ b/manuale/parte-05-checklist-pre-pubblicazione.md
@@ -2,6 +2,14 @@ _[Indice manuale](README.md)_
 
 # Parte 5 — Checklist pre-pubblicazione
 
+### 🤖 Checklist AI (Claude Code) — gate obbligato prima del commit
+
+Se il file è stato scritto, modificato o anche solo ripassato con Claude Code (CLI desktop, app mobile, sessione cloud, agent GitHub-integrato), **prima del `git add`** Claude **deve obbligatoriamente** invocare l'agent `pc-article-reviewer` sul file appena salvato. Solo dopo il via libera dell'agent (o dopo l'applicazione dei suoi fix) si procede al commit. Vale anche per un singolo articolo. Regola codificata in `CLAUDE.md` § *"Auto-gate AGID prima del commit di un nuovo articolo"*.
+
+**Eccezione — registro non-AGID solo su richiesta esplicita:** se l'utente chiede esplicitamente un documento in registro diverso (comunicato stampa, lettera istituzionale, paper scientifico, relazione tecnica, memoria, bando, delibera, ordinanza, scheda accademica, **o qualsiasi altro genere a richiesta esplicita**), il gate è sospeso per quel documento e Claude applica le convenzioni di genere del settore di appartenenza. Per i comunicati stampa vedi **Parte 12**.
+
+La checklist umana che segue resta valida **anche** dopo il passaggio dell'agent: l'agent fa il pre-flight automatico, l'utente fa il check finale.
+
 ### Checklist articolo
 
 **Frontmatter:**

--- a/manuale/parte-12-comunicati-stampa-tempo-ordinario-e-tempo-emergenziale.md
+++ b/manuale/parte-12-comunicati-stampa-tempo-ordinario-e-tempo-emergenziale.md
@@ -2,6 +2,8 @@ _[Indice manuale](README.md)_
 
 # Parte 12 — Comunicati stampa (tempo ordinario e tempo emergenziale)
 
+> 🤖 **Nota per chi redige con Claude Code.** I comunicati stampa rientrano nell'**eccezione di registro non-AGID** definita in `CLAUDE.md` § *"Auto-gate AGID prima del commit di un nuovo articolo"*. Quando chiedi a Claude di scrivere un comunicato stampa, il gate AGID standard (qualità ChatGPT 9.5/10 con frasi <20 parole, voce attiva da UX writer per il cittadino) **viene sospeso** e Claude applica le **convenzioni di genere** del comunicato istituzionale: piramide rovesciata, lead 5W, virgolettati attribuiti, blocco firma, distribuzione ai media. La differenza con un articolo del sito è sostanziale — pubblico target diverso (giornalisti vs cittadini), registro diverso (formale-tecnico vs piano-divulgativo), struttura diversa (linearità vs gerarchia di lettura libera). **L'eccezione la attivi tu chiedendo esplicitamente "scrivi un comunicato stampa"**: se ti limiti a "scrivi un articolo sull'evento X", Claude resta nel registro AGID web-cittadino. Lo stesso vale per altri generi tecnici elencati nell'eccezione (lettera istituzionale, paper scientifico, relazione, bando, ordinanza, scheda accademica, eccetera): l'eccezione la decidi tu, non Claude.
+
 ### 12.1 — A cosa serve un comunicato stampa
 
 Il comunicato stampa è lo strumento con cui il Gruppo comunica ufficialmente con i media. Nasce

--- a/manuale/parte-19-agenti-specializzati.md
+++ b/manuale/parte-19-agenti-specializzati.md
@@ -16,10 +16,11 @@ l'agente giusto.
 
 ## 19.1 I cinque agenti e quando si attivano
 
-### 1. Caporedattore (revisione articoli)
+### 1. Caporedattore (revisione articoli) — 🔴 GATE OBBLIGATO
 
-**Quando lo attivi**: hai scritto un articolo nuovo o ne hai modificato uno
-sostanziale e vuoi un controllo prima di pubblicare.
+**Da maggio 2026 questo agent è il gate obbligato pre-commit.** Quando Claude Code (in qualunque sessione: CLI desktop, app mobile, sessione cloud, agent GitHub-integrato) genera o modifica sostanzialmente un articolo in `content/comunicazioni/`, **prima del `git add`** invoca questo agent. Non è "proattivo a discrezione": è obbligatorio. Regola codificata in `CLAUDE.md` § *"Auto-gate AGID prima del commit di un nuovo articolo"* e in `.claude/rules/02-content-design-pa.md` § *"Auto-gate AGID prima del commit"*. Esiste perché il 9 maggio 2026 abbiamo dovuto rivedere retroattivamente 43 articoli storici per ripianare il debito accumulato dalle sessioni che non lo invocavano spontaneamente.
+
+**Quando lo attivi tu manualmente**: hai scritto un articolo a mano o ne hai modificato uno sostanziale e vuoi un controllo prima di pubblicare. (Se l'articolo lo ha generato Claude, l'agent è già passato per il gate prima del commit.)
 
 **Frasi naturali che lo attivano automaticamente**:
 
@@ -27,14 +28,11 @@ sostanziale e vuoi un controllo prima di pubblicare.
 - *"Controlla l'articolo `<nome-file>.md`, va bene?"*
 - *"Mi dici se ci sono errori in questo articolo?"*
 - *"Verifica frontmatter e linguaggio AGID dell'articolo che ho scritto."*
+- *"Fai una revisione AGID di tutti gli articoli del mese di X"* (batch retrospettivo).
 
-**Cosa fa**: legge il file, applica le 13 categorie di badge, verifica formato
-data, lunghezza description (≤160 char per SEO), sezioni rigide delle pagine
-rischio, foto secondo convenzione, link interni esistenti, niente conteggi
-inventario, niente burocratese, NUE 112 unico numero emergenza Lazio.
+**Cosa fa**: legge il file, applica le 13 categorie di badge, verifica formato data, lunghezza description (≤160 char per SEO), sezioni rigide delle pagine rischio, foto secondo convenzione, link interni esistenti, niente conteggi inventario, niente burocratese, NUE 112 unico numero emergenza Lazio. Quando lo si invoca con istruzione esplicita di edit (come nel pre-commit gate), applica i fix direttamente con razionale AGID per ogni modifica.
 
-**Cosa NON fa**: non riscrive l'articolo da solo. Ti dà una lista di cose da
-sistemare e tu decidi.
+**🔴 Eccezione — registro non-AGID:** se l'utente ha chiesto esplicitamente un documento in registro diverso (comunicato stampa, lettera istituzionale, paper scientifico, relazione tecnica, memoria, bando, delibera, ordinanza, scheda accademica, **o qualsiasi altro genere a richiesta esplicita**), il gate è sospeso per quel documento. Claude applica le convenzioni del genere (vedi **Parte 12** per i comunicati stampa). L'eccezione la attivi tu chiedendo esplicitamente quel registro: in assenza di richiesta esplicita, il default è AGID.
 
 **Identità tecnica** (se proprio ti serve): `pc-article-reviewer`.
 


### PR DESCRIPTION
## Sommario

Propaga la nuova regola "Auto-gate AGID prima del commit di un nuovo articolo" (introdotta in PR #163) a **tutti i documenti operativi** che parlano di redazione articoli — così la regola è visibile da ogni canale: CLI desktop, app mobile, sessione cloud, ChatGPT-cloud via GitHub connector, lettori umani del manuale.

## File modificati (9)

| File | Cosa cambia |
|---|---|
| `AGENTS.md` | I "3 vincoli operativi non negoziabili" diventano **4**. Nuova sezione 3.4 col gate completo + eccezione registro non-AGID. Quickref e titolo sezione 3 aggiornati. |
| `README.md` (root pubblico) | Nota sotto "Nuovo articolo" che cita il gate e l'eccezione documenti non-AGID |
| `MANUALE-SITO.md` (indice) | Nuove voci nella tabella "Cerca per argomento" — gate + eccezione registro |
| `MANUALE-MOBILE.md` | Nota in cima a "2. Pubblicare un articolo nuovo da mobile" — distingue Claude Code app (gate obbligato) da Claude generica |
| `manuale/parte-01` § Passo 1.13 | Blockquote per Claude Code che rinvia al gate prima del Passo 1.14 (Commit) |
| `manuale/parte-05` (checklist) | Nuova sezione iniziale "Checklist AI — gate obbligato pre-commit". La checklist umana resta valida **dopo** il gate AI |
| `manuale/parte-12` (comunicati stampa) | Nota in cima — i comunicati rientrano nell'eccezione di registro non-AGID. Spiegata la differenza pubblico-target / registro / struttura tra articolo web AGID e comunicato stampa istituzionale |
| `manuale/parte-19` § 19.1 (agenti) | Voce "Caporedattore" ora ha banner 🔴 GATE OBBLIGATO. Esplicitata l'eccezione registro non-AGID |
| `.claude/agents/pc-article-reviewer.md` | Description riscritta come **MANDATORY GATE** (non solo "PROACTIVELY") + eccezione registro |

## Why

Senza propagazione, la regola viveva solo in `CLAUDE.md` + `rules/02-content-design-pa.md`. Gli agent ChatGPT-cloud (che leggono `AGENTS.md`), i lettori umani del manuale (che leggono `manuale/parte-NN-*.md`), gli sviluppatori che leggono `README.md`, e perfino l'agent `pc-article-reviewer` stesso (che si auto-descrive nel suo file) **non la vedevano**. Ora ogni canale di documentazione la espone.

`CONTESTO-AI.md` rigenerato (gitignored, non committato).

## Test plan

- [x] Tutti i file modificati validati
- [x] Sintassi Markdown OK
- [ ] Verifica al prossimo articolo che le sessioni esterne (ChatGPT-cloud) leggano la regola e la rispettino

---
_Generated by [Claude Code](https://claude.ai/code/session_01994Zx5QNm5ZHn18X6Yfp2p)_