### PR TITLE
URGENTE: footer blu illeggibile in modalità lettura — rimuovi color scuro da body globale

### DIFF
--- a/themes/flavour-pcgenzano/static/css/a11y-toolbar.css
+++ b/themes/flavour-pcgenzano/static/css/a11y-toolbar.css
@@ -458,13 +458,19 @@ html.a11y-spacing .article-body p { margin-bottom: 2em !important; }
    fuori da Hugo, includono solo print.css proprio). */
 html.a11y-reading-mode body {
   background: #fdf6e3 !important;
-  color: #1a1a1a !important;
 }
 /* Anche `main` esplicitamente crema, perché in alcuni layout ha
    background bianco proprio che vincerebbe su body. */
 html.a11y-reading-mode main {
   background: #fdf6e3 !important;
 }
+/* IMPORTANTE — il `color` NON viene forzato su body globale.
+   Una versione precedente di questa regola applicava
+   `color: #1a1a1a !important` a tutto body, ma ribaltava il testo
+   bianco del footer blu istituzionale (.it-footer-main) e di altri
+   elementi "isole brand" che hanno testo bianco esplicito su sfondo
+   scuro proprio. Il colore scuro viene applicato SOLO ai figli delle
+   card crema dal blocco "FIX CONTRASTO" più sotto, dove serve. */
 /* SEZIONI E CARD CHE COPRONO LA PAGINA — fix urgente 12 maggio 2026.
    Senza queste regole, sulla homepage si vede tutto bianco perché:
    - `.servizi-section` ha `background: var(--pc-light-bg)` esplicito


### PR DESCRIPTION
Bug segnalato dall'utente con screenshot: il footer blu istituzionale (.it-footer-main) mostrava testo scuro invece che bianco in modalità lettura → illeggibile (blu scuro su blu, contrast ~1.5:1).

Causa: la regola `html.a11y-reading-mode body { color: #1a1a1a !important; }` forzava il colore scuro su tutti i discendenti del body, comprese le "isole brand" (footer, hero, banner) che hanno testo bianco esplicito su sfondi scuri.

Fix: rimosso `color` da body globale. Mantenuta solo `background: #fdf6e3 !important`. Il colore scuro viene applicato SOLO ai figli delle card crema dal blocco "FIX CONTRASTO" già esistente (PR #176), che è scopato esattamente agli stessi selettori delle card che diventano crema → coppia coerente, niente ribaltamenti su isole brand.

Risultato:
- Footer blu istituzionale → testo bianco (nativo) leggibile
- Hero blu → testo bianco leggibile
- Banner allerta/emergenza colorati → testo bianco leggibile
- Card crema → testo scuro #1a1a1a (regola fix contrasto invariata, contrasto 14:1 WCAG AAA)

File toccato: 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)