### PR TITLE
Versione facile: filtro esplicito nei template che iteravano le pagine

### DIFF
--- a/themes/flavour-pcgenzano/layouts/comunicazioni/list.html
+++ b/themes/flavour-pcgenzano/layouts/comunicazioni/list.html
@@ -1,5 +1,8 @@
 {{ define "main" }}
-{{- $pages := .Pages -}}
+{{/* Escludi le versioni "facile da leggere" (A2 CEFR) dall'archivio:
+     hanno `versione_facile_di` nel frontmatter e devono essere
+     raggiungibili solo dall'articolo madre via toggle. */}}
+{{- $pages := where .Pages "Params.versione_facile_di" nil -}}
 {{- $badges := slice -}}
 {{- $anni := slice -}}
 {{- range $pages -}}

--- a/themes/flavour-pcgenzano/layouts/partials/articoli-correlati.html
+++ b/themes/flavour-pcgenzano/layouts/partials/articoli-correlati.html
@@ -12,7 +12,10 @@
 {{- $self := .RelPermalink -}}
 {{- $correlati := slice -}}
 {{- if $badgeAttuale -}}
-  {{- range where (where .Site.RegularPages "Section" "comunicazioni") "Params.badge" "==" $badgeAttuale -}}
+  {{/* Escludi le versioni "facile da leggere" (A2 CEFR) dai correlati:
+       hanno `versione_facile_di` nel frontmatter e devono essere
+       raggiungibili solo dall'articolo madre. */}}
+  {{- range where (where (where .Site.RegularPages "Section" "comunicazioni") "Params.badge" "==" $badgeAttuale) "Params.versione_facile_di" nil -}}
     {{- if ne .RelPermalink $self -}}
       {{- $correlati = $correlati | append . -}}
     {{- end -}}

--- a/themes/flavour-pcgenzano/layouts/partials/latest-news.html
+++ b/themes/flavour-pcgenzano/layouts/partials/latest-news.html
@@ -1,7 +1,10 @@
 {{/* Notizie in evidenza — ultimi 2 mesi, hero + lista laterale
      Usato in: homepage */}}
 {{ $maxAge := now.AddDate 0 -2 0 }}
-{{ $filtered := where (where .Site.RegularPages "Section" "comunicazioni") ".Date" ">=" $maxAge }}
+{{/* Escludi le versioni "facile da leggere" (A2 CEFR): hanno
+     `versione_facile_di` nel frontmatter e devono essere accessibili
+     solo dall'articolo madre, non in homepage. */}}
+{{ $filtered := where (where (where .Site.RegularPages "Section" "comunicazioni") ".Date" ">=" $maxAge) "Params.versione_facile_di" nil }}
 {{/* Ordina per Lastmod (tiebreaker per articoli con stessa data), poi per Date.
      Hugo sort è stabile: articoli con stessa Date mantengono l'ordine Lastmod. */}}
 {{ $byLastmod := sort $filtered ".Lastmod" "desc" }}


### PR DESCRIPTION
## Why

Screenshot dell'utente del 12 maggio 2026 11:03 (CEST) mostra l'articolo "Perché le allerte hanno colori? Versione facile da leggere" ancora in cima all'archivio `/comunicazioni/`, nonostante:
- `_build.list: never` applicato nella PR #186
- cache-bust FTP forzato nella PR #187

Possibili cause non distinguibili da cloud (sandbox non raggiunge il dominio live):
- Hugo non rispetta `_build.list: never` come atteso per `.Pages` di sezione
- Cache stale FTP non ancora invalidata sull'indice

## Cosa fa questa PR

Filtro esplicito `where ... "Params.versione_facile_di" nil` direttamente nei 3 template che generano liste:

1. `themes/flavour-pcgenzano/layouts/partials/latest-news.html` — homepage "Notizie in Evidenza"
2. `themes/flavour-pcgenzano/layouts/comunicazioni/list.html` — archivio `/comunicazioni/`
3. `themes/flavour-pcgenzano/layouts/partials/articoli-correlati.html` — "Leggi anche"

`.PrevInSection`/`.NextInSection` restano governati dal `_build.list: never` del file `*-facile.md` (sufficiente per quel caso).

## Effetto sul deploy

Modificare i template costringe Hugo a rigenerare TUTTI gli HTML di archivio e articoli → `ftp-deploy-action` vede diff su `public/index.html`, `public/comunicazioni/index.html`, e tutti i `public/comunicazioni/<slug>/index.html` → re-upload completo. Niente cache-bust manuale necessario.

## Cosa NON cambia

- `_build.list: never` resta nel file `*-facile.md` (belt-and-suspenders)
- L'articolo facile resta accessibile via il bottone "Leggi in italiano semplice" iniettato da `versione-facile-toggle.html` sull'articolo madre
- Nessun altro template/template-output toccato

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3E5eNgZV6mEHo9gH3YvbS)_