### PR TITLE
Audit 13/05: stato allerta autonomo in /allerte-meteo/ + pagina /area-volontari/ intermedia

### DIFF
--- a/content/allerte-meteo/_index.md
+++ b/content/allerte-meteo/_index.md
@@ -15,15 +15,11 @@ dataUltimaRevisione: "2026-05-06"
 
 Le allerte meteo indicano i possibili effetti al suolo di pioggia, temporali, vento e altri fenomeni. Servono a prepararsi prima che la situazione diventi pericolosa.
 
-<div class="card border-warning mb-4">
-<div class="card-body bg-warning bg-opacity-10 p-4">
-<h2 class="h5 text-dark"><i class="bi bi-broadcast me-2" aria-hidden="true"></i>Stato dell'allerta</h2>
-<p class="mb-2">Lo stato aggiornato è visibile nella barra colorata in cima alla <a href="/">homepage</a>. Il dato viene letto dai bollettini ufficiali del <strong>Centro Funzionale Regionale del Lazio</strong> per il Comune di Genzano di Roma.</p>
-<a href="https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti" target="_blank" rel="noopener noreferrer" class="btn btn-warning">
-  <i class="bi bi-box-arrow-up-right me-1" aria-hidden="true"></i> Vai al bollettino della Regione Lazio
-</a>
-</div>
-</div>
+## Stato attuale dell'allerta
+
+Lo stato sotto è letto direttamente dai **bollettini ufficiali del Centro Funzionale Regionale del Lazio** per il Comune di Genzano di Roma. È lo stesso valore mostrato nella barra in cima alla [homepage](/) e aggiornato automaticamente quando cambia il livello.
+
+{{< allerta-stato-attuale >}}
 
 <div class="card border-info mb-4">
 <div class="card-body bg-info bg-opacity-10 p-4">

