### PR TITLE
Cache-bust: forza re-upload FTP indici sezione per audit header/footer

### DIFF
--- a/content/accessibilita/_index.md
+++ b/content/accessibilita/_index.md
@@ -251,3 +251,5 @@ Ai sensi dell'art. 3-quinquies della Legge 9 gennaio 2004 n. 4, in caso di rispo
 - [Facile da leggere](/facile-da-leggere/) — istruzioni essenziali in linguaggio semplice
 - [Glossario](/glossario/) — sigle e termini tecnici spiegati
 - [Strumenti in tempo reale](/strumenti/) — servizi esterni e fonti di consultazione
+
+<!-- cache-bust: 2026-05-12 forza re-upload FTP per allineare header/footer dopo audit -->

--- a/content/comunicazioni/_index.md
+++ b/content/comunicazioni/_index.md
@@ -11,3 +11,5 @@ sitemap:
 In questa pagina trovi l'**archivio completo degli articoli** pubblicati dal Gruppo: avvisi, comunicati, resoconti delle attività, materiali di prevenzione e aggiornamenti operativi. L'archivio è filtrabile per categoria e per anno e ordinato dal più recente al più datato.
 
 In fondo alla pagina trovi anche i collegamenti ai **canali social ufficiali** del Gruppo, per seguirci anche su Facebook, Instagram, X e Telegram.
+
+<!-- cache-bust: 2026-05-12 forza re-upload FTP per allineare header/footer dopo audit -->

--- a/content/formazione/_index.md
+++ b/content/formazione/_index.md
@@ -116,3 +116,5 @@ Tutti gli articoli su formazione e scuole sono filtrabili nell'[archivio delle c
 - [Educazione civica](/formazione/educazione-civica/) — moduli per docenti
 - [Rischi e prevenzione](/rischi-prevenzione/) — comportamenti per scenario
 - [Diventa volontario](/diventa-volontario/) — come entrare nel Gruppo
+
+<!-- cache-bust: 2026-05-12 forza re-upload FTP per allineare header/footer dopo audit -->

--- a/content/rischi-prevenzione/_index.md
+++ b/content/rischi-prevenzione/_index.md
@@ -77,3 +77,5 @@ Tutti gli articoli su rischi e prevenzione sono filtrabili nell'[archivio delle 
 - [Piano di emergenza](/piano-emergenza/) — aree e procedure comunali
 - [Piano familiare](/piano-familiare/) — organizzare la famiglia prima dell'emergenza
 - [Numeri utili](/numeri-utili/) — recapiti essenziali
+
+<!-- cache-bust: 2026-05-12 forza re-upload FTP per allineare header/footer dopo audit -->


### PR DESCRIPTION
## Cosa cambia

Aggiunto un commento HTML invisibile in coda a 4 `_index.md` di sezione (`comunicazioni`, `accessibilita`, `formazione`, `rischi-prevenzione`) per modificare di pochi byte l'output HTML e forzare `ftp-deploy-action` a ri-caricare quelle pagine su Aruba.

## Why

Audit del 12 maggio 2026 ha rilevato che pagine indice di sezione servono ancora **header v.B/v.C** e **footer ridotto** (versioni precedenti al refactor menu di aprile/maggio 2026), mentre pagine recenti (`/glossario/`, singoli articoli `/comunicazioni/<slug>/`) servono **header v.A armonizzato**.

Ipotesi: pipeline Hugo deterministica + `dangerous-clean-slate: false` su `ftp-deploy-action` → se il `.md` di sezione non cambia, anche dopo build pulita l'HTML output ha lo stesso hash del file remoto, e ftp-deploy-action salta l'upload. Risultato: HTML stale di aprile sopravvive su Aruba mentre il template Hugo è già aggiornato nel repo.

## Cosa NON è in questa PR

Niente modifica template, niente modifica menu, niente modifica navbar/footer. Solo cache-bust di 4 file.

## Verifica post-deploy

Aspettare ~3 min, poi aprire in **incognito** (no cache browser):
- `https://www.protezionecivilegenzano.it/comunicazioni/`
- `https://www.protezionecivilegenzano.it/accessibilita/`
- `https://www.protezionecivilegenzano.it/formazione/`
- `https://www.protezionecivilegenzano.it/rischi-prevenzione/`

Se l'header passa a v.A armonizzato e il footer mostra Social Media Policy + Attribuzioni + RSS + Mappa sito → bug era stale-cache, Prompt A audit non serve, resta solo il Prompt B (rewrite `/accessibilita/` + ZgotmplZ + doc Braille).

Se restano disallineate → c'è un bug template reale, scala al Prompt A.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3E5eNgZV6mEHo9gH3YvbS)_