### PR TITLE
Allerta gialla per oggi + fix workflow MAX(oggi, domani)

### DIFF
--- a/.github/workflows/check-allerta.yml
+++ b/.github/workflows/check-allerta.yml
@@ -42,40 +42,79 @@ jobs:
         run: |
           python3 << 'PYEOF'
           import csv, json, io, os, sys, urllib.request
+          from datetime import datetime, timezone, timedelta
 
-          CSV_URL = (
-              "https://raw.githubusercontent.com/opendatasicilia/"
-              "DPC-bollettini-criticita-idrogeologica-idraulica/"
-              "refs/heads/main/data/bollettini/bollettino-oggi-comuni-latest.csv"
-          )
+          # opendatasicilia espone due CSV: "bollettino-oggi" (per il giorno
+          # corrente, validità fino alle 23:59 del giorno di emissione) e
+          # "bollettino-domani" (per il giorno successivo, validità dal
+          # 00:00 alle 23:59 del giorno dopo l'emissione).
+          # Tra la mezzanotte e le ~14:00 del giorno corrente, "oggi" è ancora
+          # quello vecchio (scaduto) mentre "domani" è già diventato la verità
+          # corrente. Per coprire il gap notturno legge entrambi e prende il
+          # MAX tra quelli VALIDI ADESSO (dentro la finestra data_validita).
+          CSV_URLS = {
+              "oggi": (
+                  "https://raw.githubusercontent.com/opendatasicilia/"
+                  "DPC-bollettini-criticita-idrogeologica-idraulica/"
+                  "refs/heads/main/data/bollettini/bollettino-oggi-comuni-latest.csv"
+              ),
+              "domani": (
+                  "https://raw.githubusercontent.com/opendatasicilia/"
+                  "DPC-bollettini-criticita-idrogeologica-idraulica/"
+                  "refs/heads/main/data/bollettini/bollettino-domani-comuni-latest.csv"
+              ),
+          }
           COMUNE = "Genzano di Roma"
           ALLERTA_PATH = "data/allerta.json"
 
-          # ── 1. Scarica il CSV ──────────────────────────────────────
-          try:
-              req = urllib.request.Request(CSV_URL, headers={"User-Agent": "PC-Genzano-Bot/1.0"})
-              with urllib.request.urlopen(req, timeout=30) as r:
-                  data = r.read().decode("utf-8")
-          except Exception as e:
-              print(f"::warning::CSV non disponibile: {e}")
-              sys.exit(0)  # Non toccare allerta.json se la fonte non risponde
+          rome_tz = timezone(timedelta(hours=2))
+          now = datetime.now(rome_tz)
 
-          # ── 2. Trova la riga di Genzano di Roma ────────────────────
-          reader = csv.DictReader(io.StringIO(data))
-          genzano = None
-          for row in reader:
-              if row.get("comune_nome", "").strip() == COMUNE:
-                  genzano = row
-                  break
+          # ── 1. Scarica entrambi i CSV e trova la riga Genzano ──────
+          bollettini = {}  # label -> row dict
+          for label, url in CSV_URLS.items():
+              try:
+                  req = urllib.request.Request(url, headers={"User-Agent": "PC-Genzano-Bot/1.0"})
+                  with urllib.request.urlopen(req, timeout=30) as r:
+                      data = r.read().decode("utf-8")
+              except Exception as e:
+                  print(f"::warning::CSV {label} non disponibile: {e}")
+                  continue
+              reader = csv.DictReader(io.StringIO(data))
+              for row in reader:
+                  if row.get("comune_nome", "").strip() == COMUNE:
+                      bollettini[label] = row
+                      break
 
-          if not genzano:
-              print(f"::warning::{COMUNE} non trovato nel CSV DPC")
+          if not bollettini:
+              print(f"::warning::Nessun bollettino raggiungibile o {COMUNE} non trovato")
               sys.exit(0)
 
-          print(f"Riga trovata: {json.dumps(genzano, ensure_ascii=False)}")
+          # ── 2. Filtra solo i bollettini VALIDI ADESSO ──────────────
+          def parse_iso(s):
+              try:
+                  return datetime.fromisoformat(s)
+              except Exception:
+                  return None
 
-          # ── 3. Estrai il livello massimo di allerta ────────────────
-          LEVEL_MAP = {"verde": 0, "gialla": 1, "arancione": 2, "rossa": 3}
+          attivi = {}
+          for label, row in bollettini.items():
+              inizio = parse_iso(row.get("data_validita_inizio", ""))
+              fine = parse_iso(row.get("data_validita_fine", ""))
+              if inizio and fine and inizio <= now <= fine:
+                  attivi[label] = row
+                  print(f"✅ Bollettino {label} ATTIVO (validità {inizio} → {fine})")
+              else:
+                  print(f"⏭️  Bollettino {label} fuori validità (inizio={inizio}, fine={fine})")
+
+          if not attivi:
+              # Tutti scaduti / non ancora attivi → fallback su quello che c'è,
+              # priorità domani > oggi (domani è di solito il più recente in arrivo).
+              fallback_key = "domani" if "domani" in bollettini else "oggi"
+              attivi = {fallback_key: bollettini[fallback_key]}
+              print(f"::warning::Nessun bollettino in finestra di validità, uso {fallback_key} come fallback")
+
+          # ── 3. Estrai il livello massimo combinando i bollettini attivi ──
           LEVEL_NAME = {0: "verde", 1: "gialla", 2: "arancione", 3: "rossa"}
 
           def extract_level(value):
