### PR TITLE
fix(home): ripristina numero in stat flotta (rollback estetico audit 13/05)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/index.html
+++ b/themes/flavour-pcgenzano/layouts/index.html
@@ -191,7 +191,7 @@
         <div class="stats-hero">
           <div class="row g-3">
             <div class="col-6"><div class="stat-hero-item"><span class="stat-hero-num" data-count="45">45</span><span class="stat-hero-label">Anni di Attività</span></div></div>
-            <div class="col-6"><div class="stat-hero-item"><span class="stat-hero-num" aria-hidden="true"><i class="bi bi-truck"></i></span><span class="stat-hero-label">Flotta operativa</span></div></div>
+            <div class="col-6"><div class="stat-hero-item"><span class="stat-hero-num" data-count="10">10+</span><span class="stat-hero-label">Mezzi operativi</span></div></div>
             <div class="col-6"><div class="stat-hero-item"><span class="stat-hero-num" data-count="20">20+</span><span class="stat-hero-label">Emergenze Nazionali</span></div></div>
             <div class="col-6"><div class="stat-hero-item"><span class="stat-hero-num" data-count="365">365</span><span class="stat-hero-label">Giorni di Operatività</span></div></div>
           </div>
@@ -282,7 +282,7 @@
       if(!e.isIntersecting)return;
       var el=e.target;
       var target=parseInt(el.getAttribute('data-count'));
-      var suffix=(target===20?'+':'');
+      var suffix=(target===20||target===10?'+':'');
       var start=0,step=Math.ceil(target/50);
       el.textContent='0'+suffix;
       var timer=setInterval(function(){


### PR DESCRIPTION
L'icona `bi-truck` introdotta nella PR #218 stonava visivamente nella stat hero (altre 3 stat sono numeri: 45, 20+, 365). Ripristino il pattern numerico con "10+" e label "Mezzi operativi":

- **10+** assorbe i 2 mezzi in allestimento (Iveco Cacciamali, Astra BM201) quando entreranno in servizio, senza richiedere modifiche al sito
- **"Mezzi operativi"** è più inclusivo di "Automezzi" (copre anche tenda sociale e vasca mobile)

Esteso il JS hardcoded `target===20?'+':''` a `target===20||target===10?'+':''` per replicare l'animazione 0→10 con suffix `+` identica a "20+".

## Test plan
- [x] Hugo build clean
- [x] Build contiene `data-count="10">10+` + "Mezzi operativi"
- [ ] Verifica live post-merge: home mostra "10+" e label corretti

🤖 Generated with [Claude Code](https://claude.com/claude-code)