### PR TITLE
P14 Sera 3: contrasto avanzato (5 varianti) + doc allineata

### DIFF
--- a/.claude/rules/03-accessibility.md
+++ b/.claude/rules/03-accessibility.md
@@ -82,17 +82,30 @@ Documentazione completa: `MANUALE-SITO.md` Parte 3.16.
 
 ## Strumenti di Accessibilità (toolbar utente)
 
-Il sito ha un **toolbar di accessibilità** nativo, presente su tutte le pagine come bottone rotondo blu (FAB) in basso a sinistra. Apre un dialog con preferenze di lettura: dimensione testo (livelli), allineamento, carattere ad alta leggibilità, spaziatura ampia, contrasto (alto/invertito), scala di grigi, nascondi immagini decorative, pausa animazioni, evidenzia link, cursore grande, **nascondi pulsanti flottanti** (Assistente virtuale + SOS 112, utile da mobile dove possono coprire il testo). Le preferenze sono salvate in `localStorage` e applicate come classi `html.a11y-*`.
+Il sito ha un **toolbar di accessibilità** nativo, presente su tutte le pagine come bottone rotondo blu (FAB) in basso a sinistra. Apre un dialog con preferenze di lettura:
 
-Per la struttura dei file, le regole di estensione e i divieti operativi vedi `04b-hugo-template-css.md` sezione "Strumenti di Accessibilità".
+- **Testo**: dimensione (4 livelli 100/110/125/150%), allineamento (predefinito/sinistra/giustificato), **Tipo carattere** (segmented a 3 valori: Predefinito / Alta leggibilità Verdana-Tahoma / Per dislessia OpenDyslexic self-hosted SIL OFL 1.1), spaziatura ampia, **Modalità lettura** (macro-toggle: sfondo crema #fdf6e3 + max-width 65ch + align-left + spaziatura).
+- **Visivo**: **Contrasto** segmented a **5 valori** (Predefinito / Alto nero-su-bianco / Invertito bianco-su-nero / Giallo-su-nero stile Windows HC Black / Blu-su-crema stile BBC My Web My Way), scala di grigi, nascondi immagini decorative, pausa animazioni.
+- **Orientamento**: evidenzia link, cursore grande.
+- **Lettura ad alta voce**: velocità (segmented Lenta 0.75x / Normale 0.95x / Veloce 1.15x) — sincronizzata bidirezionalmente con la pill inline accanto al bottone "Leggi ad alta voce" via `CustomEvent('pcgenzano:tts-rate-change')` su `window`, chiave storage condivisa `pcgenzano-tts-rate`.
+- **Pulsanti flottanti**: nascondi Assistente virtuale / SOS 112 / selettore lingua (utile da mobile dove possono coprire il testo).
+
+Le preferenze sono salvate in `localStorage` chiave `pcgenzano-a11y-prefs` (tranne `ttsRate` che vive nella chiave dedicata `pcgenzano-tts-rate`) e applicate come classi `html.a11y-*`. C'è anche un **inline early-script** in `baseof.html` che applica le pref pre-paint per evitare FOUC.
+
+**Pref `fontFamily` (sostituisce il vecchio bool `readableFont`):** tre valori `default` / `readable` / `dyslexic`. Migrazione legacy automatica in `load()`: chi aveva `readableFont:true` viene mappato a `fontFamily:'readable'` alla prima visita e il vecchio campo rimosso al primo save. Le classi `a11y-readable-font` e `a11y-dyslexic-font` sono **mutuamente esclusive** lato JS — mai applicate insieme su `<html>`.
+
+Per la struttura dei file, le regole di estensione e i divieti operativi vedi `04b-hugo-template-css.md` sezione "Strumenti di Accessibilità". Documentazione operativa completa: `manuale/parte-18-lettura-accessibile-maggio-2026.md` § 18.18 "Modalità lettura".
 
 **Principio:** il toolbar è uno strumento di **preferenze utente** sopra a un sito **già conforme WCAG 2.2 AA**. Non sostituisce l'accessibilità nativa: la integra. **Non è un overlay commerciale** (tipo AccessiBe, UserWay, Equally AI), che il W3C-WAI e le associazioni delle persone con disabilità sconsigliano perché mascherano problemi invece di risolverli.
 
 **Regole operative:**
 
-- Quando si modifica un componente del sito, controllare che funzioni anche con il toolbar attivo: in particolare con **contrasto invertito** (sfondo nero, testo bianco), **scala di grigi**, **immagini nascoste** e **pausa animazioni**.
+- Quando si modifica un componente del sito, controllare che funzioni anche con il toolbar attivo: in particolare con **contrasto invertito** (sfondo nero, testo bianco), **giallo-su-nero**, **blu-su-crema**, **modalità lettura**, **scala di grigi**, **immagini nascoste** e **pausa animazioni**.
 - Le icone funzionali (Bootstrap Icons) restano visibili anche con "Nascondi immagini" attivo: solo `<img>`, `<picture>`, `<video>`, `<iframe>` e SVG decorativi sono nascosti.
 - Il FAB ha posizione **bottom-left** per non collidere con `back-to-top` (right) né con `sos-112` (right su mobile). Mantenere questa convenzione.
+- **`a11y-reading-mode`** (Modalità lettura): la crema si applica **solo** a `body`, `main` e a un elenco esplicito di classi del tema (`.servizi-section`, `.notizie-section`, `.card*`, `.quick-action-card`, `.stat-hero-item`, `.bg-light`, `.bg-white`). **VIETATO usare selettori generici** tipo `section:not(.hero-section)` perché catturano anche la `<section>` interna al `<footer>` e rompono il colore di brand del footer (incidente 12 maggio 2026, PR #179). Per estendere a una nuova sezione, aggiungere classe **esplicita**.
+- **`a11y-contrast-yellow-black` e `a11y-contrast-blue-cream`** (varianti contrasto avanzate): applicano override esplicito su body + intestazioni + form input + card + hero + banner + footer (ridipinti in coppia colore per coerenza visiva). **Niente `filter: invert(1)`** che ribalterebbe immagini e logo.
+- Per i contrasti, mai usare `html.a11y-reading-mode body { color: ... !important }` o regole `color` su `body` globale: ribaltano il testo bianco delle "isole brand" (footer blu, hero blu, banner colorati). Il colore del testo va applicato **solo** dove anche lo sfondo è ribaltato (coppia coerente).
 - La pagina pubblica `/accessibilita/` descrive il toolbar al cittadino e va tenuta allineata se si aggiungono o tolgono funzioni.
 
 ## TTS "Leggi ad alta voce" (Web Speech API)

--- a/content/accessibilita/_index.md
+++ b/content/accessibilita/_index.md
@@ -4,7 +4,7 @@ description: "Dichiarazione di accessibilità conforme al modello AGID. Stato di
 layout: "single"
 toc: true
 tts: true
-dataUltimaRevisione: "2026-05-10"
+dataUltimaRevisione: "2026-05-12"
 aliases:
   - /dichiarazione-accessibilita.html
 ---
@@ -126,17 +126,19 @@ Il sito è progettato per facilitare la consultazione da computer, tablet e smar
 
 In ogni pagina, in basso a sinistra, trovi un pulsante rotondo blu con l'icona di accessibilità. Aprendo il pannello puoi:
 
-- ingrandire il testo;
-- cambiare l'allineamento dei paragrafi;
-- attivare un carattere ad alta leggibilità;
-- aumentare spaziatura di righe e lettere;
-- attivare contrasto alto o contrasto invertito;
+- ingrandire il testo (quattro livelli, fino al 150 per cento);
+- cambiare l'allineamento dei paragrafi (predefinito, a sinistra, giustificato);
+- scegliere il **tipo di carattere**: predefinito, ad alta leggibilità (Verdana/Tahoma), oppure **OpenDyslexic** (carattere disegnato per persone con dislessia, opzionale);
+- aumentare la spaziatura di righe e lettere;
+- attivare la **Modalità lettura**: sfondo crema, riga di lettura ottimale (65 caratteri), spaziatura aumentata, allineamento a sinistra forzato. Pensata per ridurre la fatica visiva nelle letture lunghe;
+- scegliere il **contrasto** tra cinque varianti: predefinito, alto (nero su bianco), invertito (bianco su nero), giallo su nero (stile Windows ad alto contrasto), blu su crema (stile BBC My Web My Way per dislessia e ipovisione);
+- regolare la **velocità della lettura ad alta voce** (lenta, normale, veloce) direttamente dal pannello — la scelta si applica subito al bottone "Leggi ad alta voce";
 - visualizzare il sito in scala di grigi;
-- nascondere immagini decorative;
+- nascondere le immagini decorative;
 - mettere in pausa le animazioni;
-- evidenziare i link;
+- evidenziare tutti i link;
 - attivare un cursore grande;
-- nascondere i pulsanti flottanti, se coprono il testo su telefono.
+- nascondere i pulsanti flottanti (Assistente virtuale, SOS 112, selettore lingua) se coprono il testo, soprattutto da telefono.
 
 Le preferenze restano salvate sul dispositivo. Puoi cancellarle con il pulsante **Reimposta tutto**.
 

--- a/manuale/parte-18-lettura-accessibile-maggio-2026.md
+++ b/manuale/parte-18-lettura-accessibile-maggio-2026.md
@@ -427,4 +427,74 @@ il testo le scrive così), (e) il build Hugo sia stato rilanciato.
 
 ---
 
+### 18.18 Modalità lettura (Sera 2/3 — maggio 2026)
+
+Sotto la sezione "Testo" del pannello Strumenti di accessibilità c'è un
+toggle **"Modalità lettura"** che applica in un click una serie di
+preferenze tipografiche pensate per ridurre la fatica visiva nelle
+letture lunghe:
+
+- sfondo **crema** `#fdf6e3` (riposante, evita il bagliore del bianco puro);
+- **`max-width: 65 ch`** sul corpo articolo (riga di lettura ottimale
+  ~60-75 caratteri, criterio AGID/Bringhurst);
+- **`text-align: left`** forzato (sovrascrive eventuale giustificato che
+  crea "fiumi di bianco" per chi ha dislessia);
+- line-height aumentato a 1.85, letter-spacing 0.02em;
+- se il **Tipo carattere** era impostato a "Predefinito", viene alzato
+  automaticamente a "Alta leggibilità" (Verdana/Tahoma) per coerenza —
+  la modalità lettura nasce per ridurre la fatica visiva e il sans-serif
+  comune è meno adatto. Se l'utente aveva già scelto "Per dislessia
+  (OpenDyslexic)", la sua scelta viene rispettata.
+
+**Contrasto risultante:** crema `#fdf6e3` + testo scuro `#1a1a1a` =
+14:1 → WCAG AAA con largo margine.
+
+**Scope CSS:**
+La crema si applica a `body`, `main`, e a un elenco esplicito di
+classi del tema: `.servizi-section`, `.notizie-section`, `.card`,
+`.card-body`, `.quick-action-card`, `.card-servizio`, `.card-notizia-hero`,
+`.card-numero-utile`, `.card-rischio`, `.link-card`, `.stat-hero-item`,
+`.bg-light`, `.bg-white`. **Niente selettori generici** tipo
+`section:not(.hero-section)` perché catturerebbero anche la `<section>`
+interna al `<footer>` (incidente del 12 maggio 2026, vedi commit
+8c7cd06 e PR #179 — bug "footer blu illeggibile in modalità lettura").
+Le "isole istituzionali" (hero blu, banner allerta, banner emergenza,
+navbar, footer blu) restano col loro colore di brand per cascade
+naturale.
+
+**`@media print`:** override esteso a body + main + tutte le classi
+sopra → sfondo bianco in stampa, niente crema sul PDF. I
+kit-calamita stampabili (`static/formazione/kit-calamita-*/`)
+non sono toccati perché non caricano `a11y-toolbar.css`.
+
+**Tipo carattere** (segmented "Predefinito / Alta leggibilità / Per dislessia"):
+il vecchio toggle bool `readableFont` è stato sostituito con la pref
+`fontFamily` a tre valori. La migrazione legacy è automatica in
+`load()`: chi aveva `readableFont:true` viene mappato a
+`fontFamily:'readable'` alla prima visita post-deploy e il vecchio
+campo viene rimosso al primo save. La classe `a11y-readable-font` e
+`a11y-dyslexic-font` sono **mutuamente esclusive** lato JS
+(`applyState()` applica una sola fra le due, mai entrambe).
+
+**Velocità lettura ad alta voce nella toolbar (Sera 1):**
+oltre alla pill velocità accanto al bottone "Leggi ad alta voce",
+c'è ora un segmented dedicato dentro il dialog toolbar (sezione
+"Lettura ad alta voce"). I due controlli sono sincronizzati
+bidirezionalmente via `CustomEvent('pcgenzano:tts-rate-change')` su
+`window` + guard `ttsRateSyncing` / `rateSyncing` su entrambi i lati
+per evitare loop di echo. Chiave storage condivisa: `pcgenzano-tts-rate`.
+
+**Contrasto a 5 varianti (Sera 3):**
+predefinito / alto (nero su bianco) / invertito (bianco su nero) /
+**giallo su nero** (stile Windows HC Black, contrast 19.6:1) /
+**blu su crema** (stile BBC My Web My Way, contrast 9.8:1). Le ultime
+due sono pensate per utenti con ipovisione (giallo/nero) e con dislessia
+o stancabilità visiva (blu/crema). Approccio: niente `filter: invert(1)`
+(ribalterebbe immagini e logo), tutto via override esplicito su body,
+intestazioni, form input, card, hero, banner. Hero blu e banner colorati
+vengono **ridipinti** per coerenza visiva quando il contrasto avanzato
+è attivo (a differenza della Modalità lettura crema dove restano blu).
+
+---
+
 _[Indice manuale](README.md)_

--- a/themes/flavour-pcgenzano/layouts/_default/baseof.html
+++ b/themes/flavour-pcgenzano/layouts/_default/baseof.html
@@ -59,7 +59,10 @@
        max-width + align-left + spaziatura. Va applicata prima del
        primo paint per evitare il flash di "modalità non attiva". */
     if(p.readingMode)add('a11y-reading-mode');
-    if(p.contrast==='high')add('a11y-contrast-high');else if(p.contrast==='invert')add('a11y-contrast-invert');
+    if(p.contrast==='high')add('a11y-contrast-high');
+    else if(p.contrast==='invert')add('a11y-contrast-invert');
+    else if(p.contrast==='yellow-black')add('a11y-contrast-yellow-black');
+    else if(p.contrast==='blue-cream')add('a11y-contrast-blue-cream');
     if(p.grayscale)add('a11y-grayscale');
     if(p.hideImages)add('a11y-hide-images');
     if(p.pauseAnimations)add('a11y-pause-animations');

--- a/themes/flavour-pcgenzano/layouts/partials/accessibility-toolbar.html
+++ b/themes/flavour-pcgenzano/layouts/partials/accessibility-toolbar.html
@@ -113,11 +113,14 @@
 
       <div class="a11y-control">
         <span class="a11y-control-label" id="a11yLblContrast">Contrasto</span>
-        <div class="a11y-segments" role="radiogroup" aria-labelledby="a11yLblContrast">
+        <div class="a11y-segments a11y-segments-stack" role="radiogroup" aria-labelledby="a11yLblContrast">
           <button type="button" class="a11y-seg" data-pref="contrast" data-value="default" aria-pressed="true">Predefinito</button>
-          <button type="button" class="a11y-seg" data-pref="contrast" data-value="high" aria-pressed="false">Alto</button>
-          <button type="button" class="a11y-seg" data-pref="contrast" data-value="invert" aria-pressed="false">Invertito</button>
+          <button type="button" class="a11y-seg" data-pref="contrast" data-value="high" aria-pressed="false">Alto (nero su bianco)</button>
+          <button type="button" class="a11y-seg" data-pref="contrast" data-value="invert" aria-pressed="false">Invertito (bianco su nero)</button>
+          <button type="button" class="a11y-seg" data-pref="contrast" data-value="yellow-black" aria-pressed="false">Giallo su nero</button>
+          <button type="button" class="a11y-seg" data-pref="contrast" data-value="blue-cream" aria-pressed="false">Blu su crema</button>
         </div>
+        <p class="a11y-hint small text-muted mt-1 mb-0" style="font-size:0.78rem;">"Giallo su nero" è la modalità ad alto contrasto del sistema Windows; "Blu su crema" è la preferenza consigliata da BBC My Web My Way per molti utenti con dislessia o ipovisione.</p>
       </div>
 
       <button type="button" class="a11y-toggle" data-pref="grayscale" aria-pressed="false">

--- a/themes/flavour-pcgenzano/static/css/a11y-toolbar.css
+++ b/themes/flavour-pcgenzano/static/css/a11y-toolbar.css
@@ -654,6 +654,130 @@ html.a11y-contrast-invert .a11y-fab,
 html.a11y-contrast-invert .a11y-dialog,
 html.a11y-contrast-invert .a11y-dialog * { /* niente override aggressivo */ }
 
+/* ── Contrasto Giallo su nero — Sera 3 (12 maggio 2026) ──
+   Stile "High Contrast Black" di Windows: sfondo nero, testo giallo
+   (#ffff00), link ciano (#00ffff). Contrast ratio giallo/nero = 19.6:1,
+   ciano/nero = 16.5:1 (entrambi WCAG AAA con larghissimo margine).
+   Approccio: override esplicito per body, intestazioni, paragrafi,
+   form input, card, alert, hero-section. Niente `filter: invert(1)`
+   (che ribalterebbe immagini e logo). Le icone Bootstrap restano
+   bianche o seguono colore corrente, quindi diventano gialle.
+   Form input: bordi visibili 2px gialli, sfondo nero.
+   Hero blu e banner colorati: override esplicito a nero+giallo per
+   coerenza visiva e leggibilità. */
+html.a11y-contrast-yellow-black body,
+html.a11y-contrast-yellow-black main { background: #000 !important; color: #ffff00 !important; }
+html.a11y-contrast-yellow-black h1,
+html.a11y-contrast-yellow-black h2,
+html.a11y-contrast-yellow-black h3,
+html.a11y-contrast-yellow-black h4,
+html.a11y-contrast-yellow-black h5,
+html.a11y-contrast-yellow-black h6,
+html.a11y-contrast-yellow-black p,
+html.a11y-contrast-yellow-black li,
+html.a11y-contrast-yellow-black td,
+html.a11y-contrast-yellow-black th,
+html.a11y-contrast-yellow-black span,
+html.a11y-contrast-yellow-black strong,
+html.a11y-contrast-yellow-black em { color: #ffff00 !important; }
+html.a11y-contrast-yellow-black a,
+html.a11y-contrast-yellow-black a:visited { color: #00ffff !important; text-decoration: underline !important; }
+html.a11y-contrast-yellow-black .card,
+html.a11y-contrast-yellow-black .alert,
+html.a11y-contrast-yellow-black .servizi-section,
+html.a11y-contrast-yellow-black .notizie-section,
+html.a11y-contrast-yellow-black .card-body,
+html.a11y-contrast-yellow-black .quick-action-card,
+html.a11y-contrast-yellow-black .card-servizio,
+html.a11y-contrast-yellow-black .card-numero-utile,
+html.a11y-contrast-yellow-black .card-rischio,
+html.a11y-contrast-yellow-black .link-card,
+html.a11y-contrast-yellow-black .stat-hero-item,
+html.a11y-contrast-yellow-black .hero-section,
+html.a11y-contrast-yellow-black .mini-hero,
+html.a11y-contrast-yellow-black .emergency-banner,
+html.a11y-contrast-yellow-black .it-footer-main,
+html.a11y-contrast-yellow-black .it-footer-small-prints {
+  background: #000 !important;
+  background-color: #000 !important;
+  color: #ffff00 !important;
+  border-color: #ffff00 !important;
+}
+/* Form input: contorno giallo, sfondo nero, testo giallo. Cursore
+   visibile su entrambi i fondi. */
+html.a11y-contrast-yellow-black input,
+html.a11y-contrast-yellow-black textarea,
+html.a11y-contrast-yellow-black select,
+html.a11y-contrast-yellow-black button:not(.a11y-fab):not(.a11y-seg):not(.a11y-toggle):not(.a11y-close):not(.a11y-btn) {
+  background: #000 !important;
+  color: #ffff00 !important;
+  border: 2px solid #ffff00 !important;
+}
+html.a11y-contrast-yellow-black input::placeholder,
+html.a11y-contrast-yellow-black textarea::placeholder { color: #cccc00 !important; }
+/* Lascia inalterati FAB e dialog di accessibilità (sono contrastati per design). */
+html.a11y-contrast-yellow-black .a11y-fab,
+html.a11y-contrast-yellow-black .a11y-dialog,
+html.a11y-contrast-yellow-black .a11y-dialog * { /* niente override */ }
+
+/* ── Contrasto Blu su crema — Sera 3 (12 maggio 2026) ──
+   Stile "BBC My Web My Way": sfondo crema #fdf6e3, testo blu istituzionale
+   #003a78 (contrast 9.8:1 vs crema, WCAG AAA). Variante adatta a utenti
+   con dislessia o ipovisione che trovano stancante il bianco puro ma
+   vogliono comunque alto contrasto + leggibilità lunga. Link in blu
+   navy più scuro #00224e (~14:1) per distinguibilità. */
+html.a11y-contrast-blue-cream body,
+html.a11y-contrast-blue-cream main { background: #fdf6e3 !important; color: #003a78 !important; }
+html.a11y-contrast-blue-cream h1,
+html.a11y-contrast-blue-cream h2,
+html.a11y-contrast-blue-cream h3,
+html.a11y-contrast-blue-cream h4,
+html.a11y-contrast-blue-cream h5,
+html.a11y-contrast-blue-cream h6,
+html.a11y-contrast-blue-cream p,
+html.a11y-contrast-blue-cream li,
+html.a11y-contrast-blue-cream td,
+html.a11y-contrast-blue-cream th,
+html.a11y-contrast-blue-cream span,
+html.a11y-contrast-blue-cream strong,
+html.a11y-contrast-blue-cream em { color: #003a78 !important; }
+html.a11y-contrast-blue-cream a,
+html.a11y-contrast-blue-cream a:visited { color: #00224e !important; text-decoration: underline !important; }
+html.a11y-contrast-blue-cream .card,
+html.a11y-contrast-blue-cream .alert,
+html.a11y-contrast-blue-cream .servizi-section,
+html.a11y-contrast-blue-cream .notizie-section,
+html.a11y-contrast-blue-cream .card-body,
+html.a11y-contrast-blue-cream .quick-action-card,
+html.a11y-contrast-blue-cream .card-servizio,
+html.a11y-contrast-blue-cream .card-numero-utile,
+html.a11y-contrast-blue-cream .card-rischio,
+html.a11y-contrast-blue-cream .link-card,
+html.a11y-contrast-blue-cream .stat-hero-item,
+html.a11y-contrast-blue-cream .hero-section,
+html.a11y-contrast-blue-cream .mini-hero,
+html.a11y-contrast-blue-cream .emergency-banner,
+html.a11y-contrast-blue-cream .it-footer-main,
+html.a11y-contrast-blue-cream .it-footer-small-prints {
+  background: #fdf6e3 !important;
+  background-color: #fdf6e3 !important;
+  color: #003a78 !important;
+  border-color: #003a78 !important;
+}
+html.a11y-contrast-blue-cream input,
+html.a11y-contrast-blue-cream textarea,
+html.a11y-contrast-blue-cream select,
+html.a11y-contrast-blue-cream button:not(.a11y-fab):not(.a11y-seg):not(.a11y-toggle):not(.a11y-close):not(.a11y-btn) {
+  background: #fffaf0 !important;
+  color: #003a78 !important;
+  border: 2px solid #003a78 !important;
+}
+html.a11y-contrast-blue-cream input::placeholder,
+html.a11y-contrast-blue-cream textarea::placeholder { color: #6b7a9c !important; }
+html.a11y-contrast-blue-cream .a11y-fab,
+html.a11y-contrast-blue-cream .a11y-dialog,
+html.a11y-contrast-blue-cream .a11y-dialog * { /* niente override */ }
+
 /* ── Scala di grigi ── */
 html.a11y-grayscale { filter: grayscale(1); }
 /* Eccezione: il dialog di accessibilità deve restare in colori vivi

--- a/themes/flavour-pcgenzano/static/js/a11y-toolbar.js
+++ b/themes/flavour-pcgenzano/static/js/a11y-toolbar.js
@@ -164,9 +164,16 @@
     // fontFamily a 'readable' se era 'default'.
     if (state.readingMode) html.classList.add('a11y-reading-mode');
 
-    // Visivo: contrasto
+    // Visivo: contrasto — 5 valori
+    //   'default'      → niente classe (resta lo stile nativo del tema)
+    //   'high'         → a11y-contrast-high       (nero su bianco)
+    //   'invert'       → a11y-contrast-invert     (bianco su nero)
+    //   'yellow-black' → a11y-contrast-yellow-black (giallo su nero, stile Windows HC Black)
+    //   'blue-cream'   → a11y-contrast-blue-cream   (blu scuro su crema, stile BBC My Web My Way)
     if (state.contrast === 'high') html.classList.add('a11y-contrast-high');
     else if (state.contrast === 'invert') html.classList.add('a11y-contrast-invert');
+    else if (state.contrast === 'yellow-black') html.classList.add('a11y-contrast-yellow-black');
+    else if (state.contrast === 'blue-cream') html.classList.add('a11y-contrast-blue-cream');
 
     // Visivo: scala di grigi
     if (state.grayscale) html.classList.add('a11y-grayscale');


### PR DESCRIPTION
Ultima tappa del Punto 14 della roadmap.

## Feature 5 — Contrasto avanzato (3 → 5 varianti)

Segmented "Contrasto" del pannello passa da 3 a 5 opzioni:
1. Predefinito
2. Alto (nero su bianco) — invariato
3. Invertito (bianco su nero) — invariato
4. **NUOVO: Giallo su nero** (`a11y-contrast-yellow-black`) — stile Windows HC Black, contrast 19.6:1
5. **NUOVO: Blu su crema** (`a11y-contrast-blue-cream`) — stile BBC My Web My Way, contrast 9.8:1, pensato per dislessia/ipovisione

Approccio: niente `filter: invert(1)` (ribalterebbe immagini e logo). Override esplicito su body, intestazioni, form input, card, hero, banner, footer (ridipinti in coppia colore per coerenza visiva).

JS + early-script (`baseof.html`) aggiornati per riconoscere i 2 nuovi valori.

## Documentazione allineata (4 file)

- `content/accessibilita/_index.md`: riscritta la lista funzioni del pannello con le 13 opzioni attuali. `dataUltimaRevisione` → 2026-05-12.
- `manuale/parte-18-lettura-accessibile-maggio-2026.md`: nuova § 18.18 "Modalità lettura" che documenta scope CSS, side-effect fontFamily, override stampa, migrazione legacy, sync bidirezionale TTS rate, varianti contrasto.
- `.claude/rules/03-accessibility.md`: sezione riscritta con struttura corrente del pannello, pref `fontFamily` a 3 valori, mutua esclusione classi, regole operative aggiornate con le lezioni dei bugfix del 12 maggio (vietato selettori generici tipo `section:not()`, vietato `color` su body globale).

## Test plan

- [x] Hugo build pulita (exit 0)
- [x] CSS post-build contiene 84 occorrenze `yellow-black` / `blue-cream`
- [x] JS post-build contiene 4 occorrenze
- [x] Nessun `image:` modificato
- [ ] **Post-deploy**: aprire pannello → sezione Visivo → Contrasto → testare "Giallo su nero" e "Blu su crema" su homepage, articolo, pagina contatti
- [ ] **Form input** (es. ricerca, form contatti) leggibili in entrambe le nuove varianti
- [ ] Hero blu si trasforma in nero/giallo in giallo-su-nero, e in crema/blu in blu-su-crema
- [ ] Modalità lettura ancora invariata (regressione test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)