### PR TITLE
P4: fascia 'Previsto domani' in homepage (≥ giallo)

### DIFF
--- a/.github/workflows/check-allerta.yml
+++ b/.github/workflows/check-allerta.yml
@@ -166,6 +166,49 @@ jobs:
           print(f"📊 MAX level={livello}, dal bollettino '{bollettino_attivo_label}'")
           print(f"Riga: {json.dumps(genzano, ensure_ascii=False)}")
 
+          # ── 3-bis. Pre-allerta dal bollettino-domani (se è davvero futuro) ──
+          # Tra le 00:00 e le ~14:00 del giorno corrente, il CSV "bollettino-domani"
+          # è ancora quello emesso ieri per OGGI (non per domani vero). Quindi
+          # includo il blocco 'domani' SOLO se la sua data_validita_inizio è
+          # strettamente DOPO l'oggi del fuso italiano. Quando il DPC pubblica
+          # il nuovo bollettino-domani (~14:00), allora data_validita_inizio
+          # avanza al giorno successivo e il blocco compare automaticamente.
+          domani_block = None
+          if "domani" in bollettini:
+              row_d = bollettini["domani"]
+              inizio_d = parse_iso(row_d.get("data_validita_inizio", ""))
+              today_in_rome = now.date()
+              if inizio_d and inizio_d.date() > today_in_rome:
+                  max_dom = 0
+                  risks_dom_order = []
+                  risks_dom_set = set()
+                  crit_d = extract_level(row_d.get("avviso_criticita", ""))
+                  if crit_d > max_dom:
+                      max_dom = crit_d
+                  for field, risk_label in RISK_FIELDS.items():
+                      lev_d = extract_level(row_d.get(field, ""))
+                      if lev_d > 0 and risk_label not in risks_dom_set:
+                          risks_dom_set.add(risk_label)
+                          risks_dom_order.append(risk_label)
+                      if lev_d > max_dom:
+                          max_dom = lev_d
+                  liv_dom = LEVEL_NAME[max_dom]
+                  titolo_dom = {
+                      "verde": "Previsto verde",
+                      "gialla": "Previsto giallo",
+                      "arancione": "Previsto arancione",
+                      "rossa": "Previsto rosso",
+                  }[liv_dom]
+                  domani_block = {
+                      "livello": liv_dom,
+                      "titolo": titolo_dom,
+                      "rischi": risks_dom_order,
+                      "data": inizio_d.date().isoformat(),
+                  }
+                  print(f"📅 Bollettino DOMANI ({inizio_d.date()}): {liv_dom}, rischi={risks_dom_order}")
+              else:
+                  print(f"⏭️  Bollettino-domani CSV punta al giorno corrente ({inizio_d.date() if inizio_d else 'n/a'}), niente pre-allerta")
+
           # ── 4. Costruisci titolo e descrizione ─────────────────────
           TITLES = {
               "verde": "NESSUNA ALLERTA",
@@ -202,6 +245,12 @@ jobs:
 
           old_level = current.get("livello", "sconosciuto")
           level_changed = current.get("livello") != livello
+          # Anche un cambio di pre-allerta DOMANI deve essere committato:
+          # ad esempio "oggi verde + domani gialla" è un'informazione nuova
+          # rispetto a "oggi verde + domani verde" e deve apparire in homepage.
+          old_domani_level = ((current.get("domani") or {}).get("livello") or "verde")
+          new_domani_level = (domani_block.get("livello") if domani_block else "verde")
+          domani_level_changed = old_domani_level != new_domani_level
 
           # Calcola se sono passate ≥6 ore dall'ultimo controllo committato.
           # Soglia: 5h45min, così il cron orario centra sicuramente la finestra
@@ -216,8 +265,8 @@ jobs:
               except Exception:
                   pass
 
-          if not level_changed and not stale_check:
-              print(f"✅ Livello invariato ({livello}) e ultimo controllo recente: skip commit")
+          if not level_changed and not domani_level_changed and not stale_check:
+              print(f"✅ Livello invariato (oggi={livello}, domani={new_domani_level}) e ultimo controllo recente: skip commit")
               gh_out = os.environ.get("GITHUB_OUTPUT", "")
               if gh_out:
                   with open(gh_out, "a") as f:
@@ -230,6 +279,9 @@ jobs:
           if level_changed:
               ultimo_aggiornamento = timestamp_now
               motivo = f"livello {old_level} → {livello}"
+          elif domani_level_changed:
+              ultimo_aggiornamento = current.get("ultimo_aggiornamento", timestamp_now)
+              motivo = f"pre-allerta domani {old_domani_level} → {new_domani_level} (oggi invariato: {livello})"
           else:
               ultimo_aggiornamento = current.get("ultimo_aggiornamento", timestamp_now)
               motivo = f"controllo periodico (livello invariato: {livello})"
@@ -241,6 +293,8 @@ jobs:
               "ultimo_aggiornamento": ultimo_aggiornamento,
               "ultimo_controllo": timestamp_now,
           }
