### PR TITLE
check-allerta: tz Europe/Rome dinamica (CET/CEST automatico)

### DIFF
--- a/.github/workflows/check-allerta.yml
+++ b/.github/workflows/check-allerta.yml
@@ -42,7 +42,8 @@ jobs:
         run: |
           python3 << 'PYEOF'
           import csv, json, io, os, sys, urllib.request
-          from datetime import datetime, timezone, timedelta
+          from datetime import datetime, timedelta
+          from zoneinfo import ZoneInfo  # gestisce automaticamente CET/CEST (ora solare/legale Europe/Rome)
 
           # opendatasicilia espone due CSV: "bollettino-oggi" (per il giorno
           # corrente, validità fino alle 23:59 del giorno di emissione) e
@@ -67,7 +68,10 @@ jobs:
           COMUNE = "Genzano di Roma"
           ALLERTA_PATH = "data/allerta.json"
 
-          rome_tz = timezone(timedelta(hours=2))
+          # ZoneInfo Europe/Rome gestisce automaticamente l'offset corretto:
+          # +02:00 in ora legale (ultima domenica di marzo → ultima domenica di ottobre)
+          # +01:00 in ora solare (ultima domenica di ottobre → ultima domenica di marzo)
+          rome_tz = ZoneInfo("Europe/Rome")
           now = datetime.now(rome_tz)
 
           # ── 1. Scarica entrambi i CSV e trova la riga Genzano ──────
@@ -186,7 +190,9 @@ jobs:
               descrizione = f"Criticità per {rischi_str}. {BASE_DESCS[livello]}"
 
           # ── 5. Confronta con allerta.json attuale ──────────────────
-          timestamp_now = now.strftime("%Y-%m-%dT%H:%M:%S+02:00")
+          # isoformat con timespec='seconds' produce automaticamente l'offset
+          # corretto in base alla data: +02:00 d'estate, +01:00 d'inverno.
+          timestamp_now = now.isoformat(timespec="seconds")
 
           try:
               with open(ALLERTA_PATH, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Bug
Il workflow usava \`timezone(timedelta(hours=2))\` **hardcoded a +02:00**. Funziona durante l'ora legale (marzo → ottobre) ma è **sbagliato di 1 ora** durante l'ora solare (resto dell'anno).

Impatto sulla logica time-aware introdotta in #204:
- \`now\` off-by-one durante l'ora solare → il filtro \`data_validita_inizio ≤ now ≤ data_validita_fine\` poteva escludere un bollettino valido o includerne uno scaduto
- \`ultimo_aggiornamento\` / \`ultimo_controllo\` con suffisso \`+02:00\` anche durante l'ora solare → timestamp semanticamente errati per ~5 mesi/anno

## Fix
- \`from zoneinfo import ZoneInfo\` (stdlib Python 3.9+)
- \`rome_tz = ZoneInfo("Europe/Rome")\` → gestisce automaticamente CET (+01:00) e CEST (+02:00) in base alla data
- \`timestamp_now = now.isoformat(timespec="seconds")\` → ISO 8601 con offset corretto

## Verifica matematica
| Data | Offset prodotto |
|---|---|
| 15 gen 2026 (ora solare) | \`+01:00\` ✓ |
| 15 lug 2026 (ora legale) | \`+02:00\` ✓ |
| 24 ott 2026 23:00 (ultimo giorno DST) | \`+02:00\` ✓ |
| 26 ott 2026 10:00 (post-DST) | \`+01:00\` ✓ |

## Nessun conflitto altrove
- \`audit-sito.yml § 26\` rifiuta solo \`Z\` (UTC), tollera entrambi i suffissi italiani
- Convenzione formato data **articoli** (CLAUDE.md punto 1, \`+02:00\` fisso come tie-break Hugo) NON cambia: è convenzione di scrittura, non timestamp operativo

🤖 Generated with [Claude Code](https://claude.com/claude-code)