### PR TITLE
P2: avvisi meteo avversi (vento/neve/calore) da parser PDF Regione Lazio

### DIFF
--- a/.github/workflows/check-allerta.yml
+++ b/.github/workflows/check-allerta.yml
@@ -313,24 +313,45 @@ jobs:
                   f.write(f"level_changed={'true' if level_changed else 'false'}\n")
           PYEOF
 
-      - name: "📝 Commit e push"
-        if: steps.check.outputs.changed == 'true'
+      - name: "🌬️ Check avvisi meteo avversi (vento, neve, calore)"
+        id: avvisi
+        run: |
+          # poppler-utils per pdftotext, preinstallato su ubuntu-latest ma garantiamo
+          which pdftotext || sudo apt-get install -y --no-install-recommends poppler-utils
+          python3 scripts/check-avvisi-meteo.py
+
+      - name: "📝 Commit e push se allerta o avviso cambiato"
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/allerta.json
-          git diff --cached --quiet && exit 0
-          git commit -m "$(cat <<EOF
-          Allerta meteo: ${{ steps.check.outputs.motivo }}
-
-          Aggiornamento automatico da bollettino DPC (opendatasicilia).
-          ${{ steps.check.outputs.descrizione }}
-          EOF
-          )"
+          if git diff --cached --quiet; then
+            echo "Nessuna modifica a data/allerta.json: skip commit"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Messaggio commit combinato: descrive cosa è cambiato
+          MSG_PARTS=()
+          if [ "${{ steps.check.outputs.changed }}" = "true" ]; then
+            MSG_PARTS+=("${{ steps.check.outputs.motivo }}")
+          fi
+          if [ "${{ steps.avvisi.outputs.changed }}" = "true" ]; then
+            if [ -n "${{ steps.avvisi.outputs.tipo }}" ]; then
+              MSG_PARTS+=("avviso meteo: ${{ steps.avvisi.outputs.tipo }} ${{ steps.avvisi.outputs.livello }}")
+            else
+              MSG_PARTS+=("avviso meteo cessato")
+            fi
+          fi
+          MSG_HEAD=$(IFS=' + '; echo "${MSG_PARTS[*]}")
+          [ -z "$MSG_HEAD" ] && MSG_HEAD="aggiornamento periodico"
+          git commit -m "Allerta meteo: $MSG_HEAD" \
+                     -m "Aggiornamento automatico da bollettino DPC (opendatasicilia) e avvisi meteo Regione Lazio."
           git push
+          echo "committed=true" >> "$GITHUB_OUTPUT"
 
       - name: "🚀 Avvia deploy"
