### PR TITLE
Cache-bust 6 pagine stale post-pipeline allerta meteo

### DIFF
--- a/content/chi-siamo/_index.md
+++ b/content/chi-siamo/_index.md
@@ -9,6 +9,7 @@ aliases:
 tts: true
 dataUltimaRevisione: "2026-05-06"
 ---
+<!-- cache-bust: 2026-05-13 forza re-upload FTP per allineare header/footer (audit 13/05) -->
 
 <div class="card border-primary mb-5">
 <div class="card-body bg-primary bg-opacity-10 p-4">

--- a/content/contatti/_index.md
+++ b/content/contatti/_index.md
@@ -7,6 +7,7 @@ aliases:
 tts: true
 dataUltimaRevisione: "2026-05-06"
 ---
+<!-- cache-bust: 2026-05-13 forza re-upload FTP per allineare header/footer (audit 13/05) -->
 
 <div class="card border-danger mb-4">
 <div class="card-body bg-danger bg-opacity-10 p-4">

--- a/content/cosa-fare-adesso/_index.md
+++ b/content/cosa-fare-adesso/_index.md
@@ -10,6 +10,7 @@ sitemap:
   changefreq: monthly
 dataUltimaRevisione: "2026-05-06"
 ---
+<!-- cache-bust: 2026-05-13 forza re-upload FTP per allineare header/footer (audit 13/05) -->
 
 <div class="card border-danger mb-4">
 <div class="card-body bg-danger bg-opacity-10 p-4">

--- a/content/diventa-volontario/_index.md
+++ b/content/diventa-volontario/_index.md
@@ -9,6 +9,7 @@ aliases:
 tts: true
 dataUltimaRevisione: "2026-05-06"
 ---
+<!-- cache-bust: 2026-05-13 forza re-upload FTP per allineare header/footer (audit 13/05) -->
 
 Diventare volontario di Protezione Civile significa mettere tempo, competenze e disponibilità al servizio della comunità. Non servono esperienze precedenti: il Gruppo ti affianca e ti forma prima dell'impiego operativo.
 

--- a/content/numeri-utili/_index.md
+++ b/content/numeri-utili/_index.md
@@ -6,6 +6,7 @@ layout: "single"
 aliases:
   - /numeri-utili/
 ---
+<!-- cache-bust: 2026-05-13 forza re-upload FTP per allineare header/footer (audit 13/05) -->
 
 <div class="card border-danger mb-4">
 <div class="card-body bg-danger bg-opacity-10 p-4">

--- a/content/rischi-prevenzione/_index.md
+++ b/content/rischi-prevenzione/_index.md
@@ -11,6 +11,7 @@ toc: true
 tts: true
 dataUltimaRevisione: "2026-05-06"
 ---
+<!-- cache-bust: 2026-05-13 forza re-upload FTP per allineare header/footer (audit 13/05) -->
 
 Conoscere i rischi del territorio aiuta a proteggere te, la tua famiglia e chi interviene nei soccorsi. In questa sezione trovi indicazioni pratiche sui principali rischi di Genzano di Roma e sui comportamenti da adottare prima, durante e dopo un'emergenza.
 


### PR DESCRIPTION
## Audit 13/05/2026 — 6 pagine stale
Template legacy servito da Aruba (header flat, footer ridotto, tel encoded, COI 15°). Hugo genera la versione nuova, ma FTP-Deploy-Action con `dangerous-clean-slate: false` non ri-uploada i file.

## Strategia
Cache-bust documentato nella `rule 05-github-aruba-deploy.md § File stantii su Aruba`, pattern già usato in PR #187 del 12/05.

## Verifica locale post-cache-bust
Tutti e 6 i file cambiano sia in size che in md5 (diff ~2-3KB ciascuno).

## Test plan
- [x] Build Hugo OK
- [x] Diff size/md5 confermato su tutte e 6
- [ ] Smoke test live post-deploy: 4 marker rispettati (megamenu, tel pulito, no 15° COI, Facile da leggere)
- [ ] Audit-sito manuale § 43: tutto verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)