### PR TITLE
Rimuovi conteggio "20 mini-giochi" dalla homepage (regola no inventario)

### DIFF
--- a/data/quick_links.yaml
+++ b/data/quick_links.yaml
@@ -94,7 +94,7 @@ servizi:
     url: "/abili-a-proteggere/"
     icona: "bi-universal-access"
     classe_icona: "si-blue"
-    descrizione: "Attività accessibili per persone con disabilità cognitive, anziani e bambini fragili. 20 mini-giochi con attestato."
+    descrizione: "Attività accessibili per persone con disabilità cognitive, anziani e bambini fragili. Mini-giochi educativi con attestato di partecipazione."
     azione: "Apri attività"
 
   - titolo: "Area Download"


### PR DESCRIPTION
Card "Abili a Proteggere" sulla homepage riportava "20 mini-giochi con attestato". Violazione della regola di progetto consolidata (`rules/04b § Niente conteggi inventario sul sito`): i materiali sono in continua modifica.

Descrizione resa qualitativa: "Mini-giochi educativi con attestato di partecipazione."

Audit collaterale: nessun altro conteggio inventario in `data/*.yaml`. La "4 attività" nel glossario è numero normativo D.Lgs. 1/2018 (citazionale, lecito).

File toccato: 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)