### PR TITLE
Bugfix Sera 2: early-script fontFamily/readingMode + cache-buster Aruba

### DIFF
--- a/themes/flavour-pcgenzano/layouts/_default/baseof.html
+++ b/themes/flavour-pcgenzano/layouts/_default/baseof.html
@@ -23,19 +23,42 @@
   <link rel="icon" type="image/png" sizes="32x32" href="{{ "images/favicon.png" | relURL }}">
   <link rel="stylesheet" href="{{ "vendor/bootstrap-italia/css/bootstrap-italia.min.css" | relURL }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-  <link rel="stylesheet" href="{{ "css/custom.css" | relURL }}">
-  <link rel="stylesheet" href="{{ "css/a11y-toolbar.css" | relURL }}">
+  {{/* Cache-buster v=<unix build time>: Aruba serve `a11y-toolbar.css`
+       con cache-control: max-age=2592000 (30 giorni), quindi senza
+       cache-buster i cambi al toolbar accessibilità (e modalità lettura)
+       arrivano agli utenti che hanno già visitato il sito solo dopo 30
+       giorni o dopo un hard refresh. Aggiungiamo `?v={unix}` su CSS/JS
+       critici della toolbar accessibilità per invalidare la cache ad
+       ogni deploy. `custom.css` è incluso perché contiene anche stili
+       interdipendenti con a11y. */}}
+  {{- $v := now.Unix -}}
+  <link rel="stylesheet" href="{{ "css/custom.css" | relURL }}?v={{ $v }}">
+  <link rel="stylesheet" href="{{ "css/a11y-toolbar.css" | relURL }}?v={{ $v }}">
   <link rel="canonical" href="{{ $canonicalURL }}">
   {{ partial "hreflang-tags.html" . }}
   {{/* Pre-rendering: applica subito le preferenze di accessibilità salvate
        per evitare il flash visivo (FOUC) all'apertura della pagina.
-       La logica completa del toolbar arriva con js/a11y-toolbar.js a fine body. */}}
+       La logica completa del toolbar arriva con js/a11y-toolbar.js a fine body.
+       Mantenere allineato a defaults / applyState() in a11y-toolbar.js. */}}
   <script>
   (function(){try{var s=localStorage.getItem('pcgenzano-a11y-prefs');if(!s)return;var p=JSON.parse(s);var h=document.documentElement;var add=function(c){h.classList.add(c)};
     if(p.textSize==='1')add('a11y-text-1');else if(p.textSize==='2')add('a11y-text-2');else if(p.textSize==='3')add('a11y-text-3');
     if(p.textAlign==='left')add('a11y-align-left');else if(p.textAlign==='justify')add('a11y-align-justify');
-    if(p.readableFont)add('a11y-readable-font');
+    /* Tipo carattere — Sera 2: nuova pref `fontFamily` con 3 valori.
+       Fallback per pre-migrazione: chi ha ancora il vecchio bool
+       `readableFont:true` E non ha ancora `fontFamily`, viene trattato
+       come 'readable' qui in early-script (la migrazione vera la fa
+       a11y-toolbar.js al primo load, ma vogliamo niente FOUC nel
+       frattempo). */
+    var ff=p.fontFamily;
+    if(ff!=='readable'&&ff!=='dyslexic'&&ff!=='default'){ff=p.readableFont?'readable':'default';}
+    if(ff==='readable')add('a11y-readable-font');
+    else if(ff==='dyslexic')add('a11y-dyslexic-font');
     if(p.spacing)add('a11y-spacing');
+    /* Modalità lettura — Sera 2: macro-toggle che applica sfondo crema +
+       max-width + align-left + spaziatura. Va applicata prima del
+       primo paint per evitare il flash di "modalità non attiva". */
+    if(p.readingMode)add('a11y-reading-mode');
     if(p.contrast==='high')add('a11y-contrast-high');else if(p.contrast==='invert')add('a11y-contrast-invert');
     if(p.grayscale)add('a11y-grayscale');
     if(p.hideImages)add('a11y-hide-images');
@@ -68,7 +91,7 @@
   </button>
   <script src="{{ "vendor/bootstrap-italia/js/bootstrap-italia.bundle.min.js" | relURL }}"></script>
   <script src="{{ "js/ext-widgets.js" | relURL }}" defer></script>
-  <script src="{{ "js/a11y-toolbar.js" | relURL }}" defer></script>
+  <script src="{{ "js/a11y-toolbar.js" | relURL }}?v={{ $v }}" defer></script>
   <script src="{{ "js/share.js" | relURL }}" defer></script>
   <script src="{{ "js/galleria-auto.js" | relURL }}" defer></script>
   {{ if .IsHome }}<script src="{{ "js/homepage-reveal.js" | relURL }}" defer></script>{{ end }}


### PR DESCRIPTION
## Summary

Fix del bug "Modalità lettura non funziona" diagnosticato dall'utente.

**Verifica del source code:** `applyState()` in `a11y-toolbar.js` riga 165 **già** gestiva `readingMode`, e la regola CSS riga 439 di `a11y-toolbar.css` **già** targava `.article-body` come container (non solo `.article-body p`). Source + sito live confermati con curl. Il codice del PR #172 era corretto.

**Vera causa del bug osservato:** cache HTTP Aruba aggressivo. `a11y-toolbar.css` veniva servito con `cache-control: max-age=2592000` (30 giorni!) e `expires: 2026-06-10`. Chi ha visitato il sito prima del deploy Sera 2 aveva il CSS vecchio cached per 30 giorni → `getComputedStyle(.article-body).backgroundColor` restava `rgba(0,0,0,0)` anche con classe `a11y-reading-mode` su `<html>`.

## Fix (1 file toccato)

`themes/flavour-pcgenzano/layouts/_default/baseof.html`:

1. **Cache-buster** `?v={{ now.Unix }}` su:
   - `css/custom.css`
   - `css/a11y-toolbar.css`
   - `js/a11y-toolbar.js`

   Costo: ~50 KB ricaricati ad ogni deploy. Beneficio: i cambi al toolbar accessibilità arrivano agli utenti in tempo reale, indipendentemente dal `max-age` Aruba.

2. **Inline early-script** (head, applica preferenze pre-paint per evitare FOUC) aggiornato da schema Sera 1 a Sera 2:
   - Gestisce `fontFamily` a 3 valori (`default`/`readable`/`dyslexic`) con fallback al legacy `readableFont` per utenti pre-migrazione (no flash di sans-serif default).
   - Applica `readingMode → a11y-reading-mode` pre-paint (no flash di "modalità non attiva").

## Vincoli rispettati

- ✅ `@media print` override su `a11y-reading-mode` invariato (regole in `a11y-toolbar.css` non toccate).
- ✅ Kit-calamita stampabili non toccati (non includono `baseof.html` né `a11y-toolbar.css`).
- ✅ Scoping `.article-body` / `.list-intro-content` invariato (hero homepage resta blu).
- ✅ Nessun `image:` modificato.

## Note operative post-deploy

Gli utenti che hanno già `a11y-toolbar.css` vecchio in cache devono fare **hard refresh una volta** (`Ctrl+Shift+R` / `Cmd+Shift+R`) per scaricare la versione nuova. Da quel momento in poi il cache-buster `?v=<unix>` fa il lavoro automaticamente ad ogni deploy.

## Test plan

- [x] Hugo build pulita (exit 0)
- [x] 3 cache-buster `?v=1778543839` presenti nell'HTML build
- [x] Inline early-script minificato contiene `fontFamily` (4×), `dyslexic` (4×), `readingMode` (2×)
- [x] Nessun `image:` modificato
- [ ] **Post-merge live test** dopo hard refresh (Ctrl+Shift+R):
   - `document.documentElement.classList.contains('a11y-reading-mode')` → `true` quando toggle attivo
   - `getComputedStyle(document.querySelector('.article-body')).backgroundColor` → `rgb(253, 246, 227)`
   - `getComputedStyle(document.querySelector('.article-body')).maxWidth` → ~700px (65ch)
   - `getComputedStyle(document.querySelector('.article-body')).textAlign` → `"left"`
- [ ] **Negative test homepage**: con `readingMode:true`, l'hero blu istituzionale deve restare blu (scoping CSS non tocca body né hero-section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)