### PR TITLE
P14 Sera 2: segmented Tipo carattere + macro-toggle Modalità lettura

### DIFF
--- a/themes/flavour-pcgenzano/layouts/partials/accessibility-toolbar.html
+++ b/themes/flavour-pcgenzano/layouts/partials/accessibility-toolbar.html
@@ -65,15 +65,25 @@
         <p class="a11y-hint small text-muted mt-1 mb-0" style="font-size:0.78rem;">Per la dislessia è preferibile l'allineamento <strong>a sinistra</strong>: il giustificato crea «fiumi di bianco» difficili da leggere (WCAG 1.4.8).</p>
       </div>
 
-      <button type="button" class="a11y-toggle" data-pref="readableFont" aria-pressed="false">
-        <i class="bi bi-type me-2" aria-hidden="true"></i>
-        <span class="a11y-toggle-text">Carattere ad alta leggibilità</span>
-        <span class="a11y-toggle-state" aria-hidden="true">Off</span>
-      </button>
+      <div class="a11y-control">
+        <span class="a11y-control-label" id="a11yLblFontFamily">Tipo carattere</span>
+        <div class="a11y-segments a11y-segments-stack" role="radiogroup" aria-labelledby="a11yLblFontFamily">
+          <button type="button" class="a11y-seg" data-pref="fontFamily" data-value="default" aria-pressed="true">Predefinito</button>
+          <button type="button" class="a11y-seg" data-pref="fontFamily" data-value="readable" aria-pressed="false">Alta leggibilità</button>
+          <button type="button" class="a11y-seg" data-pref="fontFamily" data-value="dyslexic" aria-pressed="false">Per dislessia (OpenDyslexic)</button>
+        </div>
+        <p class="a11y-hint small text-muted mt-1 mb-0" style="font-size:0.78rem;">"Alta leggibilità" usa Verdana/Tahoma (già installati). "Per dislessia" carica il font OpenDyslexic: alcune persone con dislessia lo trovano d'aiuto, le evidenze scientifiche sono discusse — provalo e decidi tu.</p>
+      </div>
 
       <button type="button" class="a11y-toggle" data-pref="spacing" aria-pressed="false">
         <i class="bi bi-distribute-vertical me-2" aria-hidden="true"></i>
         <span class="a11y-toggle-text">Spaziatura ampia (righe e lettere)</span>
+        <span class="a11y-toggle-state" aria-hidden="true">Off</span>
+      </button>
+
+      <button type="button" class="a11y-toggle" data-pref="readingMode" aria-pressed="false">
+        <i class="bi bi-book me-2" aria-hidden="true"></i>
+        <span class="a11y-toggle-text">Modalità lettura (sfondo crema + spaziatura)</span>
         <span class="a11y-toggle-state" aria-hidden="true">Off</span>
       </button>
     </fieldset>

--- a/themes/flavour-pcgenzano/static/css/a11y-toolbar.css
+++ b/themes/flavour-pcgenzano/static/css/a11y-toolbar.css
@@ -186,6 +186,11 @@
   border-radius: 8px;
   padding: 4px;
 }
