### PR TITLE
Audit issue #165: fix bug veri + 2 falsi positivi del workflow audit

### DIFF
--- a/.github/workflows/audit-sito.yml
+++ b/.github/workflows/audit-sito.yml
@@ -679,14 +679,18 @@ jobs:
           fi
 
           # ----------------------------------------------------------------
-          section "26. Formato data articoli (no T/timezone)"
+          section "26. Formato data articoli (no UTC, sì +02:00 Europe/Rome)"
           # NB: la sezione 8 verifica il range dell'anno; questa verifica il formato.
-          BAD_DATE_FORMAT=$(grep -lrE '^date: [0-9]{4}-[0-9]{2}-[0-9]{2}T' content/comunicazioni/ 2>/dev/null || true)
+          # Regola 02-content-design-pa.md § "Regola critica formato data":
+          #   - 1 articolo/giorno → date: AAAA-MM-GG (semplice)
+          #   - 2+ articoli/giorno → date: AAAA-MM-GGTHH:MM:SS+02:00 (orari crescenti)
+          # Il bug VERO è solo `T...Z` (UTC esplicito), non un T qualunque.
+          BAD_DATE_FORMAT=$(grep -lrE '^date: [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:]+Z' content/comunicazioni/ 2>/dev/null || true)
           if [ -n "$BAD_DATE_FORMAT" ]; then
-            err "Articoli con data in formato AAAA-MM-DDTHH:MM:SSZ (Hugo li esclude dal build):"
+            err "Articoli con data in formato \`AAAA-MM-DDTHH:MM:SSZ\` UTC (regola 02: usare \`+02:00\` Europe/Rome, mai \`Z\`):"
             echo "$BAD_DATE_FORMAT" | sed 's/^/- `/; s/$/`/' >> "$REPORT"
           else
-            ok "Tutte le date articolo nel formato \`AAAA-MM-GG\`."
+            ok "Tutte le date articolo in formato corretto (\`AAAA-MM-GG\` o \`AAAA-MM-GGTHH:MM:SS+02:00\`)."
           fi
 
           # ----------------------------------------------------------------
