### PR TITLE
Schema.org Sera 1: HowTo opt-in per pagine /rischi-prevenzione/* (POC 2 pagine)

### DIFF
--- a/.claude/rules/04a-hugo-shortcode-partial.md
+++ b/.claude/rules/04a-hugo-shortcode-partial.md
@@ -301,7 +301,21 @@ Pagina interattiva che guida il cittadino con domande semplici fino a una rispos
 
 `themes/flavour-pcgenzano/layouts/partials/structured-data.html` inietta il blocco `<script type="application/ld+json">` con i dati strutturati Schema.org per i motori di ricerca e gli assistenti vocali.
 
-**Schema attivi:** Organization+NGO, ContactPoint, WebSite (con SearchAction), BreadcrumbList, Article (per `/comunicazioni/`), Event (aggiuntivo per `badge: Evento` con location Place + organizer), FAQPage (per `/faq/`), WebPage (default), Question/Answer, ImageObject, PostalAddress, GeoCoordinates, City.
+**Schema attivi:** Organization+NGO, ContactPoint, WebSite (con SearchAction), BreadcrumbList, Article (per `/comunicazioni/`), Event (aggiuntivo per `badge: Evento` con location Place + organizer), FAQPage (per `/faq/`), HowTo (per pagine `/rischi-prevenzione/*` con frontmatter `howto_prima` / `howto_durante` / `howto_dopo` — vedi sotto), WebPage (default), Question/Answer, HowToStep, ImageObject, PostalAddress, GeoCoordinates, City.
+
+**HowTo opt-in per pagine rischio.** Da maggio 2026 le pagine `/rischi-prevenzione/*` con struttura uniforme PRIMA/DURANTE/DOPO (rischio sismico, idrogeologico, incendio, vulcanico, ondate-di-calore, blackout, vento-forte, temporali-intensi) possono attivare il markup `HowTo` aggiungendo nel frontmatter 3 campi stringa:
+
+```yaml
+howto_prima: "Riassunto in 1-3 frasi delle azioni preventive da fare prima dell'evento."
+howto_durante: "Riassunto in 1-3 frasi delle azioni immediate da fare durante l'evento."
+howto_dopo: "Riassunto in 1-3 frasi delle azioni di recupero da fare dopo l'evento."
+```
+
+Il partial controlla `if and .Params.howto_prima .Params.howto_durante .Params.howto_dopo` — il blocco HowTo viene emesso **solo** se tutti e tre i campi sono presenti. Pagine senza i campi continuano ad avere solo `WebPage` + `BreadcrumbList` (nessuna regressione).
+
+**`totalTime`** calcolato come `ReadingTime × 1.5` minuti (lettura → applicazione pratica), minimo 5 minuti. **`url` di ciascun HowToStep** punta al frammento `#cosa-fare-prima` / `#cosa-fare-durante` / `#cosa-fare-dopo` della pagina, ancore presenti su tutte le pagine rischio per la struttura uniforme già documentata in `rule 06-protezione-civile-scientifica.md`.
+
+⚠️ **Sintassi obbligatoria `| jsonify | safeJS`** per ogni campo testuale dentro `<script type="application/ld+json">`. Hugo applica un **secondo escape JS contestuale** alle stringhe dentro `<script>`, e il solo `| jsonify` produce doppio escape (es. `name: "\"Foo\""`). Aggiungere `| safeJS` dopo `| jsonify` impedisce il secondo escape e produce JSON valido. Vale anche per gli apostrofi italiani (es. "L'unica difesa"). Testato con `validator.schema.org` post-fix del 12 maggio 2026.
 
 **Importante — vincolo di tipo Organization:** l'Organization è marcata come `["Organization", "NGO"]`, **NON** `GovernmentOrganization` né `EmergencyService`. Il Gruppo è associazione di volontariato OdV, non ente pubblico né servizio di emergenza chiamabile direttamente — usare quei tipi indurrebbe Google/assistenti vocali a presentare il Gruppo come servizio chiamabile, contraddicendo la regola "in emergenza chiama il 112".
 

--- a/content/rischi-prevenzione/rischio-idrogeologico.md
+++ b/content/rischi-prevenzione/rischio-idrogeologico.md
@@ -5,6 +5,11 @@ description: "Le norme di comportamento da adottare in caso di alluvioni, frane 
 tts: true
 weight: 2
 toc: true
+# Schema.org HowTo — 3 step PRIMA/DURANTE/DOPO per rich result Google.
+# Aggiunto 12 maggio 2026.
+howto_prima: "Informati sullo stato di allerta consultando la pagina Allerte Meteo. Verifica che tombini e caditoie vicino casa siano liberi da foglie e detriti. Metti in sicurezza auto e beni che si trovano in locali interrati o a rischio allagamento. Non lasciare oggetti di valore in cantine o garage a rischio. Tieni pronto il kit di emergenza. Individua le zone più sicure dell'abitazione (i piani alti)."
+howto_durante: "Se sei in casa, chiudi immediatamente il contatore del gas e dell'elettricità se l'acqua raggiunge gli impianti. Spostati ai piani alti della casa. NON scendere mai in cantine, garage o locali interrati. Tieni chiuse le porte che danno verso i locali più bassi per rallentare l'ingresso dell'acqua. Se sei all'aperto, allontanati dai corsi d'acqua, dai fossi, dai ponti e dalle zone depresse. Non attraversare mai strade allagate, né a piedi né in auto."
+howto_dopo: "Non rientrare in casa finché le autorità non lo autorizzano. Non entrare in locali allagati dove sono presenti impianti elettrici. Non bere acqua del rubinetto finché non viene dichiarata potabile. Fai attenzione alle strade che potrebbero essere state danneggiate o rese scivolose dal fango. Segnala al 112 situazioni di pericolo (smottamenti, strade interrotte, persone in difficoltà). Documenta i danni con foto per le eventuali richieste di risarcimento."
 ---
 Con il termine "rischio idrogeologico" si intendono i rischi legati all'azione delle acque: alluvioni, allagamenti, frane e smottamenti, che possono essere innescati da piogge intense e persistenti.
 

--- a/content/rischi-prevenzione/rischio-sismico.md
+++ b/content/rischi-prevenzione/rischio-sismico.md
@@ -5,6 +5,12 @@ description: "Cosa fare prima, durante e dopo una scossa di terremoto per la sic
 tts: true
 weight: 1
 toc: true
+# Schema.org HowTo — 3 step PRIMA/DURANTE/DOPO per rich result Google.
+# Vedi rule 04a-hugo-shortcode-partial.md § "Partial structured-data".
+# Aggiunto 12 maggio 2026.
+howto_prima: "Fissa alle pareti mobili alti, librerie e scaffali con tasselli o staffe. Allontana gli oggetti pesanti dai letti e dai divani. Tieni a portata di mano un kit di emergenza con torcia, radio a pile, acqua e medicinali. Individua i punti sicuri della tua casa (sotto un tavolo robusto, contro un muro portante, vicino a una trave). Individua le vie di fuga e le aree di attesa più vicine. Compila il Piano Familiare e condividilo con tutti i componenti della famiglia."
+howto_durante: "Se sei in un luogo chiuso, cerca riparo sotto un tavolo robusto, una scrivania o vicino a un muro portante. Proteggiti la testa con un cuscino o con le braccia. NON precipitarti fuori durante la scossa. Non usare le scale e non usare l'ascensore. Allontanati da finestre, vetri, specchi e mobili pesanti che possono cadere. Se sei all'aperto, allontanati da edifici, alberi, lampioni, linee elettriche e cartelloni; cerca un'area aperta e attendi la fine della scossa."
+howto_dopo: "Assicurati dello stato di salute delle persone intorno a te. Esci con prudenza, indossando le scarpe (possono esserci vetri e calcinacci). Raggiungi le aree di attesa previste dal Piano di Emergenza Comunale. Non rientrare in casa finché le autorità non lo consentono. Non usare il telefono se non per reali necessità, per non intasare le linee. Chiudi il gas e l'interruttore generale dell'elettricità prima di uscire. Stai lontano da costruzioni danneggiate. Ascolta le notizie fornite dalle autorità tramite radio o canali ufficiali."
 ---
 Il terremoto è un evento naturale non prevedibile. L'unica difesa possibile è la prevenzione, la conoscenza delle corrette norme di comportamento e la preparazione.
 

--- a/themes/flavour-pcgenzano/layouts/partials/structured-data.html
+++ b/themes/flavour-pcgenzano/layouts/partials/structured-data.html
@@ -267,6 +267,55 @@
 }
 </script>
 {{ end }}
+{{/* HowTo — schema aggiuntivo per pagine procedure di emergenza con
+     struttura PRIMA/DURANTE/DOPO esplicitata nel frontmatter.
+     Attivato dai 3 campi `howto_prima` / `howto_durante` / `howto_dopo`.
+     Pagine candidate: /rischi-prevenzione/* (sismico, idrogeologico,
+     incendio, vulcanico, ondate-di-calore, blackout, vento-forte,
+     temporali-intensi). Aiuta Google a generare il box "How To" nei
+     risultati di ricerca. Sintassi: {{ . | jsonify }} per gestire
+     correttamente apostrofi italiani e virgolette interne. */}}
+{{ if and .Params.howto_prima .Params.howto_durante .Params.howto_dopo }}
+{{- $totalMin := math.Max 5 (int (math.Round (mul .ReadingTime 1.5))) -}}
+{{/* IMPORTANTE: dentro <script> Hugo applica un secondo escape JS
+     contestuale che produce "\"Foo\"" da jsonify. Per evitare il
+     doppio escape uso `| jsonify | safeJS`. Stessa logica per tutti
+     i campi che contengono testo italiano con apostrofi/virgolette. */}}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": {{ .Title | jsonify | safeJS }},
+  "description": {{ with .Description }}{{ . | jsonify | safeJS }}{{ else }}{{ printf "Procedure di emergenza per %s: cosa fare prima, durante e dopo." .Title | jsonify | safeJS }}{{ end }},
+  "totalTime": "PT{{ $totalMin }}M",
+  "inLanguage": "it-IT",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Prima",
+      "text": {{ .Params.howto_prima | jsonify | safeJS }},
+      "url": "{{ $prodURL }}#cosa-fare-prima"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Durante",
+      "text": {{ .Params.howto_durante | jsonify | safeJS }},
+      "url": "{{ $prodURL }}#cosa-fare-durante"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Dopo",
+      "text": {{ .Params.howto_dopo | jsonify | safeJS }},
+      "url": "{{ $prodURL }}#cosa-fare-dopo"
+    }
+  ]
+}
+</script>
+{{ end }}
+
 {{/* BreadcrumbList — tutte le pagine tranne la homepage */}}
 {{ if not .IsHome }}
 <script type="application/ld+json">


