### PR TITLE
Counter catalogo pittogrammi: inizializza ai totali invece che 0 (fix audit ChatGPT)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/pittogrammi/single.html
+++ b/themes/flavour-pcgenzano/layouts/pittogrammi/single.html
@@ -41,8 +41,8 @@
         </div>
 
         <div class="catalogo-counter mt-2 small text-muted" aria-live="polite" aria-atomic="true">
-          <span id="counter-iso">0</span> simboli ISO 7010 ·
-          <span id="counter-ara">0</span> simboli ARASAAC mostrati
+          <span id="counter-iso">{{ sub (len (readDir $isoDir)) 1 }}</span> simboli ISO 7010 ·
+          <span id="counter-ara">{{ sub (len (readDir $araDir)) 1 }}</span> simboli ARASAAC mostrati
         </div>
       </div>
 


### PR DESCRIPTION
## Sommario

Fix del counter del catalogo pittogrammi (`/pittogrammi/`). All'apertura della pagina il counter mostrava `"0 simboli ISO 7010 · 0 simboli ARASAAC mostrati"`: era il counter del filtro di ricerca (aggiornato via JS al primo input), ma un crawler o un utente senza JS vedeva letteralmente `"0"`.

## Audit ChatGPT 2026-05-11

Esattamente quello che ChatGPT ha segnalato nel punto 12 dell'audit *"Catalogo pittogrammi: 0 simboli"*. **Non era un bug di caricamento** (i pittogrammi ci sono: 45 ISO 7010 + 125 ARASAAC, e gli H2 li mostravano correttamente) — era solo il counter del filtro inizializzato a `0`.

## Fix

Inizializza i counter ai totali reali al build, riusando la stessa funzione `readDir` già utilizzata dai due H2 sottostanti:

```diff
- <span id="counter-iso">0</span> simboli ISO 7010 ·
- <span id="counter-ara">0</span> simboli ARASAAC mostrati
+ <span id="counter-iso">{{ sub (len (readDir $isoDir)) 1 }}</span> simboli ISO 7010 ·
+ <span id="counter-ara">{{ sub (len (readDir $araDir)) 1 }}</span> simboli ARASAAC mostrati
```

Al caricamento la barra dice subito *"45 simboli ISO 7010 · 125 simboli ARASAAC mostrati"*; quando l'utente filtra, il JS li aggiorna come prima. Coerente con la semantica "mostrati" (= visibili in pagina).

## Test plan

- [x] Diff minimo (1 file, 2 righe)
- [x] Riusa logica esistente, nessuna dipendenza JS nuova
- [ ] Build Hugo CI pulito
- [ ] Verifica visiva post-deploy

## Note

Gli altri findings dell'audit ChatGPT (allerta meteo, `/index.html`, `/piano_protezione_civile/index.php`, area-download dimensioni) sono **falsi positivi da cache Google** o richiedono accesso lato server Aruba — non risolvibili dalla sandbox cloud. Vedi nota in chat per dettagli.

---
_Generated by [Claude Code](https://claude.ai/code/session_01994Zx5QNm5ZHn18X6Yfp2p)_