@@ -95,22 +134,33 @@ jobs:
           }
 
           max_level = 0
-          active_risks = []
+          active_risks_set = set()  # ordine inserito? no, ricostruito sotto
+          active_risks_order = []
+          bollettino_attivo_label = None
 
-          # Livello complessivo da avviso_criticita
-          crit_level = extract_level(genzano.get("avviso_criticita", ""))
-          if crit_level > max_level:
-              max_level = crit_level
+          for label, row in attivi.items():
+              crit_level = extract_level(row.get("avviso_criticita", ""))
+              if crit_level > max_level:
+                  max_level = crit_level
+                  bollettino_attivo_label = label
 
-          # Livelli per singolo rischio (per i dettagli)
-          for field, label in RISK_FIELDS.items():
-              level = extract_level(genzano.get(field, ""))
-              if level > 0:
-                  active_risks.append(label)
-              if level > max_level:
-                  max_level = level
+              for field, risk_label in RISK_FIELDS.items():
+                  level = extract_level(row.get(field, ""))
+                  if level > 0 and risk_label not in active_risks_set:
+                      active_risks_set.add(risk_label)
+                      active_risks_order.append(risk_label)
+                  if level > max_level:
+                      max_level = level
+                      bollettino_attivo_label = label
 
+          if bollettino_attivo_label is None:
+              bollettino_attivo_label = next(iter(attivi))
+
+          active_risks = active_risks_order
           livello = LEVEL_NAME[max_level]
+          genzano = attivi[bollettino_attivo_label]
+          print(f"📊 MAX level={livello}, dal bollettino '{bollettino_attivo_label}'")
+          print(f"Riga: {json.dumps(genzano, ensure_ascii=False)}")
 
           # ── 4. Costruisci titolo e descrizione ─────────────────────
           TITLES = {
@@ -136,10 +186,6 @@ jobs:
               descrizione = f"Criticità per {rischi_str}. {BASE_DESCS[livello]}"
 
           # ── 5. Confronta con allerta.json attuale ──────────────────
-          from datetime import datetime, timezone, timedelta
-
-          rome_tz = timezone(timedelta(hours=2))
-          now = datetime.now(rome_tz)
           timestamp_now = now.strftime("%Y-%m-%dT%H:%M:%S+02:00")
 
           try:

--- a/data/allerta.json
+++ b/data/allerta.json
@@ -1,7 +1,7 @@
 {
-  "livello": "verde",
-  "titolo": "NESSUNA ALLERTA",
-  "descrizione": "Non sono previsti fenomeni significativi sul nostro territorio.",
-  "ultimo_aggiornamento": "2026-05-01T15:50:29+02:00",
-  "ultimo_controllo": "2026-05-13T00:30:42+02:00"
+  "livello": "gialla",
+  "titolo": "ALLERTA GIALLA — temporali",
+  "descrizione": "Ordinaria criticità idrogeologica per temporali sulla Zona F — Bacini Costieri Sud (Genzano). Bollettino DPC/Regione Lazio del 12 maggio 2026, validità 13 maggio 00:00–23:59.",
+  "ultimo_aggiornamento": "2026-05-12T14:42:59+02:00",
+  "ultimo_controllo": "2026-05-13T03:10:00+02:00"
 }


### PR DESCRIPTION
## Sintesi
Due cambi in un commit, legati allo stesso bug.

## 1. \`data/allerta.json\` → gialla
Conforme al bollettino DPC/Regione Lazio del 12/05/2026 valido oggi 13/05:
- Zona Lazi-F (Bacini Costieri Sud): **Ordinaria per rischio temporali / ALLERTA GIALLA**
- Confermato dal PDF ufficiale Regione Lazio (linkato dall'utente).

## 2. \`check-allerta.yml\` → MAX time-aware (oggi + domani)
**Bug:** opendatasicilia espone DUE CSV separati:
- \`bollettino-oggi\`: validità ~14:00 → 23:59 del giorno di emissione
- \`bollettino-domani\`: validità 00:00 → 23:59 del giorno successivo

Tra mezzanotte e ~14:00, "oggi" è SCADUTO e "domani" è la verità corrente. Ma il workflow leggeva solo "oggi", lasciando il sito stale per ~14 ore notturne.

**Fix:** legge entrambi, filtra per validità temporale (\`data_validita_inizio ≤ now ≤ data_validita_fine\`), combina i livelli MAX tra quelli validi.

**Test offline (eseguito ora, 13/05 alle 03:14):**
\`\`\`
oggi   (12/05 14:42 → 12/05 23:59): SCADUTO, escluso
domani (13/05 00:00 → 13/05 23:59): ATTIVO, livello gialla
→ RISULTATO: livello=gialla, rischi=[temporali]
\`\`\`
Combacia con bollettino reale.

## Test plan
- [x] YAML workflow valido (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [x] Logica testata offline con CSV live: produce \`gialla / temporali\`
- [ ] Verifica live dopo deploy: homepage e \`/emergenza/\` mostrano allerta gialla
- [ ] Test al prossimo cambio bollettino (~14:00 oggi): aggiornamento automatico funziona

🤖 Generated with [Claude Code](https://claude.com/claude-code)