### PR TITLE
P15: Podcast dashboard + bottone Scarica trascrizione PDF

### DIFF
--- a/content/podcast/_index.md
+++ b/content/podcast/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Podcast — Ascolta gli articoli del sito"
+description: "Tutti gli articoli del Gruppo Comunale ascoltabili ad alta voce, gratis, senza app esterne. Lettura vocale diretta dal browser con voce italiana."
+type: "podcast"
+layout: "list"
+dataUltimaRevisione: "2026-05-12"
+---
+
+Tutti gli articoli pubblicati sul sito possono essere **ascoltati ad alta voce** direttamente dal tuo browser, senza scaricare nulla e senza installare app. La voce italiana del tuo dispositivo legge il testo in tempo reale.
+
+**Come funziona.** Apri un articolo e clicca il bottone **"Leggi ad alta voce"** in cima al contenuto. Il browser usa la voce italiana del sistema operativo (Chrome, Edge, Safari iOS, Firefox supportano tutti questa funzione). Niente account, niente cookie, niente connessione a server esterni: la lettura avviene **interamente sul tuo dispositivo**.
+
+**Velocità di lettura.** Lenta, normale o veloce — scegli dal selettore accanto al bottone, oppure dal pannello **Strumenti di accessibilità** (icona blu in basso a sinistra di ogni pagina).
+
+**Trascrizione PDF.** Su ogni articolo è disponibile un bottone **"Scarica trascrizione PDF"** che apre la finestra di stampa del browser: scegli "Salva come PDF" per avere il testo dell'articolo su carta digitale, formato A4, senza il chrome del sito.
+
+**Versione Braille (BRF).** Ogni articolo ha anche una versione [Braille Ready Format](/manuali/) scaricabile, compatibile con display braille e stampanti braille (Index, ViewPlus). Pensata per ciechi e ipovedenti che usano lettori tattili.
+
+Sotto trovi l'elenco completo degli articoli ascoltabili, con la **durata stimata** di lettura ad alta voce.

--- a/hugo.toml
+++ b/hugo.toml
@@ -279,10 +279,16 @@ enableGitInfo = true
   weight = 8
 
 [[menus.main]]
+  name = "Podcast"
+  url = "/podcast/"
+  parent = "risorse"
+  weight = 9
+
+[[menus.main]]
   name = "Mappa del Sito"
   url = "/mappa-sito/"
   parent = "risorse"
-  weight = 9
+  weight = 10
 
 # --- Voci dirette ---
 [[menus.main]]

--- a/static/app-shared/site-chrome.js
+++ b/static/app-shared/site-chrome.js
@@ -144,6 +144,7 @@
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/standard-iso/" role="menuitem"><span>Standard ISO</span></a></li>' +
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/trasparenza/" role="menuitem"><span>Trasparenza</span></a></li>' +
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/open-data/" role="menuitem"><span>Open Data</span></a></li>' +
+                    '<li role="none"><a class="list-item" href="' + SITE_URL + '/podcast/" role="menuitem"><span>Podcast</span></a></li>' +
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/mappa-sito/" role="menuitem"><span>Mappa del Sito</span></a></li>' +
                   '</ul></div></div>' +
                 '</li>' +

--- a/themes/flavour-pcgenzano/layouts/_default/single.html
+++ b/themes/flavour-pcgenzano/layouts/_default/single.html
@@ -110,6 +110,12 @@
            Specifiche: manuale/parte-24-output-braille-articoli.md */}}
       {{ partial "scarica-braille.html" . }}
 
+      {{/* ── DOWNLOAD TRASCRIZIONE PDF (Punto 15 roadmap) ──
+           Chiama window.print(). Il sito ha già @media print globale che
+           stampa solo il corpo articolo (no chrome). L'utente sceglie
+           "Salva come PDF" nella finestra di stampa. */}}
+      {{ partial "scarica-trascrizione-pdf.html" . }}
+
       {{/* ── CONTENUTO ── */}}
       <article class="article-body">{{ .Content }}</article>
 

