### PR TITLE
Versione facile: nascosta da homepage e liste, accessibile solo dall'articolo madre

### DIFF
--- a/content/comunicazioni/2026-05-12-iso-22324-codici-colore-allerta-facile.md
+++ b/content/comunicazioni/2026-05-12-iso-22324-codici-colore-allerta-facile.md
@@ -12,6 +12,10 @@ area: "Lazio"
 allegati: []
 versione_facile_di: "2026-05-12-iso-22324-codici-colore-allerta"
 draft: false
+_build:
+  list: never
+  render: always
+  publishResources: true
 ---
 
 I bollettini di allerta usano quattro colori.


### PR DESCRIPTION
## Cosa cambia

Aggiunto `_build.list: never` al frontmatter del file `content/comunicazioni/2026-05-12-iso-22324-codici-colore-allerta-facile.md`.

## Effetto

Hugo esclude la pagina da:
- homepage (`partials/latest-news.html`)
- archivio `/comunicazioni/`
- articoli correlati (stesso badge)
- prev/next (`.PrevInSection` / `.NextInSection`)
- feed RSS e sitemap

La pagina resta renderizzata come pagina standalone, raggiungibile solo via il bottone "Leggi in italiano semplice" iniettato da `partials/versione-facile-toggle.html` sull'articolo madre.

## Why

L'utente non vuole che le versioni A2 CEFR ("facile da leggere") competano in homepage con l'articolo madre o appaiano duplicate negli archivi. Restano accessibili come supporto cognitivo a chi parte dall'articolo madre.

## Convenzione per il futuro

La stessa stanza `_build` va aggiunta a ogni futuro `*-facile.md`. Formalizzazione in `CLAUDE.md § "Versione italiano semplice"` / `manuale/parte-25-italiano-l2-versione-facile.md` da fare in commit successivo se confermato.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3E5eNgZV6mEHo9gH3YvbS)_