-        if: steps.check.outputs.changed == 'true'
+        if: steps.commit.outputs.committed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/check-avvisi-meteo.py
+++ b/scripts/check-avvisi-meteo.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+Aggiorna data/allerta.json con il blocco "avviso_meteo" leggendo la pagina
+"Allertamenti" della Regione Lazio, filtrando i PDF degli avvisi di
+condizioni meteorologiche avverse (vento, neve, ondate di calore, ghiaccio,
+gelate, mareggiate) — distinti dai normali allertamenti di criticità
+idrogeologica e idraulica già coperti dal check-allerta sul CSV opendatasicilia.
+
+Logica:
+1. Scarica la pagina HTML degli "allertamenti".
+2. Estrae i link PDF e la loro data dal nome file (regex su date IT).
+3. Filtra solo i PDF emessi negli ultimi 5 giorni (gli avvisi sono validi
+   24-36 ore, do margine per coprire emissioni serali).
+4. Per ognuno, scarica e parsa con pdftotext:
+   - Identifica "PER I SEGUENTI RISCHI: <RISCHIO>"
+   - Se <RISCHIO> contiene "IDROGEOLOGIC" → ignora (già coperto)
+   - Altrimenti estrae: livello, descrizione fenomeno, validità
+5. Se trova un avviso valido ADESSO (validità ≥ now), lo scrive
+   in data/allerta.json come campo "avviso_meteo".
+6. Se nessun avviso valido adesso, rimuove il campo "avviso_meteo"
+   esistente (cessazione automatica).
+
+Dipendenze runtime:
+- poppler-utils (per pdftotext) — preinstallato su ubuntu-latest
+- python3 (stdlib only)
+
+Anti-spam: lo script aggiorna allerta.json solo se cambia il "tipo" o il
+"livello" dell'avviso_meteo (non per refresh periodici). Il workflow
+notifica-telegram.yml deve essere esteso separatamente per gestire questo
+nuovo campo (TODO follow-up).
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+ROOT = Path(__file__).resolve().parent.parent
+ALLERTA_PATH = ROOT / "data" / "allerta.json"
+
+BASE_URL = "https://protezionecivile.regione.lazio.it"
+INDEX_URL = f"{BASE_URL}/gestione-emergenze/centro-funzionale/bollettini/allertamenti"
+
+ROME_TZ = ZoneInfo("Europe/Rome")
+USER_AGENT = "PC-Genzano-Bot/1.0"
+HTTP_TIMEOUT = 30
+
+# Finestra retroattiva: scaricamo solo PDF emessi negli ultimi N giorni.
+# Gli avvisi DPC sono validi 24-36 ore, 5 giorni di margine basta e avanza.
+LOOKBACK_DAYS = 5
+
+# Mapping: parola chiave nel campo "PER I SEGUENTI RISCHI:" → tipo umano.
+# IDROGEOLOG e IDRAULICA sono ignorati: già coperti dal CSV opendatasicilia.
+RISK_TYPES = {
+    "VENTO": "vento",
+    "NEVE": "neve",
+    "GHIACCIO": "ghiaccio e gelate",
+    "GELATE": "ghiaccio e gelate",
+    "ONDATA DI CALORE": "ondate di calore",
+    "ONDATE DI CALORE": "ondate di calore",
+    "CALORE": "ondate di calore",
+    "MAREGGIATE": "mareggiate",
+    "TEMPORALI": "temporali",  # avviso meteo separato dal bollettino criticità
+}
+
+# Tipi che SONO già coperti dal CSV (= ignora):
+SKIP_RISKS = ["IDROGEOLOG", "IDRAULIC", "CRITICIT"]
+
+LEVEL_NAMES = {0: "verde", 1: "gialla", 2: "arancione", 3: "rossa"}
+
+
+def http_get(url, timeout=HTTP_TIMEOUT):
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read()
+
+
+def http_get_text(url):
+    data = http_get(url)
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode("latin-1", errors="replace")
+
+
+def estrai_data_da_nome(filename):
+    """Cerca date nel nome file: GG_MM_AAAA, GG-MM-AAAA, GG MM AAAA."""
+    m = re.search(r"(\d{2})[_\-\s.](\d{2})[_\-\s.](\d{4})", filename)
+    if not m:
+        return None
+    try:
+        return datetime(int(m.group(3)), int(m.group(2)), int(m.group(1)), tzinfo=ROME_TZ)
+    except ValueError:
+        return None
+
+
+def parse_pdf(pdf_bytes):
+    """Restituisce testo del PDF via pdftotext stdin/stdout."""
+    res = subprocess.run(
+        ["pdftotext", "-layout", "-", "-"],
+        input=pdf_bytes,
+        capture_output=True,
+        timeout=30,
+    )
+    if res.returncode != 0:
+        return ""
+    return res.stdout.decode("utf-8", errors="replace")
+
+
+def estrai_rischio(testo):
+    """Estrae il valore di 'PER I SEGUENTI RISCHI: <X>' dal testo PDF."""
+    m = re.search(r"PER\s+I\s+SEGUENTI\s+RISCHI\s*:\s*(.+?)\s*\.", testo, re.IGNORECASE)
+    if m:
+        return m.group(1).strip().upper()
+    return None
+
+
+def classifica_rischio(rischio_raw):
+    """Mappa il rischio raw del PDF al tipo umano. None se è SOLO idrogeologico.
+
+    Caso composito: 'VENTO, NEVE, CRITICITÀ IDROGEOLOGICA ED IDRAULICA' →
+    estraggo "vento, neve" e ignoro la parte idrogeologica che è già
+    coperta dal CSV opendatasicilia.
+    """
+    if not rischio_raw:
+        return None
+    tipi_trovati = []
+    seen = set()
+    for kw, tipo_umano in RISK_TYPES.items():
+        if kw in rischio_raw and tipo_umano not in seen:
+            seen.add(tipo_umano)
+            tipi_trovati.append(tipo_umano)
+    if tipi_trovati:
+        return ", ".join(tipi_trovati)
+    # Nessuna keyword meteo riconosciuta: è solo idrogeologico (già coperto)?
+    for skip in SKIP_RISKS:
+        if skip in rischio_raw:
+            return None
+    # Rischio sconosciuto, non skippabile: ritorno la stringa raw normalizzata
+    return rischio_raw.title()
+
+
+def estrai_livello(testo):
+    """Estrae il livello max menzionato nel PDF (ROSSA > ARANCIONE > GIALLA)."""
+    t = testo.upper()
+    if "ALLERTA ROSSA" in t:
+        return 3
+    if "ALLERTA ARANCIONE" in t:
+        return 2
+    if "ALLERTA GIALLA" in t:
+        return 1
+    return 0
+
+
+def estrai_validita_e_descrizione(testo, data_emissione):
+    """Estrae validità + descrizione fenomeno dal PDF.
+
+    Pattern frequenti:
+    - 'dalle prime ore di domani, martedì 31.03.2026, e per le successive 24-36 ore'
+    - 'a partire dalla mezzanotte di domani'
+    - 'dalle prossime ore'
+
+    Se non trova validità esplicita, assume:
+    - inizio: data emissione (o domani 00:00 se 'dalle prime ore di domani')
+    - fine: inizio + 36 ore
+    """
+    inizio = data_emissione
+    fine = data_emissione + timedelta(hours=36)
+
+    # Cerca "dalle prime ore di domani, ..., DD.MM.YYYY"
+    m = re.search(r"dalle\s+prime\s+ore\s+di\s+domani.*?(\d{1,2})[./](\d{1,2})[./](\d{4})", testo, re.IGNORECASE)
+    if m:
+        try:
+            inizio = datetime(int(m.group(3)), int(m.group(2)), int(m.group(1)), 0, 0, tzinfo=ROME_TZ)
+            fine = inizio + timedelta(hours=36)
+        except ValueError:
+            pass
+
+    # Estrazione descrizione fenomeno: frase tipica "si prevedono sul Lazio:\n<descr>."
+    descrizione = None
+    m2 = re.search(r"si\s+prevedono\s+sul\s+Lazio\s*:?\s*\n?\s*([^\n]+?)\.", testo, re.IGNORECASE | re.DOTALL)
+    if m2:
+        descrizione = m2.group(1).strip().replace("\n", " ")
+        descrizione = re.sub(r"\s+", " ", descrizione)
+        if len(descrizione) > 250:
+            descrizione = descrizione[:247] + "..."
+
+    return inizio, fine, descrizione
+
+
+def load_allerta():
+    try:
+        with open(ALLERTA_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_allerta(data):
+    with open(ALLERTA_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def main():
+    now = datetime.now(ROME_TZ)
+    print(f"[{now.isoformat(timespec='seconds')}] check-avvisi-meteo: scarico {INDEX_URL}")
+
+    try:
+        html = http_get_text(INDEX_URL)
+    except Exception as e:
+        print(f"::warning::Impossibile scaricare la pagina allertamenti: {e}")
+        return 0
+
+    # Estrai tutti i link PDF della cartella tbl_avvisi_meteo_avverso
+    pdf_paths = re.findall(
+        r'href="(/sites/default/files/binary/rl_protezione_civile/tbl_avvisi_meteo_avverso/[^"]*\.pdf)"',
+        html,
+    )
+    pdf_paths = list(dict.fromkeys(pdf_paths))  # dedup mantenendo ordine
+    print(f"Trovati {len(pdf_paths)} PDF candidati nella pagina")
+
+    # Filtra per data dal nome (lookback)
+    candidates = []
+    cutoff = now - timedelta(days=LOOKBACK_DAYS)
+    for path in pdf_paths:
+        filename = urllib.parse.unquote(path.rsplit("/", 1)[-1])
+        data_pdf = estrai_data_da_nome(filename)
+        if data_pdf is None:
+            continue
+        if data_pdf < cutoff:
+            continue
+        candidates.append((data_pdf, path, filename))
+
+    candidates.sort(key=lambda x: x[0], reverse=True)  # più recente prima
+    print(f"Candidati ultimi {LOOKBACK_DAYS} giorni: {len(candidates)}")
+
+    avviso_attivo = None
+    for data_pdf, path, filename in candidates:
+        full_url = BASE_URL + urllib.parse.quote(path)
+        # Quote rimette anche % di caratteri speciali, ma il path che abbiamo
+        # è già URL-style. Decodifico prima e ri-quoto correttamente.
+        full_url = BASE_URL + path  # spazi tipo "vento 30 03 2026" → urllib li gestisce con il quote sotto
+        try:
+            req = urllib.request.Request(full_url.replace(" ", "%20"), headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as r:
+                pdf_bytes = r.read()
+        except Exception as e:
+            print(f"  ⏭️  {filename}: impossibile scaricare ({e})")
+            continue
+
+        testo = parse_pdf(pdf_bytes)
+        if not testo:
+            print(f"  ⏭️  {filename}: pdftotext output vuoto")
+            continue
+
+        rischio_raw = estrai_rischio(testo)
+        tipo = classifica_rischio(rischio_raw)
+        if not tipo:
+            print(f"  ⏭️  {filename}: rischio='{rischio_raw}' (skip, idrogeologico già coperto)")
+            continue
+
+        livello = estrai_livello(testo)
+        if livello == 0:
+            print(f"  ⏭️  {filename}: tipo={tipo} ma nessun livello allerta esplicito")
+            continue
+
+        inizio, fine, descrizione = estrai_validita_e_descrizione(testo, data_pdf)
+        if now > fine:
+            print(f"  ⏭️  {filename}: tipo={tipo}, livello={LEVEL_NAMES[livello]}, ma scaduto ({fine.isoformat()})")
+            continue
+
+        # Trovato un avviso valido. Prendiamo il PIÙ RECENTE che soddisfa.
+        avviso_attivo = {
+            "tipo": tipo,
+            "livello": LEVEL_NAMES[livello],
+            "validita_inizio": inizio.isoformat(timespec="seconds"),
+            "validita_fine": fine.isoformat(timespec="seconds"),
+            "url": full_url.replace(" ", "%20"),
+            "fonte_data": data_pdf.date().isoformat(),
+        }
+        if descrizione:
+            avviso_attivo["descrizione"] = descrizione
+        print(f"  ✅ {filename}: tipo={tipo}, livello={LEVEL_NAMES[livello]}, valido fino a {fine.isoformat(timespec='seconds')}")
+        break
+
+    # Aggiorna allerta.json se serve
+    allerta = load_allerta()
+    avviso_corrente = allerta.get("avviso_meteo")
+
+    changed = False
+    if avviso_attivo:
+        if not avviso_corrente or avviso_corrente.get("tipo") != avviso_attivo["tipo"] or avviso_corrente.get("livello") != avviso_attivo["livello"]:
+            print(f"⚠️  Aggiornamento avviso_meteo: {avviso_corrente.get('tipo') if avviso_corrente else 'nessuno'} → {avviso_attivo['tipo']} ({avviso_attivo['livello']})")
+            changed = True
+        allerta["avviso_meteo"] = avviso_attivo
+    elif avviso_corrente:
+        print(f"⚠️  Avviso meteo cessato: era {avviso_corrente.get('tipo')} ({avviso_corrente.get('livello')})")
+        del allerta["avviso_meteo"]
+        changed = True
+    else:
+        print("ℹ️  Nessun avviso meteo attivo (né prima né adesso)")
+
+    if changed:
+        save_allerta(allerta)
+        print("✓ data/allerta.json aggiornato")
+
+    gh_out = os.environ.get("GITHUB_OUTPUT", "")
+    if gh_out:
+        with open(gh_out, "a") as f:
+            f.write(f"changed={'true' if changed else 'false'}\n")
+            if avviso_attivo:
+                f.write(f"tipo={avviso_attivo['tipo']}\n")
+                f.write(f"livello={avviso_attivo['livello']}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/themes/flavour-pcgenzano/layouts/index.html
+++ b/themes/flavour-pcgenzano/layouts/index.html
@@ -69,6 +69,29 @@
     <span id="allerta-domani-titolo">{{ $domaniTitolo }}</span>{{ if $domaniRischi }} <span class="text-nowrap">— {{ $domaniRischi }}</span>{{ end }}
   </div>
 </div>
+{{/* ── AVVISO METEO AVVERSO (vento, neve, calore...) — solo se attivo ── */}}
+{{ $avvisoLiv := "verde" }}
+{{ $avvisoTipo := "" }}
+{{ $avvisoDescr := "" }}
+{{ $avvisoUrl := "" }}
+{{ $avvisoVisibile := false }}
+{{ with $allerta.avviso_meteo }}
+  {{ $avvisoLiv = .livello }}
+  {{ $avvisoTipo = .tipo }}
+  {{ $avvisoDescr = .descrizione }}
+  {{ $avvisoUrl = .url }}
+  {{ $avvisoVisibile = true }}
+{{ end }}
+<div id="avviso-meteo-bar" class="avviso-meteo-bar avviso-meteo-bar-{{ $avvisoLiv }}" role="alert" aria-label="Avviso meteo avverso"{{ if not $avvisoVisibile }} style="display:none"{{ end }}>
+  <div class="container">
+    <i class="bi bi-wind me-2" aria-hidden="true"></i>
+    <strong>Avviso meteo:</strong>
+    <span id="avviso-meteo-tipo">{{ $avvisoTipo }}</span>
+    <span id="avviso-meteo-livello" class="ms-1">— allerta {{ $avvisoLiv }}</span>
+    {{ if $avvisoDescr }}<span id="avviso-meteo-descr" class="d-none d-md-inline ms-2">({{ $avvisoDescr }})</span>{{ end }}
+    {{ if $avvisoUrl }}<a id="avviso-meteo-url" href="{{ $avvisoUrl }}" target="_blank" rel="noopener noreferrer" class="ms-2 avviso-meteo-link">PDF ufficiale <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{{ end }}
+  </div>
+</div>
 {{ end }}
 
 {{/* ══════════════════════════════════════════════════════

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -129,6 +129,30 @@ body { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; 
   .allerta-bar-domani { display: none !important; }
 }
 
+/* ── AVVISO METEO AVVERSO v1.0 ──
+   Fascia per "Avvisi di condizioni meteorologiche avverse" del DPC
+   (vento, neve, ondate di calore, ghiaccio/gelate, mareggiate).
+   Letti dal parser PDF Regione Lazio (script check-avvisi-meteo.py).
+   Toni più intensi rispetto alla pre-allerta "domani" perché un avviso
+   in corso ha priorità informativa simile al banner principale, ma
+   pattern diagonale per distinguerlo visivamente. */
+.avviso-meteo-bar { padding: 0.5rem 0; font-size: 0.85rem; font-weight: 500; border-top: 1px solid rgba(0,0,0,0.08); border-bottom: 1px solid rgba(0,0,0,0.08); }
+.avviso-meteo-bar-gialla { background: #ffeb99 !important; color: #5c4400 !important; }
+.avviso-meteo-bar-arancione { background: #fdc890 !important; color: #6b2e00 !important; }
+.avviso-meteo-bar-rossa { background: #f6b1b8 !important; color: #6f0f1c !important; }
+.avviso-meteo-bar i { font-size: 1rem; opacity: 0.85; vertical-align: -0.1em; }
+.avviso-meteo-bar strong { font-weight: 600; }
+.avviso-meteo-bar #avviso-meteo-tipo { text-transform: capitalize; font-weight: 600; }
+.avviso-meteo-link { color: inherit; text-decoration: underline; text-underline-offset: 2px; font-weight: 500; }
+.avviso-meteo-link:hover { opacity: 0.85; }
+.avviso-meteo-link:focus-visible { outline: 2px solid currentColor; outline-offset: 2px; }
+@media (max-width: 575.98px) {
+  .avviso-meteo-bar { font-size: 0.78rem; }
+}
+@media print {
+  .avviso-meteo-bar { display: none !important; }
+}
+
 /* ── HERO CON PATTERN ── */
 .hero-section {
   background: linear-gradient(145deg, var(--pc-primary-dark) 0%, var(--pc-primary) 35%, var(--pc-primary-light) 100%);


### PR DESCRIPTION
## Cosa fa
Estende il sistema di allerta meteo per coprire anche gli **Avvisi di condizioni meteorologiche avverse** del DPC (vento, neve, ondate di calore, gelate, mareggiate) che il CSV opendatasicilia attualmente non copre.

## Fonte dati
Pagina ufficiale Regione Lazio: \`/bollettini/allertamenti\`. PDF firmati emessi a evento (~1-3/mese). Parsing con \`pdftotext\` (poppler-utils).

## Architettura
- **\`scripts/check-avvisi-meteo.py\`** (nuovo): scarica pagina HTML, lista PDF ultimi 5gg, parse, classifica, scrive blocco \`"avviso_meteo"\` in \`data/allerta.json\`.
- **\`check-allerta.yml\`**: nuovo step dopo il check criticità. Commit combinato se almeno uno cambia.
- **Hugo template + CSS**: nuova fascia \`#avviso-meteo-bar\` sotto la pre-allerta "domani", solo quando attiva.

## Gestione avvisi compositi
PDF tipo "VENTO, NEVE, IDROGEOLOGICA": estrae \`tipo='vento, neve'\` e ignora la parte idrogeologica già coperta dal CSV opendatasicilia.

## Test offline (eseguito ora)
\`\`\`
10 PDF nella pagina:
  ⏭️  9 criticità idrogeologica (skippati, già coperti)
  ⏭️  1 avviso vento 30/03 (scaduto)
  ⏭️  1 composito vento+neve 31/03 (scaduto)
→ Nessun avviso meteo attivo adesso (corretto)
\`\`\`

## Cessazione automatica
Se un avviso era attivo e il nuovo run non trova più nulla valido (perché scaduto o superato), il blocco viene rimosso da \`allerta.json\` → la fascia sparisce dalla homepage al prossimo deploy.

## Test plan
- [x] Hugo build clean
- [x] YAML workflow valido
- [x] Logica classificazione composita verificata su PDF reali
- [ ] Verifica live: nessuna fascia avviso visibile (corretto, oggi non ci sono avvisi)
- [ ] Test reale al prossimo avviso meteo emesso (può essere fra giorni o settimane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)