### PR TITLE
P16 hot-fix: versione facile invisibile in homepage/archivio/RSS/cerca (raggiungibile SOLO dall'articolo madre)

### DIFF
--- a/.claude/rules/02-content-design-pa.md
+++ b/.claude/rules/02-content-design-pa.md
@@ -358,9 +358,19 @@ content/comunicazioni/<slug>-facile.md   ← versione italiano L2 A2
 
 **Frontmatter incrociato:**
 - Versione completa: `versione_facile: "<slug>-facile"`
-- Versione facile: `versione_facile_di: "<slug>"`
+- Versione facile: `versione_facile_di: "<slug>"` + **`_build: { list: false, render: true }` OBBLIGATORIO**
 
 Hugo renderizza entrambi come pagine distinte. Il partial `partials/versione-facile-toggle.html` aggiunge un banner giallo in cima a ciascuna pagina che linka all'altra.
+
+🔴 **VINCOLO HIDE DALLE LISTE.** Ogni file `<slug>-facile.md` DEVE includere nel frontmatter:
+
+```yaml
+_build:
+  list: false
+  render: true
+```
+
+Senza questa configurazione la versione facile compare in homepage, archivio `/comunicazioni/`, pagina `/podcast/`, feed RSS, sitemap, index.json (ricerca) e articoli correlati — confondendo gli utenti che si trovano due "card articolo" praticamente identiche. Con `_build.list = false` la versione facile è raggiungibile **solo** dal bottone "Leggi in italiano semplice" sull'articolo madre. È esattamente il comportamento richiesto. Storia: regola aggiunta il 12 maggio 2026 dopo prima pubblicazione P16 che aveva fatto comparire la versione facile in homepage come "ultima notizia" doppia (vedi PR di hot-fix). Specifiche complete: `manuale/parte-25-italiano-l2-versione-facile.md § 25.11`.
 
 **Eccezione gate AGID obbligata.** La versione facile NON segue il linguaggio AGID standard. Usa le **regole CEFR A2**:
 - frasi corte (8-12 parole massimo),

--- a/content/comunicazioni/2026-05-12-iso-22324-codici-colore-allerta-facile.md
+++ b/content/comunicazioni/2026-05-12-iso-22324-codici-colore-allerta-facile.md
@@ -12,6 +12,16 @@ area: "Lazio"
 allegati: []
 versione_facile_di: "2026-05-12-iso-22324-codici-colore-allerta"
 draft: false
+# _build.list = false esclude la versione facile da: homepage "ultime
+# notizie", archivio /comunicazioni/, pagina /podcast/, articoli correlati,
+# feed RSS, sitemap, indice di ricerca /index.json. La pagina resta
+# renderizzata (render: true) e raggiungibile via URL diretto SOLO dal
+# bottone "Leggi in italiano semplice" presente sull'articolo madre.
+# Convenzione obbligatoria per tutti i file *-facile.md (vedi
+# manuale/parte-25-italiano-l2-versione-facile.md § 25.11).
+_build:
+  list: false
+  render: true
 ---
 
 I bollettini di allerta usano quattro colori.

--- a/manuale/parte-25-italiano-l2-versione-facile.md
+++ b/manuale/parte-25-italiano-l2-versione-facile.md
@@ -65,6 +65,9 @@ area: "Lazio"
 allegati: []
 versione_facile_di: "2026-05-12-iso-22324-codici-colore-allerta"
 draft: false
+_build:
+  list: false
+  render: true
 ---
 ```
 
@@ -72,6 +75,7 @@ draft: false
 - `image: ""` sulla versione facile → Hugo genererà automaticamente una cover tipografica (vedi regola progetto sul banner). Mai una foto utente.
 - `date` della versione facile: usare lo **stesso giorno** della versione completa con orario leggermente posteriore (`T00:03` vs `T00:02`) per mantenere l'ordering cronologico Hugo.
 - `description`: indicare chiaramente che è la **versione semplificata**.
+- **`_build.list = false` OBBLIGATORIO** (vedi § 25.11 sotto).
 
 ## 25.4 Bottone toggle (automatico via partial)
 
@@ -153,7 +157,34 @@ Come riferimento operativo, c'è una versione facile completa del primo articolo
 3. **Multilingua sulla versione facile**: per ora solo italiano A2. Versioni inglese / arabo / rumeno / cinese semplificate sono fuori scope (esisterebbe la traduzione automatica di Chrome/iOS).
 4. **Toggle "Mostra entrambe affiancate"** (split-view): l'utente sceglie una versione e legge solo quella. Niente UI complessa.
 
-## 25.10 Riferimenti
+## 25.11 Hide dalle liste — `_build.list = false` OBBLIGATORIO
+
+Da 12 maggio 2026 (revisione richiesta dall'utente dopo prima pubblicazione P16) **ogni file `<slug>-facile.md` deve avere `_build.list: false` nel frontmatter**. Senza questa regola la versione facile compariva in homepage come "ultima notizia" doppia, nell'archivio `/comunicazioni/`, nella pagina `/podcast/`, nel feed RSS e nell'indice di ricerca — confondendo gli utenti.
+
+Lo standard Hugo `_build`:
+
+```yaml
+_build:
+  list: false       # esclusa da homepage, archivio, RSS, sitemap,
+                    # podcast list, articoli correlati, index.json (ricerca)
+  render: true      # ma resta renderizzata come pagina HTML accessibile
+                    # via URL diretto
+```
+
+**Cosa esclude `_build.list: false`:**
+- `where .Site.RegularPages "..."` → niente più in homepage `partials/latest-news.html`
+- `.Site.AllPages` → niente più in `index.json` di ricerca, sitemap.xml, RSS feed di sezione
+- `articoli-correlati.html` (legge da `.Site.RegularPages`) → niente più nei correlati
+- `podcast/list.html` (filtra da `.Site.RegularPages`) → niente più in /podcast/
+
+**Cosa resta funzionante:**
+- URL diretto `/comunicazioni/<slug>-facile/` → HTML renderizzato (perché `render: true`)
+- Bottone "Leggi in italiano semplice" sull'articolo madre (lo costruisce il partial `versione-facile-toggle.html` leggendo `Params.versione_facile`, non `Site.Pages`)
+- Bottone "Torna alla versione completa" sulla versione facile (legge dal proprio frontmatter `versione_facile_di`)
+
+**Risultato netto:** la versione facile è raggiungibile **solo** dall'articolo madre. Non appare in nessuna lista pubblica. Esattamente il comportamento richiesto.
+
+## 25.12 Riferimenti
 
 - **CEFR (Quadro Comune Europeo di Riferimento per le Lingue)** — Consiglio d'Europa: <https://www.coe.int/en/web/common-european-framework-reference-languages/>
 - **Italiano L2 A2** — descrittori ufficiali: comprensione di frasi e parole frequenti su famiglia, lavoro, ambiente immediato. Lettura di testi brevi con vocabolario ad alta frequenza.


### PR DESCRIPTION
Bug segnalato dall'utente con screenshot homepage: la versione facile dell'articolo ISO 22324 compariva come card "ultima notizia" indipendente, identica all'articolo madre. Visivamente confondente.

Richiesta esplicita: *"non voglio vedere in home page nè in altre parti l'articolo di lettura semplice! deve essere raggiungibile solamente dall'articolo madre."*

## Fix

Aggiunto al frontmatter del file `*-facile.md`:

```yaml
_build:
  list: false       # esclude da TUTTE le liste/feed/sitemap/index
  render: true      # ma resta renderizzata come HTML accessibile
```

Hugo `_build.list: false` rimuove la pagina da `.Site.RegularPages` e `.Site.AllPages`. Effetto:

- ❌ NON appare in homepage "ultime notizie"
- ❌ NON appare in archivio `/comunicazioni/`
- ❌ NON appare in pagina `/podcast/`
- ❌ NON appare in articoli correlati
- ❌ NON appare in RSS di sezione
- ❌ NON appare in sitemap.xml
- ❌ NON appare in `index.json` (indice ricerca)
- ✅ Pagina HTML RESTA renderizzata via URL diretto
- ✅ Bottone "Leggi in italiano semplice" sull'articolo madre punta ancora correttamente alla versione facile

## Documentazione aggiornata (convenzione OBBLIGATORIA d'ora in poi)

- `manuale/parte-25-italiano-l2-versione-facile.md`: esempio frontmatter aggiornato + nuova sezione § 25.11 "Hide dalle liste — _build.list = false OBBLIGATORIO"
- `.claude/rules/02-content-design-pa.md`: vincolo `_build.list: false` esplicitato come 🔴 RED BOX nella sezione "Versione italiano semplice"

## Test post-fix

Tutti i 7 controlli ✅ passati (verificati con grep sull'HTML post-build):
- 0 occorrenze in homepage, archivio, podcast, RSS, index.json
- 1 occorrenza nel bottone toggle dell'articolo madre

🤖 Generated with [Claude Code](https://claude.com/claude-code)