### PR TITLE
Peso automatico (N KB / N MB) sui link a PDF locali

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -20,8 +20,27 @@
          quindi togliamo lo slash iniziale: "cerca/" → "/sito-pc-genzano/cerca/"
          mentre "/cerca/" → "/cerca/" (rotto su GitHub Pages). */ -}}
   {{- $relLink := strings.TrimPrefix "/" $link -}}
+  {{- /* Peso automatico per PDF locali: legge os.Stat al build e appende "(N KB)" o "(N MB)".
+         Skip se l'autore ha già scritto manualmente la dimensione nel testo del link. */ -}}
+  {{- $sizeSuffix := "" -}}
+  {{- if and $isStatic (strings.HasSuffix $lowerPath ".pdf") -}}
+    {{- $textLower := lower (printf "%s" .Text) -}}
+    {{- $hasManualSize := or (in $textLower "kb)") (in $textLower "mb)") -}}
+    {{- if not $hasManualSize -}}
+      {{- $staticPath := printf "static%s" $path -}}
+      {{- if fileExists $staticPath -}}
+        {{- $bytes := (os.Stat $staticPath).Size -}}
+        {{- if ge $bytes 1048576 -}}
+          {{- $sizeSuffix = printf " (%.1f MB)" (div (float $bytes) 1048576.0) -}}
+        {{- else -}}
+          {{- $kb := math.Ceil (div (float $bytes) 1024.0) -}}
+          {{- $sizeSuffix = printf " (%.0f KB)" $kb -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
   {{- if $isStatic -}}
-    <a href="{{ $relLink | relURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
+    <a href="{{ $relLink | relURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}{{ $sizeSuffix }}</a>
   {{- else -}}
     {{- $cleanPath := strings.TrimSuffix "/" (strings.TrimPrefix "/" $path) -}}
     {{- $target := site.GetPage $cleanPath -}}

--- a/themes/flavour-pcgenzano/layouts/_default/_markup/render-link.html
+++ b/themes/flavour-pcgenzano/layouts/_default/_markup/render-link.html
@@ -20,8 +20,27 @@
          quindi togliamo lo slash iniziale: "cerca/" → "/sito-pc-genzano/cerca/"
          mentre "/cerca/" → "/cerca/" (rotto su GitHub Pages). */ -}}
   {{- $relLink := strings.TrimPrefix "/" $link -}}
+  {{- /* Peso automatico per PDF locali: legge os.Stat al build e appende "(N KB)" o "(N MB)".
+         Skip se l'autore ha già scritto manualmente la dimensione nel testo del link. */ -}}
+  {{- $sizeSuffix := "" -}}
+  {{- if and $isStatic (strings.HasSuffix $lowerPath ".pdf") -}}
+    {{- $textLower := lower (printf "%s" .Text) -}}
+    {{- $hasManualSize := or (in $textLower "kb)") (in $textLower "mb)") -}}
+    {{- if not $hasManualSize -}}
+      {{- $staticPath := printf "static%s" $path -}}
+      {{- if fileExists $staticPath -}}
+        {{- $bytes := (os.Stat $staticPath).Size -}}
+        {{- if ge $bytes 1048576 -}}
+          {{- $sizeSuffix = printf " (%.1f MB)" (div (float $bytes) 1048576.0) -}}
+        {{- else -}}
+          {{- $kb := math.Ceil (div (float $bytes) 1024.0) -}}
+          {{- $sizeSuffix = printf " (%.0f KB)" $kb -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
   {{- if $isStatic -}}
-    <a href="{{ $relLink | relURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
+    <a href="{{ $relLink | relURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}{{ $sizeSuffix }}</a>
   {{- else -}}
     {{- $cleanPath := strings.TrimSuffix "/" (strings.TrimPrefix "/" $path) -}}
     {{- $target := site.GetPage $cleanPath -}}


### PR DESCRIPTION
## Cosa fa
Estende il render hook Markdown `render-link.html` (root + tema, copie sincronizzate) per **appendere automaticamente la dimensione** del file ai link che puntano a PDF locali in `static/`.

## Esempi su link già esistenti nel sito
- `CNA — Best Practices in Social Media Crisis Communications ... (2023)` → `... (637 KB)`
- `DHS/FEMA SAVER — Innovative Uses of Social Media in Emergency Management` → `... (1.5 MB)`
- `Presentazione ufficiale YouPol (PDF)` → `... (PDF) (2.9 MB)`

## Logica
- Link a `.pdf` locale + `fileExists` vero → `os.Stat` → formato `(N KB)` se <1MB, `(N.N MB)` altrimenti.
- **Idempotente**: skip se `.Text` contiene già `KB)` o `MB)` (autore ha già scritto a mano).
- **PDF esterni** (DPC, Regione Lazio, ecc.) → invariati. Il peso non è determinabile a build-time senza HTTP HEAD.
- **`allegati:` YAML** → già coperti dal template `single.html` con campo `dimensione`. Tutti i 15 allegati esistenti hanno il campo popolato.

## Riferimento
WCAG 3.3.5 (Help) + buona prassi AGID: indicare tipo e dimensione dei documenti scaricabili.

## Test plan
- [x] Build Hugo pulito (`hugo --quiet --minify` exit 0)
- [x] Verifica HTML renderizzato: 3 link PDF mostrano correttamente "(637 KB)", "(1.5 MB)", "(2.9 MB)"
- [ ] Verifica live dopo deploy: aprire `/siti-utili/`, `/comunicazioni/2026-04-27-app-youpol-polizia-stato-bullismo-violenza-droga/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)