### PR TITLE
P-igiene: doc strategia cache-bust + audit § 43 Stale FTP files detection

### DIFF
--- a/.claude/rules/05-github-aruba-deploy.md
+++ b/.claude/rules/05-github-aruba-deploy.md
@@ -205,6 +205,43 @@ Lo script `scripts/auto-cover-mancanti.py` agisce così:
 2. **Cover tipografica istituzionale** (gradiente blu + titolo, generata automaticamente)
 3. **Default SVG** (`images/notizia-default.svg`) — solo come fallback estremo se anche cover tipografica fallisce
 
+## File stantii su Aruba — strategia cache-bust dopo modifiche al chrome
+
+⚠️ **Problema noto del deploy FTP** (`dangerous-clean-slate: false`): l'azione `SamKirkland/FTP-Deploy-Action@v4.3.5` configurata in `deploy.yml` carica **solo i file modificati** rispetto a quelli già su Aruba (confronto per dimensione + timestamp). Conseguenza: se Hugo rigenera un HTML ma il contenuto rispetto al file su Aruba è bytewise identico (raro ma possibile), il file non viene ricaricato.
+
+**Caso patologico più frequente — refactoring del chrome** (`partials/navbar.html`, `partials/footer.html`, `partials/utility-bar.html`, `partials/slim-header.html`, `_default/baseof.html`): tutti gli HTML del sito hanno il chrome cambiato → Hugo li rigenera → FTP dovrebbe caricarli tutti. **Ma** se in quel periodo ci sono **deploy falliti consecutivi** (build error), gli HTML restano stantii su Aruba per ore o giorni. Quando il deploy si sblocca, alcuni file potrebbero non essere ri-caricati (timestamp identico, contenuto leggermente diverso → FTP li ignora).
+
+**Storia incidente 12 maggio 2026**: 4 deploy falliti per il bug `_build`/`build` del frontmatter (PR #186/#188/#190) hanno bloccato l'upload per ~7 ore. Le pagine `/cosa-fare-adesso/`, `/formazione/`, `/comunicazioni/`, `/accessibilita/` su Aruba mostravano un header "Versione B/C" piatto risalente al deploy del 18 aprile 2026 (header pre-refactoring del 10 maggio), mentre altre pagine (`/`, `/glossario/`, `/abili-a-proteggere/`, articoli) avevano già l'header canonico "Versione A". PR #191 (sha `dfe5e19`) ha sbloccato il deploy → tutti gli HTML allineati.
+
+### Strategia cache-bust raccomandata
+
+Quando modifichi **un partial del chrome** (`navbar.html`, `footer.html`, `slim-header.html`, `utility-bar.html`, `baseof.html`), nello **stesso PR** aggiungi un commento cache-bust nei `_index.md` delle sezioni principali per forzare la rigenerazione "evidente" lato Hugo + il re-upload FTP:
+
+```markdown
+<!-- cache-bust: AAAA-MM-GG forza re-upload FTP per allineare header/footer -->
+```
+
+Sezioni da toccare (in ordine di importanza, le ho gerarchizzate dal più al meno frequentate):
+
+1. `content/comunicazioni/_index.md` (archivio principale)
+2. `content/cosa-fare-adesso/_index.md` (pagina critica emergenza)
+3. `content/formazione/_index.md`
+4. `content/rischi-prevenzione/_index.md` (hub rischi)
+5. `content/accessibilita/_index.md` (pagina legale)
+6. `content/contatti/_index.md`
+
+Il commento HTML in fondo al frontmatter cambia per ogni cache-bust diverso (nuova data), Hugo lo rigenera, il timestamp/dimensione cambia, FTP lo riconosce come "diverso" → upload forzato.
+
+**Riferimento storico**: PR #187 (12 maggio 2026 — "Cache-bust: forza re-upload FTP indici sezione per audit header/footer") ha applicato questa strategia per la prima volta dopo l'incidente del menu refactoring. Pattern adottato come **convenzione stabile**.
+
+### Detection: il workflow audit-sito.yml controlla la coerenza Last-Modified
+
+Da maggio 2026, `audit-sito.yml` ha una sezione (sezione 43 — "Stale FTP files detection") che ogni lunedì 09:00 UTC fa `curl -I` su un campione di 8 pagine Hugo critiche, estrae `Last-Modified` HTTP, e lo confronta col timestamp dell'ultimo deploy `success` recuperato via API GitHub. Soglia di tolleranza: 2 ore (il deploy FTP impiega ~10-15 minuti; 2h copre eventuali ritardi senza falsi positivi).
+
+Se anche una sola pagina ha `Last-Modified` più vecchio della soglia, apre/aggiorna l'issue settimanale di audit con sezione dedicata. Il fix è applicare cache-bust come descritto sopra + rilanciare deploy.
+
+**Eccezione**: le pagine HTML statiche sotto `static/` (es. `/abili-a-proteggere/`, `/giochi/`, `/quizpc/`, `/formazionepc/`, kit-calamita stampabili) hanno l'header iniettato lato client da `static/app-shared/site-chrome.js`. Il loro `Last-Modified` HTML può essere vecchio senza che sia un bug: il chrome JavaScript si aggiorna automaticamente al caricamento. NON vanno incluse nel check Last-Modified delle pagine Hugo.
+
 ## Verifica prima del push
 
 Prima di fare push su `main`, verifica sempre:

--- a/.github/workflows/audit-sito.yml
+++ b/.github/workflows/audit-sito.yml
@@ -38,6 +38,7 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: read   # per `gh run list --workflow=deploy.yml` nella sezione 43 (Stale FTP files detection)
 
 jobs:
   audit:
@@ -58,6 +59,8 @@ jobs:
       - name: "🧪 Audit contenuti"
         id: audit
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # auth gh CLI per sezione 43
         run: |
           # Override del default GitHub Actions (set -e -o pipefail).
           # Lo script ha 40+ sezioni con grep condizionali. Un grep che
@@ -1075,6 +1078,67 @@ jobs:
           # tutti i conteggi inventario sono stati rimossi dal sito e sostituiti
           # con descrizioni qualitative. Non c'è più drift da inseguire perché
           # non ci sono più numeri da allineare.
+
+          # ----------------------------------------------------------------
+          section "43. Stale FTP files detection — Last-Modified pagine Hugo"
+          # Il deploy FTP usa `dangerous-clean-slate: false`: i file su Aruba che
+          # NON cambiano fra due build non vengono ricaricati. In caso di deploy
+          # falliti consecutivi (es. bug `_build`/`build` frontmatter del 12 maggio
+          # 2026, 4 deploy falliti consecutivi che hanno bloccato l'upload per
+          # ~7 ore), alcune pagine restavano stantie con vecchio header/footer.
+          # Questa sezione fa curl -I sulle pagine Hugo critiche e verifica che
+          # Last-Modified HTTP sia entro 2 ore dall'ultimo deploy `success`.
+          # Specifiche: rule 05-github-aruba-deploy.md § "File stantii su Aruba —
+          # strategia cache-bust dopo modifiche al chrome".
+          #
+          # Sono escluse le pagine HTML statiche sotto static/ (es.
+          # /abili-a-proteggere/, /giochi/, kit-calamita stampabili): hanno l'header
+          # iniettato lato client da site-chrome.js, il loro Last-Modified può essere
+          # vecchio senza che sia un bug (il chrome JS si aggiorna automaticamente).
+          STALE_PAGES=""
+          if command -v gh >/dev/null 2>&1; then
+            # Recupera timestamp dell'ultimo deploy success (UTC ISO 8601)
+            LATEST_DEPLOY=$(gh run list --workflow=deploy.yml --status=success --limit=1 --json updatedAt --jq '.[0].updatedAt' 2>/dev/null || echo "")
+            if [ -n "$LATEST_DEPLOY" ]; then
+              LATEST_DEPLOY_EPOCH=$(date -u -d "$LATEST_DEPLOY" +%s 2>/dev/null || echo "0")
+              # Soglia: 2 ore (7200 sec). Il deploy FTP impiega ~10-15 min;
+              # 2h copre ritardi senza falsi positivi.
+              THRESHOLD=7200
+              # 8 pagine Hugo critiche (NON statiche). Tutte dovrebbero essere
+              # ri-deployate ad ogni cambio del chrome (navbar/footer/utility-bar).
+              SAMPLE_URLS="https://www.protezionecivilegenzano.it/
+              https://www.protezionecivilegenzano.it/comunicazioni/
+              https://www.protezionecivilegenzano.it/cosa-fare-adesso/
+              https://www.protezionecivilegenzano.it/formazione/
+              https://www.protezionecivilegenzano.it/accessibilita/
+              https://www.protezionecivilegenzano.it/glossario/
+              https://www.protezionecivilegenzano.it/contatti/
+              https://www.protezionecivilegenzano.it/rischi-prevenzione/"
+              for url in $SAMPLE_URLS; do
+                lm=$(curl -sI --max-time 10 -H "Cache-Control: no-cache" "$url" 2>/dev/null | grep -i "^last-modified:" | sed 's/last-modified: *//I' | tr -d '\r' | head -1)
+                if [ -n "$lm" ]; then
+                  lm_epoch=$(date -u -d "$lm" +%s 2>/dev/null || echo "0")
+                  if [ "$lm_epoch" -gt 0 ]; then
+                    delta=$((LATEST_DEPLOY_EPOCH - lm_epoch))
+                    if [ "$delta" -gt "$THRESHOLD" ]; then
+                      hrs=$((delta / 3600))
+                      STALE_PAGES="${STALE_PAGES}- \`$url\` Last-Modified \`$lm\` (~${hrs}h prima dell'ultimo deploy success). Probabile file stantio su Aruba.\n"
+                    fi
+                  fi
+                fi
+              done
+              if [ -n "$STALE_PAGES" ]; then
+                err "Pagine Hugo con Last-Modified stantio rispetto all'ultimo deploy \`success\` (\`$LATEST_DEPLOY\`). Applicare cache-bust nei \`_index.md\` (vedi rule 05-github-aruba-deploy.md § \"File stantii su Aruba\"):"
+                printf "%b" "$STALE_PAGES" >> "$REPORT"
+              else
+                ok "Tutte le pagine Hugo campione hanno Last-Modified entro 2h dall'ultimo deploy success."
+              fi
+            else
+              warn "Impossibile recuperare timestamp ultimo deploy success via gh CLI: check Last-Modified saltato."
+            fi
+          else
+            warn "gh CLI non disponibile sul runner: check Last-Modified pagine Hugo saltato."
+          fi
 
           # ----------------------------------------------------------------
           # Output


### PR DESCRIPTION
Investigation del bug "3 versioni di header (A/B/C) convivono sul sito" segnalato stamattina dall'utente ha rivelato che **non esiste un layout legacy nel codice**: era un fenomeno di **file stantii su Aruba** causato dai 4 deploy falliti consecutivi del 12 maggio 2026 (bug `_build` / `build` frontmatter). Il fix di PR #191 ha sbloccato il deploy → tutte le pagine ora coerenti, smoke test live su 9 pagine confermato.

Questo PR aggiunge **prevenzione + detection automatica** per non ripetere l'incidente.

## Modifiche (2 file, 101 insertions)

1. **`.claude/rules/05-github-aruba-deploy.md`** — nuova sezione "File stantii su Aruba — strategia cache-bust dopo modifiche al chrome":
   - Problema documentato (`dangerous-clean-slate: false` + deploy falliti = HTML stantii)
   - Storia incidente 12 maggio 2026
   - Strategia preventiva: commento HTML `<!-- cache-bust: ... -->` nei `_index.md` delle 6 sezioni principali quando si modifica un partial del chrome
   - Eccezione documentata: pagine HTML statiche con chrome iniettato via JS (`site-chrome.js`) NON sono soggette al check

2. **`.github/workflows/audit-sito.yml`** — nuova sezione **"43. Stale FTP files detection — Last-Modified pagine Hugo"**:
   - Ogni lunedì 09:00 UTC, `gh run list --workflow=deploy.yml --status=success --limit=1` recupera timestamp ultimo deploy success
   - `curl -I` su 8 pagine Hugo critiche
   - Confronto Last-Modified HTTP vs timestamp deploy, soglia 2h
   - Se delta > 2h, apre/aggiorna l'issue settimanale audit
   - Permissions `actions: read` + env `GH_TOKEN` aggiunti

## Test

- ✅ YAML validation audit-sito.yml
- ✅ Hugo build pulita
- ✅ Simulazione locale § 43: 8/8 pagine FRESH rispetto al deploy success 2026-05-12T16:44:48Z

## Smoke test esteso post-fix PR #191 (9 pagine)

| Pagina | Header canonico | Stale |
|---|---|---|
| / | ✅ | ✅ no |
| /comunicazioni/ | ✅ | ✅ no |
| /cosa-fare-adesso/ | ✅ | ✅ no |
| /formazione/ | ✅ | ✅ no |
| /accessibilita/ | ✅ | ✅ no |
| /glossario/ | ✅ | ✅ no |
| /contatti/ | ✅ | ✅ no |
| /comunicazioni/<articolo> | ✅ | ✅ no |
| /abili-a-proteggere/ | (statica, chrome JS) | n/a |

🤖 Generated with [Claude Code](https://claude.com/claude-code)