+          if domani_block:
+              new_data["domani"] = domani_block
 
           with open(ALLERTA_PATH, "w", encoding="utf-8") as f:
               json.dump(new_data, f, indent=2, ensure_ascii=False)

--- a/data/allerta.json
+++ b/data/allerta.json
@@ -3,5 +3,5 @@
   "titolo": "ALLERTA GIALLA — temporali",
   "descrizione": "Ordinaria criticità idrogeologica per temporali sulla Zona F — Bacini Costieri Sud (Genzano). Bollettino DPC/Regione Lazio del 12 maggio 2026, validità 13 maggio 00:00–23:59.",
   "ultimo_aggiornamento": "2026-05-12T14:42:59+02:00",
-  "ultimo_controllo": "2026-05-13T03:10:00+02:00"
+  "ultimo_controllo": "2026-05-13T05:30:00+02:00"
 }

--- a/themes/flavour-pcgenzano/layouts/index.html
+++ b/themes/flavour-pcgenzano/layouts/index.html
@@ -42,6 +42,33 @@
     </div>
   </div>
 </div>
+{{/* ── PRE-ALLERTA DOMANI — visibile solo se livello-domani ≥ gialla.
+     Il div esce SEMPRE dal template (per consentire al JS client di
+     aggiornarlo dinamicamente anche se al build domani era verde), ma
+     parte con display:none quando non c'è pre-allerta da mostrare. */}}
+{{ $domaniLivelliVisibili := slice "gialla" "arancione" "rossa" }}
+{{ $domaniVisibile := false }}
+{{ $domaniLiv := "verde" }}
+{{ $domaniDataLeg := "" }}
+{{ $domaniTitolo := "" }}
+{{ $domaniRischi := "" }}
+{{ with $allerta.domani }}
+  {{ if in $domaniLivelliVisibili .livello }}
+    {{ $domaniVisibile = true }}
+    {{ $domaniLiv = .livello }}
+    {{ $domaniTitolo = .titolo }}
+    {{ $domaniRischi = delimit .rischi ", " }}
+    {{ $td := time.AsTime .data }}
+    {{ $domaniDataLeg = printf "%d %s %d" $td.Day (index $mesi (int $td.Month)) $td.Year }}
+  {{ end }}
+{{ end }}
+<div id="allerta-bar-domani" class="allerta-bar-domani allerta-bar-domani-{{ $domaniLiv }}" role="status" aria-label="Pre-allerta meteo per domani"{{ if not $domaniVisibile }} style="display:none"{{ end }}>
+  <div class="container">
+    <i class="bi bi-calendar-event me-2" aria-hidden="true"></i>
+    <strong>Previsto domani{{ if $domaniDataLeg }} ({{ $domaniDataLeg }}){{ end }}:</strong>
+    <span id="allerta-domani-titolo">{{ $domaniTitolo }}</span>{{ if $domaniRischi }} <span class="text-nowrap">— {{ $domaniRischi }}</span>{{ end }}
+  </div>
+</div>
 {{ end }}
 
 {{/* ══════════════════════════════════════════════════════
@@ -346,12 +373,55 @@ function checkAllertaDPC(){
 
       // Aggiorna "Verificato: <ora>" con l'ora locale del client (max freschezza)
       var ck=document.getElementById('allerta-controllo');
+      var mesi=['gennaio','febbraio','marzo','aprile','maggio','giugno','luglio','agosto','settembre','ottobre','novembre','dicembre'];
       if(ck){
         var n=new Date();
         var pad=function(x){return x<10?'0'+x:''+x};
-        var mesi=['gennaio','febbraio','marzo','aprile','maggio','giugno','luglio','agosto','settembre','ottobre','novembre','dicembre'];
         ck.textContent=n.getDate()+' '+mesi[n.getMonth()]+' '+n.getFullYear()+', '+pad(n.getHours())+':'+pad(n.getMinutes());
       }
+
+      // Pre-allerta DOMANI: se il bollettino-domani CSV punta a un giorno
+      // strettamente futuro rispetto a oggi, ed ha livello ≥ gialla, mostra
+      // la fascia. Altrimenti nascondi/rimuovi.
+      var barDomani=document.getElementById('allerta-bar-domani');
+      var domaniRow=results[1]?parseBollettino(results[1]):null;
+      var domaniLevel=0;
+      var domaniRisks=[];
+      var domaniDate=null;
+      if(domaniRow){
+        var inizioD=domaniRow.inizio?new Date(domaniRow.inizio):null;
+        var p2=function(x){return x<10?'0'+x:''+x};
+        var oggiYMD=now.getFullYear()+'-'+p2(now.getMonth()+1)+'-'+p2(now.getDate());
+        var inizioYMD=inizioD?inizioD.getFullYear()+'-'+p2(inizioD.getMonth()+1)+'-'+p2(inizioD.getDate()):null;
+        if(inizioYMD&&inizioYMD>oggiYMD){
+          for(var cd=0;cd<colonne.length;cd++){
+            var levD=levelFromValue(domaniRow[colonne[cd].key]);
+            if(levD>domaniLevel)domaniLevel=levD;
+            if(levD>0&&['temporali','idrogeologico','idraulico'].indexOf(colonne[cd].key)>=0){
+              var nomeR=colonne[cd].nome.toLowerCase();
+              if(domaniRisks.indexOf(nomeR)<0)domaniRisks.push(nomeR);
+            }
+          }
+          domaniDate=inizioD;
+        }
+      }
+      if(barDomani){
+        if(domaniLevel>=1&&domaniDate){
+          var liv=names[domaniLevel];
+          var titoloDom={gialla:'Previsto giallo',arancione:'Previsto arancione',rossa:'Previsto rosso'}[liv];
+          var dataLeg=domaniDate.getDate()+' '+mesi[domaniDate.getMonth()]+' '+domaniDate.getFullYear();
+          barDomani.className='allerta-bar-domani allerta-bar-domani-'+liv;
+          barDomani.style.display='';
+          var html='<div class="container"><i class="bi bi-calendar-event me-2" aria-hidden="true"></i><strong>Previsto domani ('+dataLeg+'):</strong> <span id="allerta-domani-titolo">'+titoloDom+'</span>';
+          if(domaniRisks.length>0)html+=' <span class="text-nowrap">— '+domaniRisks.join(', ')+'</span>';
+          html+='</div>';
+          barDomani.innerHTML=html;
+        }else{
+          // Niente pre-allerta valida: nascondi la fascia
+          barDomani.style.display='none';
+        }
+      }
+
       bar.classList.remove('allerta-bar-loading');
     })
     .catch(function(){ bar.classList.remove('allerta-bar-loading'); });

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -111,6 +111,24 @@ body { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; 
 .allerta-bar-meta a:focus-visible { outline: 2px solid currentColor; outline-offset: 2px; }
 .allerta-bar-meta i { opacity: 0.85; }
 
+/* ── PRE-ALLERTA DOMANI v1.0 ──
+   Fascia compatta sotto la barra allerta principale che pre-annuncia il
+   livello previsto per il giorno successivo. Solo se livello ≥ gialla.
+   Toni desaturati (-25%) rispetto al banner principale per non competere
+   visivamente: il livello PRESENTE conta più della previsione. */
+.allerta-bar-domani { padding: 0.4rem 0; font-size: 0.82rem; font-weight: 500; }
+.allerta-bar-domani-gialla { background: #fff3cd !important; color: #664d03 !important; border-top: 1px solid #ffd966; }
+.allerta-bar-domani-arancione { background: #ffe8d0 !important; color: #7a3a00 !important; border-top: 1px solid #fdb280; }
+.allerta-bar-domani-rossa { background: #fad7da !important; color: #841a26 !important; border-top: 1px solid #f5a6ad; }
+.allerta-bar-domani i { font-size: 0.95rem; opacity: 0.85; vertical-align: -0.05em; }
+.allerta-bar-domani strong { font-weight: 600; }
+@media (max-width: 575.98px) {
+  .allerta-bar-domani { font-size: 0.78rem; }
+}
+@media print {
+  .allerta-bar-domani { display: none !important; }
+}
+
 /* ── HERO CON PATTERN ── */
 .hero-section {
   background: linear-gradient(145deg, var(--pc-primary-dark) 0%, var(--pc-primary) 35%, var(--pc-primary-light) 100%);


### PR DESCRIPTION
## Cosa fa
Aggiunge una fascia compatta sotto il banner allerta principale che pre-annuncia il livello previsto per il giorno successivo. Mostrata **solo** se livello-domani ≥ gialla **e** se il bollettino-domani CSV punta a una data strettamente futura (evita falsa pre-allerta tra 00:00 e ~14:00 quando il CSV "domani" sta ancora coprendo il giorno corrente).

## Esempio output
\`\`\`
[ALLERTA GIALLA — temporali  ……  Bollettino Ufficiale]
[Verificato: 13 maggio 2026, 14:30 · Fonte: Centro Funzionale Lazio]
└─ 📅 Previsto domani (14 maggio 2026): Previsto giallo — temporali
\`\`\`

## Toni desaturati ~25% per non competere col banner principale
| Livello | Banner principale | Fascia "domani" |
|---|---|---|
| gialla | #ffc107 / #000 | #fff3cd / #664d03 |
| arancione | #fd7e14 / #fff | #ffe8d0 / #7a3a00 |
| rossa | #dc3545 / #fff | #fad7da / #841a26 |

## Allineato 1:1 server e client
- **Server** (\`check-allerta.yml\`): nuovo blocco \`"domani": {livello, titolo, rischi, data}\` in \`data/allerta.json\`.
- **JS client**: stessa logica, fetch dei due CSV già attivo dal PR #205.
- **Template Hugo**: div sempre renderizzato con \`display:none\` di default, il JS lo mostra/nasconde dinamicamente.

## Trigger commit esteso
Il workflow ora committa anche se solo la pre-allerta domani cambia (escalation o cessazione), non solo per "oggi". Messaggio commit dedicato: \`pre-allerta domani verde → gialla (oggi invariato: verde)\`.

## Test plan
- [x] Hugo build clean
- [x] YAML workflow valido
- [x] HTML renderizzato: div con \`display:none\` corretto (livello = verde, blocco domani assente)
- [ ] Verifica live dopo 14:00: il DPC pubblica il bollettino del 14/05, workflow lo legge, fascia appare automaticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)