--- a/content/area-volontari/_index.md
+++ b/content/area-volontari/_index.md
@@ -1,0 +1,100 @@
+---
+title: "Area Volontari"
+description: "Accesso alla piattaforma operativa Activepager riservata ai volontari del Gruppo Comunale di Protezione Civile di Genzano di Roma."
+layout: "single"
+toc: false
+sitemap:
+  priority: 0.5
+  changefreq: monthly
+dataUltimaRevisione: "2026-05-13"
+---
+
+Questa pagina spiega cos'è l'**Area Volontari** e ti porta alla piattaforma esterna su cui i volontari del Gruppo consultano turni, attivazioni, comunicazioni interne e moduli.
+
+## A chi è riservata
+
+L'Area Volontari è **riservata ai volontari iscritti** al Gruppo Comunale di Protezione Civile di Genzano di Roma. Non è uno strumento per il cittadino. Le credenziali sono distribuite dalla segreteria al momento dell'iscrizione, dopo la formazione di base.
+
+Se sei un cittadino e vuoi sapere come **diventare volontario**, vai alla pagina [Diventa Volontario](/diventa-volontario/).
+
+Se sei un cittadino in emergenza, chiama il **112**. L'Area Volontari **non è un canale di contatto per emergenze**.
+
+## A cosa serve
+
+Sulla piattaforma i volontari possono:
+
+- consultare il **calendario turni** e le attivazioni in corso;
+- ricevere **comunicazioni interne** del Capo Gruppo e dei referenti di squadra;
+- scaricare **modulistica operativa** (schede attivazione, verbali, registri radio);
+- aggiornare i **propri dati personali** e i **disponibilità** settimanali;
+- consultare lo **storico delle attività** svolte.
+
+## Piattaforma usata
+
+L'Area Volontari è ospitata sulla piattaforma **Activepager** ([activepager.com](https://www.activepager.com/)), un servizio gestionale per organizzazioni di volontariato e protezione civile usato da numerosi gruppi comunali italiani.
+
+**Perché un servizio esterno**: il Gruppo non sviluppa né mantiene gestionali interni. Activepager è una piattaforma specializzata, conforme GDPR, con uptime e backup garantiti, scelta perché evita di concentrare dati operativi su strumenti più fragili (fogli di calcolo condivisi, chat, ecc.).
+
+## Dati trattati
+
+Sulla piattaforma esterna sono trattati i **dati strettamente necessari** alla gestione del gruppo di volontariato:
+
+- anagrafica del volontario (nome, cognome, contatti);
+- formazione tecnica conseguita;
+- disponibilità ai turni;
+- attività svolte e ore di volontariato;
+- comunicazioni interne fra responsabili e volontari.
+
+Il **titolare del trattamento** resta il Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma. Activepager opera come **responsabile esterno** ai sensi dell'art. 28 del Regolamento (UE) 2016/679 (GDPR).
+
+Per dettagli sul trattamento dati e diritti dell'interessato vedi la [Privacy Policy](/privacy/) del sito.
+
+## Accesso alla piattaforma
+
+<div class="text-center my-4">
+<a href="https://www.activepager.com/login" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-lg">
+  <i class="bi bi-box-arrow-up-right me-1" aria-hidden="true"></i> Accedi alla piattaforma Activepager
+</a>
+</div>
+
+<div class="alert alert-warning small" role="note">
+<i class="bi bi-info-circle me-1" aria-hidden="true"></i>
+Il link sopra apre un **sito esterno** (activepager.com) in una nuova scheda. Le credenziali ti sono state fornite dalla segreteria del Gruppo. Se hai dimenticato la password o non hai ancora ricevuto le credenziali, scrivi a [segreteria@protezionecivilegenzano.it](mailto:segreteria@protezionecivilegenzano.it).
+</div>
+
+## Domande frequenti
+
+<details class="faq-item">
+<summary><strong>Non sono volontario, posso registrarmi?</strong></summary>
+
+No. L'Area Volontari è riservata a chi è già iscritto al Gruppo. Per entrare nel Gruppo segui la procedura sulla pagina [Diventa Volontario](/diventa-volontario/): domanda di ammissione, colloquio, formazione di base, poi assegnazione di credenziali Activepager.
+
+</details>
+
+<details class="faq-item">
+<summary><strong>Ho dimenticato la password</strong></summary>
+
+Usa la funzione "Password dimenticata" sulla schermata di login di Activepager. Se non funziona, scrivi alla segreteria.
+
+</details>
+
+<details class="faq-item">
+<summary><strong>Posso usarlo dal cellulare?</strong></summary>
+
+Sì. Activepager ha interfaccia web responsive e un'app dedicata. La piattaforma funziona da browser mobile e da app.
+
+</details>
+
+<details class="faq-item">
+<summary><strong>I miei dati restano in Italia?</strong></summary>
+
+Activepager dichiara di trattare i dati nel rispetto del GDPR. Per dettagli sui server e sui sub-responsabili consulta direttamente la loro [Privacy Policy](https://www.activepager.com/privacy/). In ogni momento puoi esercitare i tuoi diritti di accesso, rettifica, cancellazione e portabilità scrivendo alla segreteria del Gruppo.
+
+</details>
+
+## Vedi anche
+
+- [Diventa Volontario](/diventa-volontario/) — come si entra nel Gruppo
+- [Chi Siamo](/chi-siamo/) — struttura del Gruppo, referenti, sede
+- [Privacy Policy](/privacy/) — trattamento dei dati
+- [Contatti](/contatti/) — come contattare la segreteria

--- a/static/app-shared/site-chrome.js
+++ b/static/app-shared/site-chrome.js
@@ -26,7 +26,7 @@
             '</div>' +
             '<div class="it-header-slim-right-zone" role="navigation" aria-label="Link rapidi e social">' +
               '<a href="' + SITE_URL + '/facile-da-leggere/" class="btn btn-slim-header btn-easy-read me-2" aria-label="Vai alla versione facile da leggere del sito"><i class="bi bi-book-half me-1" aria-hidden="true"></i><span class="d-none d-md-inline">Facile da leggere</span><span class="d-md-none">Aa</span></a>' +
-              '<a href="https://activepager.com/auth/login" target="_blank" rel="noopener noreferrer" class="btn btn-slim-header me-3" aria-label="Accedi al gestionale volontari (si apre in una nuova finestra)"><i class="bi bi-box-arrow-in-right me-1" aria-hidden="true"></i><span class="d-none d-md-inline">Area Volontari</span><span class="d-md-none">Accedi</span></a>' +
+              '<a href="' + SITE_URL + '/area-volontari/" class="btn btn-slim-header me-3" aria-label="Area Volontari: informazioni e accesso al gestionale"><i class="bi bi-box-arrow-in-right me-1" aria-hidden="true"></i><span class="d-none d-md-inline">Area Volontari</span><span class="d-md-none">Accedi</span></a>' +
               '<span class="slim-header-divider d-none d-lg-inline" aria-hidden="true"></span>' +
               '<a href="https://www.facebook.com/protezionecivilegenzanodiroma" target="_blank" rel="noopener noreferrer" aria-label="Facebook" class="text-white me-2"><i class="bi bi-facebook" aria-hidden="true"></i></a>' +
               '<a href="https://www.instagram.com/protezionecivilegenzano/" target="_blank" rel="noopener noreferrer" aria-label="Instagram" class="text-white me-2"><i class="bi bi-instagram" aria-hidden="true"></i></a>' +

--- a/themes/flavour-pcgenzano/layouts/partials/slim-header.html
+++ b/themes/flavour-pcgenzano/layouts/partials/slim-header.html
@@ -25,8 +25,9 @@
               <span class="d-none d-md-inline">Facile da leggere</span>
               <span class="d-md-none">Aa</span>
             </a>
-            {{/* Area Riservata — posizione AGID standard */}}
-            <a href="https://activepager.com/auth/login" target="_blank" rel="noopener noreferrer" class="btn btn-slim-header me-3" aria-label="Accedi al gestionale volontari (si apre in una nuova finestra)">
+            {{/* Area Riservata — posizione AGID standard. Punta alla pagina intermedia
+                 /area-volontari/ che spiega cos'è, chi la gestisce e come accedere. */}}
+            <a href="{{ "/area-volontari/" | relURL }}" class="btn btn-slim-header me-3" aria-label="Area Volontari: informazioni e accesso al gestionale">
               <i class="bi bi-box-arrow-in-right me-1" aria-hidden="true"></i>
               <span class="d-none d-md-inline">Area Volontari</span>
               <span class="d-md-none">Accedi</span>

--- a/themes/flavour-pcgenzano/layouts/shortcodes/allerta-stato-attuale.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/allerta-stato-attuale.html
@@ -1,0 +1,55 @@
+{{- /* Shortcode allerta-stato-attuale — mostra il livello corrente leggendo data/allerta.json.
+       Riusabile su qualunque pagina (allerte-meteo, emergenza, cosa-fare-adesso, ecc.).
+       Il dato è coerente con la barra in homepage perché legge la stessa fonte (data/allerta.json),
+       aggiornata da check-allerta.yml.
+*/ -}}
+{{- $allerta := .Site.Data.allerta -}}
+{{- if $allerta -}}
+{{- $controllo := or $allerta.ultimo_controllo $allerta.ultimo_aggiornamento -}}
+{{- $t := time.AsTime $controllo -}}
+{{- $mesi := slice "" "gennaio" "febbraio" "marzo" "aprile" "maggio" "giugno" "luglio" "agosto" "settembre" "ottobre" "novembre" "dicembre" -}}
+{{- $bg := "bg-success bg-opacity-10 border-success" -}}
+{{- $titoloCol := "text-success-emphasis" -}}
+{{- $icon := "bi-shield-check" -}}
+{{- if eq $allerta.livello "giallo" -}}
+  {{- $bg = "bg-warning bg-opacity-10 border-warning" -}}
+  {{- $titoloCol = "text-warning-emphasis" -}}
+  {{- $icon = "bi-exclamation-triangle-fill" -}}
+{{- else if eq $allerta.livello "arancione" -}}
+  {{- $bg = "bg-orange bg-opacity-25 border-warning" -}}
+  {{- $titoloCol = "text-danger-emphasis" -}}
+  {{- $icon = "bi-exclamation-triangle-fill" -}}
+{{- else if eq $allerta.livello "rosso" -}}
+  {{- $bg = "bg-danger bg-opacity-25 border-danger" -}}
+  {{- $titoloCol = "text-danger-emphasis" -}}
+  {{- $icon = "bi-exclamation-octagon-fill" -}}
+{{- end -}}
+
+<div class="card mb-4 border-2 {{ $bg }}" role="region" aria-label="Stato allerta meteo attuale">
+  <div class="card-body p-4">
+    <div class="d-flex flex-wrap align-items-center mb-2">
+      <i class="bi {{ $icon }} fs-3 me-3 {{ $titoloCol }}" aria-hidden="true"></i>
+      <div>
+        <h2 class="h5 mb-0 {{ $titoloCol }}">Stato attuale: {{ $allerta.titolo }}</h2>
+        <p class="mb-0 text-muted small">Livello {{ $allerta.livello | title }} · Comune di Genzano di Roma</p>
+      </div>
+    </div>
+    {{- with $allerta.descrizione }}
+    <p class="mb-2">{{ . }}</p>
+    {{- end }}
+    <p class="small text-muted mb-2">
+      <i class="bi bi-clock-history me-1" aria-hidden="true"></i>
+      Verificato: <strong>{{ printf "%d %s %d, %02d:%02d" $t.Day (index $mesi (int $t.Month)) $t.Year $t.Hour $t.Minute }}</strong>
+      · Fonte: <a href="https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti" target="_blank" rel="noopener noreferrer">Centro Funzionale Regionale Lazio</a>
+    </p>
+    <a href="https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-primary">
+      <i class="bi bi-box-arrow-up-right me-1" aria-hidden="true"></i> Bollettino ufficiale Regione Lazio
+    </a>
+  </div>
+</div>
+{{- else -}}
+<div class="alert alert-secondary" role="note">
+  <strong>Stato allerta non disponibile.</strong> Consulta direttamente il
+  <a href="https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti" target="_blank" rel="noopener noreferrer">bollettino della Regione Lazio</a>.
+</div>
+{{- end -}}


### PR DESCRIPTION
## Sommario

Recepisce i **2 fix effettivamente validi** dell'audit del 13/05/2026 (scartati i falsi positivi e le proposte peggiorative motivate nel commit body).

## Fix applicati

### 1. `/allerte-meteo/` mostra lo stato in autonomia

Prima la pagina diceva *"lo stato è visibile in cima alla homepage"* — pattern AGID sbagliato: una pagina operativa deve **fornire il dato che promette nel titolo**.

Ora la pagina include lo stato dell'allerta direttamente, leggendo la stessa fonte (`data/allerta.json`) della barra homepage. Implementazione via nuovo shortcode **`allerta-stato-attuale.html`** riusabile (livello/titolo/descrizione/timestamp/CFR Lazio), con gradiente colore per livello (verde/giallo/arancione/rosso) e fallback grafico se il dato è assente.

### 2. Nuova pagina intermedia `/area-volontari/`

Tra il menu "Area Volontari" e la piattaforma esterna `activepager.com` c'è ora una pagina di trust che spiega:
- a chi è riservata (volontari iscritti, non cittadini)
- a cosa serve (turni, comunicazioni, modulistica)
- quale piattaforma usata e perché (Activepager — gestionale specializzato)
- **dati trattati e ruolo GDPR**: titolare = Gruppo, responsabile esterno ex art. 28 = Activepager
- FAQ pratiche (registrazione, password, mobile, residenza dati)
- bottone "Accedi alla piattaforma" con disclaimer "apre sito esterno"

Aggiornati `slim-header.html` e `site-chrome.js` per puntare a `/area-volontari/` invece che diretto a `activepager.com`.

## NON applicato (motivato in commit body)

- ❌ "Sostituire Windy con Leaflet+Open-Meteo" → degrada qualità informativa; Radar DPC ufficiale è già presente
- ❌ "Sostituire INGV con feed self-hosted" → meno autorevole, più fragile
- ❌ "Privacy RPD/DPO formale" → decisione organizzativa del Gruppo, non tecnica
- ❌ "Piano bonifica PDF" → già dichiarato in AGID, scope multi-mese
- ❌ "Open data territoriale integrato col Comune" → fuori scope di un Gruppo Comunale di volontariato

## Falsi positivi smentiti

- "Menu cita Trasparenza + Podcast" → Podcast non esiste, gli altri ci sono già
- "site-chrome.js non sincronizzato" → già allineato (commento esplicito nel file)
- "Cartografia DAE/idranti in costruzione" → non più presente
- "JSON-LD da aggiungere" → già presente con 10+ schema types

## Test plan

- [x] YAML frontmatter validato
- [x] `node --check site-chrome.js` OK
- [x] Anti-pattern `image:` non applicabile (pagine `/_index.md`)
- [ ] Build Hugo CI pulito
- [ ] Verifica visiva post-deploy: `/allerte-meteo/` mostra stato live + `/area-volontari/` raggiungibile dal menu

---
_Generated by [Claude Code](https://claude.ai/code/session_01994Zx5QNm5ZHn18X6Yfp2p)_