### PR TITLE
Fix stampa PDF: nasconde header center wrapper

### DIFF
--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -823,6 +823,7 @@ article:not(.card) .galleria img {
   /* Nascondi tutto il chrome del sito */
   .skip-to-content,
   .it-header-slim-wrapper,
+  .it-header-center-wrapper,
   .it-header-wrapper,
   .it-header-navbar-wrapper,
   header.it-header-wrapper,


### PR DESCRIPTION
## Cosa risolve
Nello screenshot utente, il PDF generato cliccando "Scarica trascrizione PDF" mostrava nell'intestazione:
- "**Protezione Civile (/)**" — il logo `<a href="/">` rimasto visibile in stampa
- A destra, "(/c-erc-a/)" frammentato — l'icona cerca `<a href="/cerca/">` rimasta visibile

## Causa
Il blocco `@media print` di `custom.css` (riga 815+) nascondeva:
- `.it-header-slim-wrapper`
- `.it-header-wrapper`
- `.it-header-navbar-wrapper`
- `nav.navbar`

ma **dimenticava `.it-header-center-wrapper`** — il blocco Bootstrap Italia (`partials/navbar.html` riga 1) che contiene **logo + brand text "Protezione Civile" + icona cerca**.

I caratteri tra parentesi erano gli `attr(href)` dei link nell'header, appesi dalla regola `a[href]::after { content: " (" attr(href) ")" }` e poi frammentati dal `word-break: break-all` dentro il riquadro angusto dell'intestazione PDF.

## Fix
Aggiunto `.it-header-center-wrapper` alla lista dei selettori `display: none !important` nel blocco `@media print`.

Una riga, chirurgica, retro-compatibile.

## Test plan
- [x] Build Hugo pulito (`hugo --quiet --minify` exit 0)
- [ ] Verifica live: aprire un qualunque articolo, click "Scarica trascrizione PDF", controllare che nell'intestazione del PDF non compaia più "Protezione Civile" o l'icona cerca con URL frammentato

## Riferimento
Bug segnalato dall'utente con screenshot 2026-05-13. Era presente "in tutti gli articoli" (citazione utente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)