+/* Variante stack: una colonna sola, etichette lunghe (es. "Per dislessia
+   (OpenDyslexic)"). Usata dal segmented Tipo carattere. */
+.a11y-segments-stack {
+  grid-template-columns: 1fr;
+}
 .a11y-seg {
   background: transparent;
   color: #1a1a1a;
@@ -416,6 +421,59 @@ html.a11y-spacing main,
 html.a11y-spacing .article-body { line-height: 2 !important; letter-spacing: 0.12em !important; word-spacing: 0.16em !important; }
 html.a11y-spacing main p,
 html.a11y-spacing .article-body p { margin-bottom: 2em !important; }
+
+/* ── Modalità lettura (Sera 2, macro-toggle) ──
+   Aggrega: sfondo crema #fdf6e3 + testo #1a1a1a (contrast ratio 14:1 -
+   abbondantemente sopra WCAG 1.4.6 AAA 7:1), max-width 65ch sul corpo
+   articolo (riga di lettura ottimale ~60-75 caratteri, AGID + Bringhurst),
+   text-align left forzato (override eventuale justify), spaziatura
+   aumentata. Il font è gestito separatamente da fontFamily:
+   readingMode alza 'default' a 'readable' via JS, lascia 'dyslexic'.
+
+   Scope: NON tocchiamo `body` globale per non ribaltare l'hero-section
+   blu istituzionale dell'homepage e altri layout speciali. Lo sfondo
+   crema si applica solo a `.article-body` (corpo articolo) e
+   `.list-intro-content` (intro pagine archivio). I kit-calamita
+   stampabili (static/formazione/kit-calamita-*/) NON sono toccati
+   perché non caricano `a11y-toolbar.css`. */
+html.a11y-reading-mode .article-body,
+html.a11y-reading-mode .list-intro-content {
+  background: #fdf6e3 !important;
+  color: #1a1a1a !important;
+  max-width: 65ch !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  padding: 1.5rem 1.75rem !important;
+  border-radius: 8px !important;
+  text-align: left !important;
+  line-height: 1.85 !important;
+  letter-spacing: 0.02em !important;
+}
+/* Anche i bullet, le voci di lista e i paragrafi figli forzati a left
+   (per battere eventuali justify forzato dal toolbar `a11y-align-justify`). */
+html.a11y-reading-mode .article-body p,
+html.a11y-reading-mode .article-body li,
+html.a11y-reading-mode .list-intro-content p,
+html.a11y-reading-mode .list-intro-content li {
+  text-align: left !important;
+}
+/* I link nel corpo restano blu istituzionali ma con sfondo crema il
+   contrast resta ottimo (#003366 su #fdf6e3 ≈ 11.6:1, WCAG AAA). */
+
+/* Override stampa: la modalità lettura NON deve sporcare il PDF/stampa.
+   Sfondo bianco, no max-width (la pagina A4 ha già i suoi margini),
+   line-height standard. */
+@media print {
+  html.a11y-reading-mode .article-body,
+  html.a11y-reading-mode .list-intro-content {
+    background: #fff !important;
+    color: #000 !important;
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+  }
+}
 
 /* ── Contrasto alto ── */
 html.a11y-contrast-high body,

--- a/themes/flavour-pcgenzano/static/js/a11y-toolbar.js
+++ b/themes/flavour-pcgenzano/static/js/a11y-toolbar.js
@@ -18,8 +18,13 @@
   var defaults = {
     textSize: '0',
     textAlign: 'default',
-    readableFont: false,
+    // fontFamily ha tre valori: 'default' | 'readable' | 'dyslexic'.
+    // Sostituisce il vecchio bool `readableFont` (vedi migrazione in load()).
+    fontFamily: 'default',
     spacing: false,
+    // readingMode (Sera 2): macro-toggle che attiva spaziatura + sfondo crema
+    // + max-width + align-left + (se fontFamily=='default') forza 'readable'.
+    readingMode: false,
     contrast: 'default',
     grayscale: false,
     hideImages: false,
@@ -34,6 +39,7 @@
     // compatibile col partial inline `leggi-ad-alta-voce.html`.
     ttsRate: '0.95'
   };
+  var FONT_FAMILY_ALLOWED = ['default', 'readable', 'dyslexic'];
 
   var state = Object.assign({}, defaults);
   // Guard anti-loop: quando aggiorniamo la UI in risposta a un evento
@@ -42,6 +48,7 @@
 
   // ----------- Storage helpers -----------
   function load() {
+    var migratedFromLegacy = false;
     try {
       var raw = window.localStorage.getItem(STORAGE_KEY);
       if (raw) {
@@ -54,9 +61,39 @@
               state[k] = saved[k];
             }
           });