--- a/themes/flavour-pcgenzano/layouts/partials/scarica-trascrizione-pdf.html
+++ b/themes/flavour-pcgenzano/layouts/partials/scarica-trascrizione-pdf.html
@@ -1,0 +1,30 @@
+{{/* Partial: scarica-trascrizione-pdf (Punto 15 roadmap — maggio 2026)
+
+     Bottone "Scarica trascrizione PDF" sopra il corpo articolo.
+     Implementazione minimale: chiama window.print(). Il sito ha già
+     `@media print` globale che nasconde header/navbar/footer/banner
+     e stampa solo il corpo articolo. L'utente sceglie "Salva come PDF"
+     nella finestra di stampa del browser per ottenere il PDF.
+
+     Niente generazione server-side (richiederebbe WeasyPrint/wkhtmltopdf
+     come dipendenza CI), niente API esterne, niente costi.
+
+     Mostrato sopra il corpo dell'articolo, vicino al bottone TTS e
+     al bottone "Scarica versione braille". Cluster di accessibilità
+     coerente. */}}
+
+{{- if eq .Section "comunicazioni" -}}
+<div class="trascrizione-pdf-download mb-3" role="region" aria-label="Scarica trascrizione PDF">
+  <button type="button"
+          class="btn btn-outline-primary btn-sm"
+          onclick="window.print()"
+          aria-label="Apri la finestra di stampa per salvare l'articolo come PDF">
+    <i class="bi bi-file-earmark-pdf me-2" aria-hidden="true"></i>
+    <span>Scarica trascrizione PDF</span>
+  </button>
+  <p class="trascrizione-pdf-hint small text-muted mt-1 mb-0">
+    Apre la finestra di stampa del browser. Scegli <strong>"Salva come PDF"</strong>
+    come destinazione: avrai l'articolo formattato A4 senza il chrome del sito.
+  </p>
+</div>
+{{- end -}}

