### PR TITLE
URGENTE: fix _build → build (Hugo 0.145+ ha rimosso underscore) — sblocca deploy bloccato da 3 PR

### DIFF
--- a/.claude/rules/02-content-design-pa.md
+++ b/.claude/rules/02-content-design-pa.md
@@ -358,14 +358,14 @@ content/comunicazioni/<slug>-facile.md   ← versione italiano L2 A2
 
 **Frontmatter incrociato:**
 - Versione completa: `versione_facile: "<slug>-facile"`
-- Versione facile: `versione_facile_di: "<slug>"` + **`_build: { list: never, render: always, publishResources: true }` OBBLIGATORIO**
+- Versione facile: `versione_facile_di: "<slug>"` + **`build: { list: never, render: always, publishResources: true }` OBBLIGATORIO**
 
 Hugo renderizza entrambi come pagine distinte. Il partial `partials/versione-facile-toggle.html` aggiunge un banner giallo in cima a ciascuna pagina che linka all'altra.
 
 🔴 **VINCOLO HIDE DALLE LISTE.** Ogni file `<slug>-facile.md` DEVE includere nel frontmatter:
 
 ```yaml
-_build:
+build:
   list: never              # esclude da Site.RegularPages, Site.AllPages,
                            # quindi da homepage, archivio, RSS, sitemap,
                            # podcast list, articoli correlati, index.json
@@ -373,7 +373,9 @@ _build:
   publishResources: true   # gli asset Page Resources sono pubblicati
 ```
 