@@ -695,6 +699,8 @@ jobs:
           MISSING_FM=""
           for art in "$CONTENT_GLOB"/comunicazioni/*.md; do
             [ -f "$art" ] || continue
+            # Salta gli _index.md: sono indici di sezione, non articoli (regola Hugo).
+            [ "$(basename "$art")" = "_index.md" ] && continue
             fm=$(awk '/^---$/{c++; next} c==1' "$art")
             for field in $REQUIRED_FIELDS; do
               echo "$fm" | grep -qE "^$field:" || MISSING_FM="${MISSING_FM}- \`$art\`: manca campo \`$field\`\n"

--- a/themes/flavour-pcgenzano/layouts/shortcodes/pagina-emergenza-lite.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/pagina-emergenza-lite.html
@@ -47,7 +47,7 @@
 <div class="lite-pagina">
 
 <p class="text-muted small" style="margin: 0.5rem 0;">
-  ℹ️ <strong>Pagina ultra-leggera</strong> per emergenze e rete debole. Per il sito completo: <a href="/">homepage</a>. Per accessibilità cognitiva: <a href="/facile-da-leggere/">facile da leggere</a>.
+  ℹ️ <strong>Pagina ultra-leggera</strong> per emergenze e rete debole. Per il sito completo: <a href="{{ "/" | relURL }}">homepage</a>. Per accessibilità cognitiva: <a href="{{ "/facile-da-leggere/" | relURL }}">facile da leggere</a>.
 </p>
 
 {{- if and $emergenza $emergenza.attiva }}
@@ -96,16 +96,16 @@
 </div>
 
 <div class="lite-link-essenziali">
-  <a href="/cosa-fare-adesso/">Cosa fare adesso (per tipo di emergenza)</a>
-  <a href="/numeri-utili/">Tutti i numeri utili</a>
-  <a href="/allerte-meteo/">Sistema di allertamento meteo</a>
-  <a href="/piano-familiare/">Crea/consulta il tuo Piano Familiare</a>
-  <a href="/cartografia/">Aree di attesa di Genzano</a>
-  <a href="/facile-da-leggere/">Facile da leggere (testo semplificato)</a>
-  <a href="/formazione/kit-calamita-bambini/"><strong>Kit calamità bambini</strong> (schede stampabili)</a>
-  <a href="/formazione/kit-calamita-anziani/"><strong>Kit calamità anziani</strong> (schede stampabili)</a>
-  <a href="/formazione/kit-calamita-strutture-sanitarie/"><strong>Kit calamità RSA</strong> (schede operative)</a>
-  <a href="/">Sito completo</a>
+  <a href="{{ "/cosa-fare-adesso/" | relURL }}">Cosa fare adesso (per tipo di emergenza)</a>
+  <a href="{{ "/numeri-utili/" | relURL }}">Tutti i numeri utili</a>
+  <a href="{{ "/allerte-meteo/" | relURL }}">Sistema di allertamento meteo</a>
+  <a href="{{ "/piano-familiare/" | relURL }}">Crea/consulta il tuo Piano Familiare</a>
+  <a href="{{ "/cartografia/" | relURL }}">Aree di attesa di Genzano</a>
+  <a href="{{ "/facile-da-leggere/" | relURL }}">Facile da leggere (testo semplificato)</a>
+  <a href="{{ "/formazione/kit-calamita-bambini/" | relURL }}"><strong>Kit calamità bambini</strong> (schede stampabili)</a>
+  <a href="{{ "/formazione/kit-calamita-anziani/" | relURL }}"><strong>Kit calamità anziani</strong> (schede stampabili)</a>
+  <a href="{{ "/formazione/kit-calamita-strutture-sanitarie/" | relURL }}"><strong>Kit calamità RSA</strong> (schede operative)</a>
+  <a href="{{ "/" | relURL }}">Sito completo</a>
 </div>
 
 <p class="lite-footer">


### PR DESCRIPTION
## Sommario

Risolve l'audit settimanale **issue #165** del 10/05/2026: fix 1 bug vero del template + 2 bug del workflow `audit-sito.yml` stesso che generavano falsi positivi sistematici.

## 🔴 Bug VERO del sito (§21)

`themes/flavour-pcgenzano/layouts/shortcodes/pagina-emergenza-lite.html` aveva **11 `href="/..."` hardcoded** (homepage, facile-da-leggere, cosa-fare-adesso, numeri-utili, allerte-meteo, piano-familiare, cartografia, kit-calamita-*). Sostituiti con `{{ "..." | relURL }}` per compatibilità con il subpath GitHub Pages (`/sito-pc-genzano/...`).

## 🟡 Bug del workflow audit (§26 + §27)

### §26 — Regex date troppo larga

Matchava qualsiasi formato `T` nel campo `date:`, anche `T+02:00` che è **esplicitamente ammesso** dalla regola `02-content-design-pa.md` § "Regola critica formato data" per articoli con 2+ pubblicazioni nello stesso giorno. Stretta a `T...Z` (UTC esplicito), unico formato realmente vietato. Senza fix: ~100 falsi positivi ogni settimana.

### §27 — `_index.md` trattato come articolo

Il loop iterava anche su `_index.md` (indice di sezione Hugo, non articolo). Aggiunto skip esplicito. Senza fix: 5 falsi positivi fissi ogni settimana per i campi obbligatori che `_index.md` per definizione non può avere.

## 🟢 Falsi positivi documentati (no fix)

| Sezione | Motivo | Decisione |
|---|---|---|
| §18 "amatrice-10-anni-memoria" | È un `aliases:` di redirect Hugo, non link rotto | Falso positivo |
| §18 `/comunicazioni/index/` | Non esiste nel repo, parsing error del workflow | Falso positivo |
| §40 `attivita_n` / `quantita` | Identificatori di campo CSV/JSON in open-data (machine-readable, niente accenti) | Falso positivo |
| §16 Hugo deprecations | Hugo 0.143.x in uso, deprecazioni v0.158+ | Skip — non urgente |
| §10 Frasi >40 parole | Soglia AGID è >20, già applicata in revisione 9-10 maggio. Articoli pre-revisione restano | Decisione editoriale |

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` su workflow → OK
- [x] `grep 'href="/' shortcode` → 0 hit (nessun path hardcoded residuo)
- [ ] Build Hugo CI pulito
- [ ] Issue #165 chiusa con riferimento al commit di fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01994Zx5QNm5ZHn18X6Yfp2p)_