+
+          // MIGRAZIONE LEGACY (Sera 2): chi aveva il vecchio bool
+          // `readableFont:true` deve ritrovarsi con il nuovo
+          // `fontFamily:"readable"`. Se entrambi sono presenti vince il
+          // nuovo. Il vecchio campo viene poi rimosso dal blob al
+          // prossimo save() (vedi save() che salva solo le chiavi di
+          // defaults, e readableFont non c'è più).
+          if (Object.prototype.hasOwnProperty.call(saved, 'readableFont')) {
+            if (saved.readableFont === true && (!saved.fontFamily || saved.fontFamily === 'default')) {
+              state.fontFamily = 'readable';
+              migratedFromLegacy = true;
+            }
+          }
+
+          // Sanitize: fontFamily deve essere uno dei tre valori validi.
+          if (FONT_FAMILY_ALLOWED.indexOf(state.fontFamily) === -1) {
+            state.fontFamily = defaults.fontFamily;
+          }
         }
       }
     } catch (e) { /* localStorage non disponibile o JSON corrotto: usa default */ }
+    // Se abbiamo migrato, salva subito così il vecchio blob viene riscritto
+    // senza il campo `readableFont` legacy.
+    if (migratedFromLegacy) {
+      try {
+        var blob = {};
+        Object.keys(defaults).forEach(function (k) {
+          if (k === 'ttsRate') return;
+          blob[k] = state[k];
+        });
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(blob));
+      } catch (e) { /* */ }
+    }
     // ttsRate: leggi dalla chiave dedicata condivisa con la pill inline.
     try {
       var r = window.localStorage.getItem(TTS_RATE_KEY);
@@ -111,11 +148,21 @@
     if (state.textAlign === 'left') html.classList.add('a11y-align-left');
     else if (state.textAlign === 'justify') html.classList.add('a11y-align-justify');
 
-    // Testo: carattere
-    if (state.readableFont) html.classList.add('a11y-readable-font');
+    // Testo: famiglia carattere (mutuamente esclusive: solo UNA classe
+    // viene aggiunta su <html>, mai entrambe. Il CSS ha selettori
+    // separati `html.a11y-readable-font` e `html.a11y-dyslexic-font`).
+    if (state.fontFamily === 'readable') html.classList.add('a11y-readable-font');
+    else if (state.fontFamily === 'dyslexic') html.classList.add('a11y-dyslexic-font');
 
     // Testo: spaziatura
     if (state.spacing) html.classList.add('a11y-spacing');
+
+    // Testo: modalità lettura (macro-toggle Sera 2). Applica classe
+    // `a11y-reading-mode` che attiva: sfondo crema, max-width 65ch,
+    // align-left, spaziatura. Il font è gestito a parte da fontFamily —
+    // vedi side-effect in setPref('readingMode', true) che alza
+    // fontFamily a 'readable' se era 'default'.
+    if (state.readingMode) html.classList.add('a11y-reading-mode');
 
     // Visivo: contrasto
     if (state.contrast === 'high') html.classList.add('a11y-contrast-high');
@@ -271,6 +318,15 @@
     // ----------- Handle controls -----------
     function setPref(name, value) {
       state[name] = value;
+      // Side-effect coerente: attivando Modalità lettura, se l'utente
+      // ha "Predefinito" come font, lo alziamo a "Alta leggibilità"
+      // perché la modalità lettura nasce per ridurre la fatica visiva
+      // e il font sans-serif comune è meno adatto. Se ha già scelto
+      // "Per dislessia" (OpenDyslexic), lo lasciamo: rispetta la scelta.
+      // La regola è stata richiesta esplicitamente in Sera 2.
+      if (name === 'readingMode' && value === true && state.fontFamily === 'default') {
+        state.fontFamily = 'readable';
+      }
       if (name === 'ttsRate') saveTtsRate();
       else save();
       applyState();


### PR DESCRIPTION
## Summary

Roadmap **Punto 14 — Toolbar accessibilità potenziata**, Sera 2.

- **Feature 1 fine** — Sostituito il toggle bool `readableFont` con un **segmented "Tipo carattere"** a 3 valori: Predefinito / Alta leggibilità / Per dislessia (OpenDyslexic). Etichetta del terzo esplicita sulla evidenza scientifica discussa, mai presentata come "alta leggibilità per tutti". Migrazione legacy automatica in `load()`: chi aveva `readableFont:true` finisce a `fontFamily:'readable'` alla prossima visita; il vecchio campo viene rimosso dal blob al primo `save()`. Mutua esclusione lato JS: `applyState()` applica una sola fra `a11y-readable-font` e `a11y-dyslexic-font`, mai entrambe.
- **Feature 4** — Nuovo toggle **"Modalità lettura"** che applica in un click la classe `a11y-reading-mode` su `<html>`: sfondo crema `#fdf6e3` + testo `#1a1a1a` (contrast 14:1, WCAG AAA), `max-width: 65ch`, `text-align: left` forzato, line-height 1.85. Side-effect coerente: attivando readingMode con font "Predefinito" il JS alza a `'readable'`; se è già `'dyslexic'` viene rispettato.

## Vincoli critici verificati

- ✅ **`@media print` override** sulla classe `a11y-reading-mode`: in stampa sfondo bianco, niente max-width, niente padding. La modalità lettura NON sporca il PDF.
- ✅ **Kit-calamita stampabili** (`static/formazione/kit-calamita-*/index.html`) caricano **solo** `kit-calamita-shared/print.css`, **non** caricano `a11y-toolbar.css` → completamente intoccati dalla classe `a11y-reading-mode` per design. Verificato con `grep` pre-commit.
- ✅ **Specificity sfondo crema**: scopato a `.article-body` + `.list-intro-content`, **non** a `body` globale. Hero-section blu istituzionale dell'homepage e altri layout speciali (mini-hero pagine interne, gradienti) restano col loro background.
- ✅ **Anti-pattern banner**: nessun campo `image:` modificato in nessun file.

## File toccati (3)

- `themes/.../partials/accessibility-toolbar.html` — segmented + toggle
- `themes/.../static/css/a11y-toolbar.css` — `a11y-reading-mode` + variante `.a11y-segments-stack`
- `themes/.../static/js/a11y-toolbar.js` — `fontFamily` (3 valori), migrazione legacy, `readingMode`, side-effect, sanitize

## Test plan

- [x] Hugo build locale pulita (exit 0)
- [x] Node syntax check del JS (OK)
- [x] Nessun residuo `readableFont` nel template HTML
- [x] Post-build: 19 occorrenze `fontFamily`/`readingMode`/`dyslexic` nel JS, 25 nel CSS
- [ ] **Visual test post-deploy** Chrome desktop: segmented Tipo carattere stack verticale, OpenDyslexic caricato (network 200), modalità lettura su `/comunicazioni/...` con crema visibile, riga ~65 chars, hero homepage rimane blu, `Ctrl+P` produce PDF bianco senza crema
- [ ] **Visual test** Firefox desktop: idem
- [ ] **Migrazione legacy**: utente con `readableFont:true` in localStorage trova `fontFamily:'readable'` attivo al prossimo caricamento (verificabile in DevTools Application → localStorage)
- [ ] **Mutua esclusione**: in DevTools, mai vedere su `<html>` sia `a11y-readable-font` sia `a11y-dyslexic-font` allo stesso momento

## Scope esplicitamente fuori da questa Sera

- Feature 5 (contrasto avanzato — varianti giallo/nero, blu/crema, fix img/logo/hero/form) → Sera 3
- Aggiornamento testuale `/accessibilita/` (oggi cita ancora "carattere ad alta leggibilità" come toggle bool) → Sera 3
- Aggiornamento `manuale/parte-18` con sezione "Modalità lettura" → Sera 3 o doc-pass dedicato
- Aggiornamento `rule 03-accessibility.md` per la nuova preferenza `fontFamily` → Sera 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)