--- a/themes/flavour-pcgenzano/layouts/podcast/list.html
+++ b/themes/flavour-pcgenzano/layouts/podcast/list.html
@@ -1,0 +1,76 @@
+{{ define "main" }}
+<div class="page-hero">
+  <div class="container">
+    {{ partial "breadcrumb.html" . }}
+    <h1>{{ .Title }}</h1>
+  </div>
+</div>
+<div class="container py-4">
+  <div class="row">
+    <div class="col-lg-10 mx-auto">
+
+      {{/* Intro pagina (frontmatter description + corpo Markdown) */}}
+      <div class="list-intro-content mb-4">
+        {{ .Content }}
+      </div>
+
+      {{/* Blacklist TTS (stessa di _default/single.html e _default/list.html).
+           Articoli su queste sezioni non hanno il bottone "Leggi ad alta voce",
+           quindi non li elenchiamo qui. La sezione comunicazioni è SEMPRE inclusa. */}}
+      {{ $allComunicazioni := where .Site.RegularPages "Section" "comunicazioni" }}
+      {{ $articoli := where $allComunicazioni "Draft" "ne" true }}
+      {{ $articoli = where $articoli "Params.tts" "ne" false }}
+      {{ $articoli = where $articoli "WordCount" "gt" 30 }}
+
+      <p class="reading-meta-info small text-muted mb-4">
+        <i class="bi bi-info-circle me-1" aria-hidden="true"></i>
+        Le durate sono <strong>stimate</strong>: la voce italiana del browser (~150 parole al minuto)
+        impiega circa il <strong>33% in più</strong> di un lettore visivo medio
+        (~200 parole al minuto). La velocità "Veloce" del pannello accessibilità
+        riduce ulteriormente i tempi.
+      </p>
+
+      <ul class="podcast-list list-unstyled" role="list">
+        {{ range $articoli.ByDate.Reverse }}
+        {{/* Durata stimata audio: ReadingTime * (200/150) = * 1.33, arrotondato. */}}
+        {{ $audioMin := math.Max 1 (int (math.Round (mul .ReadingTime 1.33))) }}
+        <li class="podcast-item card mb-3" role="listitem">
+          <div class="card-body p-3 d-flex flex-wrap align-items-start gap-3">
+            <div class="podcast-icon" aria-hidden="true">
+              <i class="bi bi-volume-up-fill"></i>
+            </div>
+            <div class="podcast-meta flex-grow-1">
+              <h2 class="h6 mb-1">
+                <a href="{{ .RelPermalink }}" class="stretched-link">{{ .Title }}</a>
+              </h2>
+              <p class="small text-muted mb-1">
+                {{ with .Params.badge }}<span class="me-2">{{ partial "badge.html" . }}</span>{{ end }}
+                <time datetime="{{ .Date.Format "2006-01-02" }}">
+                  <i class="bi bi-calendar3 me-1" aria-hidden="true"></i>{{ .Date | time.Format ":date_long" }}
+                </time>
+              </p>
+              {{ with .Description }}<p class="small mb-0">{{ . }}</p>{{ end }}
+            </div>
+            <div class="podcast-duration small text-end">
+              <i class="bi bi-clock me-1" aria-hidden="true"></i>
+              <strong>~{{ $audioMin }} {{ if eq $audioMin 1 }}minuto{{ else }}minuti{{ end }}</strong>
+              <span class="visually-hidden">di ascolto stimati</span>
+              <br>
+              <span class="small text-muted">audio</span>
+            </div>
+          </div>
+        </li>
+        {{ end }}
+      </ul>
+
+      <p class="small text-muted mt-4">
+        Trovi un totale di <strong>{{ len $articoli }}</strong> articoli ascoltabili sul sito.
+        Tutti rispondono alla stessa logica: bottone <em>Leggi ad alta voce</em> in cima
+        al testo, voce italiana del dispositivo, niente account.
+      </p>
+
+      {{ partial "page-tools.html" . }}
+    </div>
+  </div>
+</div>
+{{ end }}

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -3130,6 +3130,81 @@ html.a11y-grayscale  img.pittogramma { filter: contrast(1.2); }
 }
 
 /* ============================================================
+   SCARICA TRASCRIZIONE PDF — Punto 15 roadmap (v1.0)
+   Bottone coordinato con braille-download (sopra/sotto a esso).
+   Implementazione minimale: window.print() + CSS print esistente.
+   ============================================================ */
+.trascrizione-pdf-download {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+.trascrizione-pdf-download .btn {
+  font-weight: 600;
+  padding: 0.4rem 0.85rem;
+}
+.trascrizione-pdf-download .trascrizione-pdf-hint {
+  font-size: 0.78rem;
+  line-height: 1.35;
+  max-width: 60ch;
+}
+@media print {
+  .trascrizione-pdf-download { display: none !important; }
+}
+
+/* ============================================================
+   PODCAST LIST — pagina /podcast/ (Punto 15 roadmap v1.0)
+   Card-style list di tutti gli articoli con TTS attivo + durata
+   stimata di lettura ad alta voce.
+   ============================================================ */
+.podcast-list { margin: 0; padding: 0; }
+.podcast-item {
+  border: 1px solid #e9ecef;
+  border-left: 4px solid var(--pc-primary, #003366);
+  border-radius: 6px;
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+.podcast-item:hover,
+.podcast-item:focus-within {
+  box-shadow: 0 4px 12px rgba(0, 51, 102, 0.12);
+  transform: translateY(-1px);
+}
+.podcast-icon {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--pc-primary, #003366);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+}
+.podcast-duration {
+  flex-shrink: 0;
+  min-width: 100px;
+  background: #f4f7fb;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: right;
+}
+@media (max-width: 575.98px) {
+  .podcast-item .card-body { flex-direction: column; }
+  .podcast-duration { min-width: auto; align-self: flex-start; text-align: left; }
+}
+@media print {
+  .podcast-list { list-style: disc; padding-left: 1.5rem; }
+  .podcast-item { border: none; box-shadow: none; }
+  .podcast-icon, .podcast-duration { display: none; }
+}
+
+/* ============================================================
    TTS FALLBACK — messaggio "lettura vocale non disponibile" (v1.0)
    Visualizzato quando il browser implementa speechSynthesis come
    stub (Tor Browser, LibreWolf, Brave con scudo massimo) e


### PR DESCRIPTION
Punto 15 della roadmap — Versione audio podcast auto-generata. Web Speech API browser-native (gratuita), niente MP3 server-side, niente feed RSS podcast (richiederebbero TTS a pagamento).

## Componenti

- Nuova pagina `/podcast/` con elenco di tutti gli articoli con TTS attivo + **durata stimata audio** (ReadingTime × 1.33, perché TTS è ~150 wpm vs 200 wpm di lettura visiva)
- Voce menu **Podcast** sotto Risorse (Hugo + site-chrome.js sincronizzati)
- Nuovo partial `scarica-trascrizione-pdf.html` con bottone che chiama `window.print()` (il sito ha già `@media print` globale che produce stampa pulita)
- CSS coordinato: card-style podcast list, hover lift, responsive

## Test

- ✅ Hugo build pulita
- ✅ Pagina /podcast/ generata con 104 articoli
- ✅ Bottone trascrizione PDF presente in articolo campione
- ✅ Nessun `image:` modificato

🤖 Generated with [Claude Code](https://claude.com/claude-code)