### PR DESCRIPTION
9° tipo Schema.org aggiunto alla copertura del sito. Audit ha rivelato 7 tipi su 9 già attivi: questo PR aggiunge **HowTo** (EducationalOccupationalCredential rimane per Sera 2).

## Vincolo rispettato

Mantenuto `["Organization", "NGO"]` per la homepage come da policy rule 04a (NON sostituito con `GovernmentOrganization`). Confermato dall'utente.

## Cambiamenti (4 file, +75 righe)

1. **`structured-data.html`** +49 righe: blocco HowTo condizionato su `howto_prima/durante/dopo` nel frontmatter. Genera @type=HowTo con name, description, totalTime (ReadingTime × 1.5 min, min 5), inLanguage=it-IT, e 3 HowToStep.
2. **`rischio-sismico.md`**: 3 campi frontmatter populated (POC)
3. **`rischio-idrogeologico.md`**: 3 campi frontmatter populated (POC)
4. **`rule 04a`** § Partial structured-data: documenta nuovo schema + sintassi obbligatoria `| jsonify | safeJS`

## Bug template risolto

Primo build aveva doppio escape: `name: "\"Rischio Sismico...\""`. Hugo dentro `<script>` applica un secondo escape JS contestuale a `jsonify`. Fix: `{{ .Title | jsonify | safeJS }}` (testato in sandbox isolato). Apostrofi italiani preservati.

## Test

- ✅ Hugo build pulita (exit 0)
- ✅ Validazione JSON-LD su 5 pagine: 0 errori parsing
- ✅ HowTo presente solo su 2 pagine POC (le altre 6 candidate restano WebPage finché non popolate)
- ✅ Tutti i HowToStep hanno @type/position/name/text/url
- ✅ Nessun `image:` modificato

## Pagine rischio Sera 2+ (opt-in progressivo)

6 pagine candidate con struttura PRIMA/DURANTE/DOPO completa ma senza howto_* ancora: blackout, ondate-di-calore, rischio-incendio, rischio-vulcanico, temporali-intensi, vento-forte. Aggiunta on-demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)