### PR TITLE
URGENTE: footer blu illeggibile in modalità lettura — rimuovi selettore section:not aggressivo

### DIFF
--- a/themes/flavour-pcgenzano/static/css/a11y-toolbar.css
+++ b/themes/flavour-pcgenzano/static/css/a11y-toolbar.css
@@ -493,11 +493,17 @@ html.a11y-reading-mode .card-rischio,
 html.a11y-reading-mode .link-card,
 html.a11y-reading-mode .stat-hero-item,
 html.a11y-reading-mode .bg-light,
-html.a11y-reading-mode .bg-white,
-html.a11y-reading-mode section:not(.hero-section):not(.emergency-banner) {
+html.a11y-reading-mode .bg-white {
   background: #fdf6e3 !important;
   background-color: #fdf6e3 !important;
 }
+/* IMPORTANTE — il selettore generico `section:not(.hero-section):not(.emergency-banner)`
+   è stato RIMOSSO (12 maggio 2026) perché catturava anche la `<section>` interna
+   a `<footer>.it-footer > .it-footer-main > .container > section`. Risultato:
+   il footer blu diventava crema, e il testo `text-white` di Bootstrap restava
+   bianco → bianco su crema, illeggibile. Se in futuro emerge che una sezione
+   specifica del tema NON ha una classe nell'elenco sopra ma deve diventare
+   crema, va aggiunta esplicitamente per classe (non con un selettore generico). */
 
 /* Eccezioni esplicite — restano col loro colore di brand:
    - .navbar / .it-header-* / .it-footer-* (chrome del sito)
@@ -585,8 +591,7 @@ html.a11y-reading-mode .list-intro-content li {
   html.a11y-reading-mode .link-card,
   html.a11y-reading-mode .stat-hero-item,
   html.a11y-reading-mode .bg-light,
-  html.a11y-reading-mode .bg-white,
-  html.a11y-reading-mode section:not(.hero-section):not(.emergency-banner) {
+  html.a11y-reading-mode .bg-white {
     background: #fff !important;
     background-color: #fff !important;
     color: #000 !important;


### PR DESCRIPTION
Bug segnalato dall'utente con screenshot: il footer blu istituzionale mostrava testo BIANCO su sfondo CREMA (invece di su blu) → illeggibile (contrasto 1.2:1).

Causa: la regola `section:not(.hero-section):not(.emergency-banner) { background: #fdf6e3 !important; }` era una rete di sicurezza troppo larga e catturava la `<section class="py-4">` INTERNA al `<footer>` → la section copriva di crema il blu del `.it-footer-main` → text-white Bootstrap restava bianco su crema = invisibile.

Fix: rimosso il selettore generico, mantenuto solo l'elenco esplicito di classi del tema. Aggiunto commento inline per evitare regressioni future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)