### PR TITLE
Storie e Racconti: refuso sottotitoli hub (Caterina→Flavia, Tobia→Flavio)

### DIFF
--- a/static/formazione/storie-e-racconti/index.html
+++ b/static/formazione/storie-e-racconti/index.html
@@ -206,7 +206,7 @@
           <a href="bosco-parlava/" class="storia-card">
             <span class="badge-fascia badge-primaria">6-8 anni</span>
             <h3>Il bosco che parlava</h3>
-            <div class="sottotitolo">L'attimo decisivo di Caterina, fra una passeggiata e un piccolo fumo</div>
+            <div class="sottotitolo">L'attimo decisivo di Flavia, fra una passeggiata e un piccolo fumo</div>
             <div class="meta"><span>6 min</span><span>Incendi boschivi</span><span>Segnalazione</span></div>
           </a>
         </div>
@@ -230,7 +230,7 @@
           <a href="muschio-dispettoso/" class="storia-card">
             <span class="badge-fascia badge-primaria">6-8 anni</span>
             <h3>Il muschio dispettoso</h3>
-            <div class="sottotitolo">L'attimo decisivo di Tobia, fra una stradina sbagliata e un fischio salvavita</div>
+            <div class="sottotitolo">L'attimo decisivo di Flavio, fra una stradina sbagliata e un fischio salvavita</div>
             <div class="meta"><span>6 min</span><span>Orientamento</span><span>Smarrimento</span></div>
           </a>
         </div>


### PR DESCRIPTION
## Cosa cambia

Due righe nella pagina hub `/formazione/storie-e-racconti/`:

- riga 209: `Caterina` → `Flavia` (sottotitolo "Il bosco che parlava")
- riga 233: `Tobia` → `Flavio` (sottotitolo "Il muschio dispettoso")

## Why

Regola del progetto: il protagonista delle storie didattiche è sempre **Flavio** (maschile) o **Flavia** (femminile), mai altri nomi.

Audit del 12 maggio 2026 ha rilevato che l'hub aveva 2 sottotitoli con nomi non coerenti, mentre le storie stesse (`bosco-parlava/`, `muschio-dispettoso/`) usano già correttamente Flavia / Flavio nel corpo del testo. Refusi di un primo draft non riportati nell'hub.

## Cosa NON cambia

Lasciati intatti, per scelta narrativa esplicita (personaggi **secondari**, non protagonisti):
- **Signora Caterina** in `giardino-parole-sicure/` — bibliotecaria adulta mentore della protagonista Flavia
- **Tobia** in `sette-sirene-paese/` — bambino più piccolo salvato dalla protagonista Flavia (11 anni) dopo un'evacuazione

La regola dell'utente parla esplicitamente di "protagonista", quindi questi personaggi secondari restano coerenti narrativamente.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3E5eNgZV6mEHo9gH3YvbS)_