-Senza questa configurazione la versione facile compare in homepage, archivio `/comunicazioni/`, pagina `/podcast/`, feed RSS, sitemap, index.json (ricerca) e articoli correlati — confondendo gli utenti che si trovano due "card articolo" praticamente identiche. Con `_build.list: never` la versione facile è raggiungibile **solo** dal bottone "Leggi in italiano semplice" sull'articolo madre. È esattamente il comportamento richiesto.
+⚠️ **CRITICO**: la chiave del frontmatter è `build:` (senza underscore). La vecchia sintassi `_build:` (con underscore) è stata **rimossa** da Hugo 0.145.0 e causa **ERROR error building site** su Hugo 0.161+, bloccando completamente il deploy. Storia: 12 maggio 2026 le PR #186/#187/#188/#190 hanno introdotto `_build:` per errore, causando 3 deploy falliti consecutivi prima del fix in PR #191.
+
+Senza questa configurazione la versione facile compare in homepage, archivio `/comunicazioni/`, pagina `/podcast/`, feed RSS, sitemap, index.json (ricerca) e articoli correlati — confondendo gli utenti che si trovano due "card articolo" praticamente identiche. Con `build.list: never` la versione facile è raggiungibile **solo** dal bottone "Leggi in italiano semplice" sull'articolo madre. È esattamente il comportamento richiesto.
 
 **Storia:** regola aggiunta il 12 maggio 2026 dopo prima pubblicazione P16 che aveva fatto comparire la versione facile in homepage come "ultima notizia" doppia (fix in PR #186 + #187 + #188). Specifiche complete: `manuale/parte-25-italiano-l2-versione-facile.md § 25.11`.
 

--- a/content/comunicazioni/2026-05-12-iso-22324-codici-colore-allerta-facile.md
+++ b/content/comunicazioni/2026-05-12-iso-22324-codici-colore-allerta-facile.md
@@ -12,7 +12,7 @@ area: "Lazio"
 allegati: []
 versione_facile_di: "2026-05-12-iso-22324-codici-colore-allerta"
 draft: false
-_build:
+build:
   list: never
   render: always
   publishResources: true

--- a/manuale/parte-25-italiano-l2-versione-facile.md
+++ b/manuale/parte-25-italiano-l2-versione-facile.md
@@ -65,7 +65,7 @@ area: "Lazio"
 allegati: []
 versione_facile_di: "2026-05-12-iso-22324-codici-colore-allerta"
 draft: false
-_build:
+build:
   list: never
   render: always
   publishResources: true
@@ -76,7 +76,7 @@ _build:
 - `image: ""` sulla versione facile → Hugo genererà automaticamente una cover tipografica (vedi regola progetto sul banner). Mai una foto utente.
 - `date` della versione facile: usare lo **stesso giorno** della versione completa con orario leggermente posteriore (`T00:03` vs `T00:02`) per mantenere l'ordering cronologico Hugo.
 - `description`: indicare chiaramente che è la **versione semplificata**.
-- **`_build.list = never` OBBLIGATORIO** (vedi § 25.11 sotto).
+- **`build.list = never` OBBLIGATORIO** (vedi § 25.11 sotto).
 
 ## 25.4 Bottone toggle (automatico via partial)
 
@@ -158,14 +158,14 @@ Come riferimento operativo, c'è una versione facile completa del primo articolo
 3. **Multilingua sulla versione facile**: per ora solo italiano A2. Versioni inglese / arabo / rumeno / cinese semplificate sono fuori scope (esisterebbe la traduzione automatica di Chrome/iOS).
 4. **Toggle "Mostra entrambe affiancate"** (split-view): l'utente sceglie una versione e legge solo quella. Niente UI complessa.
 
-## 25.11 Hide dalle liste — `_build.list = never` OBBLIGATORIO
+## 25.11 Hide dalle liste — `build.list = never` OBBLIGATORIO
 
-Da 12 maggio 2026 (revisione richiesta dall'utente dopo prima pubblicazione P16) **ogni file `<slug>-facile.md` deve avere `_build.list: never` nel frontmatter**. Senza questa regola la versione facile compariva in homepage come "ultima notizia" doppia, nell'archivio `/comunicazioni/`, nella pagina `/podcast/`, nel feed RSS e nell'indice di ricerca — confondendo gli utenti che si trovavano due card praticamente identiche.
+Da 12 maggio 2026 (revisione richiesta dall'utente dopo prima pubblicazione P16) **ogni file `<slug>-facile.md` deve avere `build.list: never` nel frontmatter**. Senza questa regola la versione facile compariva in homepage come "ultima notizia" doppia, nell'archivio `/comunicazioni/`, nella pagina `/podcast/`, nel feed RSS e nell'indice di ricerca — confondendo gli utenti che si trovavano due card praticamente identiche.
 
-Sintassi Hugo moderna `_build` (espressiva):
+Sintassi Hugo moderna `build` (espressiva):
 
 ```yaml
-_build:
+build:
   list: never              # esclusa da homepage, archivio, RSS, sitemap,
                            # podcast list, articoli correlati, index.json
   render: always           # ma resta renderizzata come pagina HTML
@@ -173,9 +173,11 @@ _build:
   publishResources: true   # gli asset Page Resources sono comunque pubblicati
 ```
 
-(La sintassi legacy `list: false` / `render: true` funziona ancora come alias, ma per chiarezza usa la forma moderna `never` / `always`.)
+⚠️ **CRITICO — chiave senza underscore.** La chiave del frontmatter è `build:` (senza underscore). La sintassi vecchia `_build:` (con underscore, usata in molta documentazione Hugo pre-0.145) è stata **rimossa** da Hugo 0.145.0 e ora causa `ERROR error building site: logged 1 error(s)` su Hugo 0.161+, **bloccando completamente il deploy**. Storia: PR #186/#187/#188/#190 del 12 maggio 2026 hanno introdotto `_build:` per errore, causando 3 deploy falliti consecutivi prima del fix in PR #191.
 
-**Cosa esclude `_build.list: never`:**
+(La sintassi dei *valori* legacy `list: false` / `render: true` funziona ancora come alias di `never` / `always`, ma usare la forma moderna è più chiaro.)
+
+**Cosa esclude `build.list: never`:**
 - `where .Site.RegularPages "..."` → niente più in homepage `partials/latest-news.html`
 - `.Site.AllPages` → niente più in `index.json` di ricerca, sitemap.xml, RSS feed di sezione
 - `articoli-correlati.html` (legge da `.Site.RegularPages`) → niente più nei correlati
@@ -188,7 +190,7 @@ _build:
 
 **Risultato netto:** la versione facile è raggiungibile **solo** dall'articolo madre. Non appare in nessuna lista pubblica. Esattamente il comportamento richiesto.
 
-**Storia del fix:** il 12 maggio 2026 la versione facile dell'articolo ISO 22324 era apparsa come card "ultima notizia" in homepage. PR #186 (frontmatter `_build.list: never`) + PR #187 (cache-bust FTP) + PR #188 (filtro esplicito nei template) hanno risolto il bug. Da allora la convenzione è **obbligatoria** per qualunque file `*-facile.md` futuro.
+**Storia del fix:** il 12 maggio 2026 la versione facile dell'articolo ISO 22324 era apparsa come card "ultima notizia" in homepage. PR #186 (frontmatter `build.list: never`) + PR #187 (cache-bust FTP) + PR #188 (filtro esplicito nei template) hanno risolto il bug. Da allora la convenzione è **obbligatoria** per qualunque file `*-facile.md` futuro.
 
 ## 25.12 Riferimenti
 


### PR DESCRIPTION
🔴 **Deploy bloccato dal 12 maggio 2026** da 3 PR consecutive (#186, #188, #190) che hanno introdotto `_build:` (con underscore) nel frontmatter.

## Errore reale dal log GitHub Actions

```
ERROR deprecated: The "_build" front matter key was deprecated in Hugo 0.145.0 and subsequently removed. Use "build" instead.
ERROR error building site: logged 1 error(s)
Process completed with exit code 1.
```

## Fix (3 file, 5 occorrenze)

- `content/comunicazioni/2026-05-12-iso-22324-codici-colore-allerta-facile.md`: `_build:` → `build:` nel frontmatter (era la causa reale del crash)
- `manuale/parte-25` § 25.3 + § 25.11: tutti i riferimenti `_build` aggiornati a `build`
- `.claude/rules/02-content-design-pa.md`: esempio + RED BOX aggiornati

Aggiunto in Parte 25 § 25.11 + rule 02 un **avviso ⚠️ CRITICO** che spiega:
- chiave senza underscore obbligatoria
- sintassi `_build:` rimossa da Hugo 0.145
- causa `ERROR error building site` su Hugo 0.161+

## Test

- ✅ Hugo build locale pulita (exit 0, 385 pages)
- ✅ Versione facile NON in homepage / archivio / RSS / podcast / cerca (0 occorrenze)
- ✅ Pagina facile RESTA renderizzata (HTML presente)
- ✅ Nessun `image:` modificato

🤖 Generated with [Claude Code](https://claude.com/claude-code)