### PR TITLE
chore(audit-sito): frequenza da settimanale a ogni 6 ore

### DIFF
--- a/.github/workflows/audit-sito.yml
+++ b/.github/workflows/audit-sito.yml
@@ -32,7 +32,7 @@ on:
   schedule:
     # Ogni lunedi alle 09:00 UTC (dopo check-normativa-links delle 08:00,
     # prima di check-links-sito delle 10:00)
-    - cron: "0 9 * * 1"
+    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Audit settimanale lasciava finestre di esposizione fino a 4-5 giorni sui file stale (incidente 13/05). Schedule ogni 6h riduce a max 6h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)