### PR TITLE
Audit sito: ordering date, link interni rotti, pin Hugo, sigla COI

### DIFF
--- a/.claude/agents/pc-article-reviewer.md
+++ b/.claude/agents/pc-article-reviewer.md
@@ -54,7 +54,7 @@ Distinzione critica `Allerta` vs `Emergenza` (regola `06-protezione-civile-scien
 - Frasi brevi (max ~20 parole), voce attiva, niente burocratese.
 - Numeri telefono in formato leggibile (es. `06 1234 5678`).
 - NUE 112 è l'unico numero emergenza nel Lazio. MAI 115/118/1515 come "numero da chiamare al cittadino" (vedi `feedback_numero_emergenza_lazio.md`).
-- COI: il Gruppo aderisce al **14° C.O.I.** della Provincia di Roma (NON 15°).
+- COI: il Gruppo aderisce al **14° COI** della Provincia di Roma (NON 15°).
 - Niente nomi di persone non pertinenti / enti locali estranei (es. Biella, Imbersago) — se serve la fonte, va come link in fondo.
 
 ### 6. Link interni

--- a/.claude/agents/pc-deploy-validator.md
+++ b/.claude/agents/pc-deploy-validator.md
@@ -28,7 +28,7 @@ Sei l'ultimo gate prima che il codice tocchi `main`. Il tuo output decide se il 
 
 5. **Niente `draft: true` in `content/comunicazioni/`**: `grep -rln "^draft: true" content/comunicazioni/`. Regola: solo immediato (data passata) o calendarizzato (data futura). Vedi `feedback_no_draft_in_revisione`.
 6. **Numero unico emergenza Lazio = 112**: nelle modifiche dell'ultimo commit, NESSUN nuovo riferimento a 115/118/1515 come "numero da chiamare al cittadino". Citazioni storiche (es. "ARES 118 è l'organizzazione") OK. Vedi `feedback_numero_emergenza_lazio`.
-7. **14° C.O.I. (NON 15°)**: `grep -rn "15[°ª]\?\s*COI\|15[°ª]\?\s*C\.O\.I\.\|quindicesimo COI" content/ themes/`. Risultati = errore storico già fixato che non deve tornare. Vedi `project_coi_roma`.
+7. **14° COI (NON 15°)**: `grep -rn "15[°ª]\?\s*COI\|15[°ª]\?\s*C\.O\.I\.\|quindicesimo COI" content/ themes/`. Risultati = errore storico già fixato che non deve tornare. Vedi `project_coi_roma`.
 8. **Nessun residuo `images-social/`**: `grep -rn "images-social" --include="*.md" --include="*.yml" --include="*.html"` deve essere vuoto (esclusi commenti storici espliciti). La cartella è stata spostata il 2 maggio 2026 in `social-bozze/<slug>/`.
 9. **Nessun marker `# TODO-foto-*` nel repo**: marker BANDITO dal 3 maggio 2026 (CLAUDE.md punto 9). Causa il rendering H1 in produzione + sovrascrive il banner. Comando: `grep -rn "^# TODO-foto-" content/`. Match = STOP, rimuovi i marker prima del push e usa l'agent `pc-image-fixer` per inserire la foto inline.
 

--- a/.github/workflows/audit-sito.yml
+++ b/.github/workflows/audit-sito.yml
@@ -50,7 +50,7 @@ jobs:
       - name: "🔧 Setup Hugo"
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "latest"
+          hugo-version: "0.143.1"
           extended: true
 
       - name: "🏗️ Build sito (per smoke test rendering)"
@@ -91,7 +91,7 @@ jobs:
 
           # ----------------------------------------------------------------
           section "1. Coerenza COI (Centro Operativo Intercomunale)"
-          # Il gruppo aderisce al 14° C.O.I. della Provincia di Roma.
+          # Il gruppo aderisce al 14° COI della Provincia di Roma.
           # Qualsiasi altro grado citato nei contenuti pubblici è un errore storico.
           BAD_COI=$(grep -rInE '\b(1[0-35-9]|20|21|22)°[[:space:]]*C\.?O\.?I\.?\b' \
             "$CONTENT_GLOB/" "$THEME_GLOB/layouts/" hugo.toml data/ 2>/dev/null || true)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: "⚙️ Setup Hugo"
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.143.1'
           extended: true
 
       - name: "♿ Setup liblouis (traduzione braille) + dipendenze Python"

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "⚙️ Setup Hugo"
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.143.1'
           extended: true
 
       - name: "🏗️ Build di prova"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Sessione di consolidamento del 6 maggio 2026 con esiti strutturali sul sito.
 - Le pagine rivolte alle scuole non inventano dati su istituti, indirizzi, referenti o procedure interne: rimandano sempre al piano del singolo istituto e alle fonti ufficiali.
 - La mappa manuale del sito si aggiorna quando si pubblicano nuove pagine informative importanti. Il `sitemap.xml` tecnico resta generato da Hugo.
 
-**Drift documentale corretto**: `14° C.O.I.` allineato in tutti i file, bandiera SPQR errata rimossa dall'articolo Reggio Emilia 1996, caption ShakeMap INGV corrette in 5 articoli storici, duplicato editoriale Amatrice 2016 risolto. Asset -2.85 MB ottimizzati.
+**Drift documentale corretto**: `14° COI` allineato in tutti i file, bandiera SPQR errata rimossa dall'articolo Reggio Emilia 1996, caption ShakeMap INGV corrette in 5 articoli storici, duplicato editoriale Amatrice 2016 risolto. Asset -2.85 MB ottimizzati.
 
 Specifiche complete in [`manuale/parte-21-aggiornamenti-contenuti-didattici-prevenzione.md`](manuale/parte-21-aggiornamenti-contenuti-didattici-prevenzione.md).
 
@@ -446,7 +446,7 @@ Il progetto ha alcune regole non negoziabili da avere a portata di vista:
 - **Banner articoli** = **sempre cover tipografica con titolo grande** (gradiente blu + badge categoria + titolo articolo + fascia istituzionale). Generata da `scripts/auto-cover-mancanti.py`. Mai vuota in produzione, mai una foto utente.
 - **Foto fornite dall'utente** = sempre nel **corpo dell'articolo** come `{{< foto >}}` (mai nel campo `image:` del frontmatter). ≥4 foto → galleria nel corpo. Sui social diventano automaticamente carosello Instagram.
 - **NUE 112** è l'unico numero di emergenza nel Lazio: 115/118/1515 non vanno mai citati come numeri da chiamare al cittadino.
-- **14° C.O.I.** della Provincia di Roma (non 15°) è il riferimento del Gruppo.
+- **14° COI** della Provincia di Roma (non 15°) è il riferimento del Gruppo.
 - **Formato data nel frontmatter**: sempre `AAAA-MM-GG`. Mai con timezone (`AAAA-MM-DDTHH:MM:SSZ` causa esclusione dell'articolo dalla build).
 - **Nessun articolo `draft: true`** — solo pubblicazione immediata (data passata) o programmata (data futura).
 - **Lingua AGID**: frasi brevi (max ~20 parole), voce attiva, niente burocratese, linguaggio inclusivo.

--- a/content/accessibilita/_index.md
+++ b/content/accessibilita/_index.md
@@ -187,7 +187,7 @@ Su ogni articolo è disponibile un bottone **Scarica versione braille**. Apre un
 
 Il file è generato automaticamente per ogni articolo pubblicato. La traduzione usa la tabella **braille italiano standard a 6 punti** (uncontracted, lettera per lettera). Il file è scaricabile gratuitamente, senza account.
 
-La generazione è automatica con la libreria open source **liblouis** (raccomandata da W3C-WAI), nessun servizio esterno coinvolto. Specifiche tecniche complete sul nostro [manuale tecnico interno](/manuali/) (Parte 24).
+La generazione è automatica con la libreria open source **liblouis** (raccomandata da W3C-WAI), nessun servizio esterno coinvolto.
 
 ### 3. PDF — Scarica trascrizione
 

--- a/content/comunicazioni/2026-04-11-antincendio-boschivo-triangolo-fuoco-attrezzature-tecniche-attacco.md
+++ b/content/comunicazioni/2026-04-11-antincendio-boschivo-triangolo-fuoco-attrezzature-tecniche-attacco.md
@@ -267,7 +267,7 @@ Sul nostro sito:
 - [Triangolo del fuoco: prevenzione incendi](/comunicazioni/2026-04-13-triangolo-del-fuoco-prevenzione-incendi/).
 - [Open Day antincendio boschivo Aprilia](/comunicazioni/2026-05-08-open-day-antincendio-boschivo-aprilia/).
 - [Estintori: classi di fuoco e uso corretto](/comunicazioni/2026-05-13-estintori-classi-fuoco-uso-corretto-manutenzione/).
-- [Piano AIB della Regione Lazio](/area-download/normativa/Piano_AIB_Lazio.pdf) (PDF dall'Area Download).
+- [Piano AIB della Regione Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Piano_AIB_Lazio.pdf) (PDF dall'Area Download).
 - [Diventa volontario](/diventa-volontario/).
 
 Fonti istituzionali:

--- a/content/comunicazioni/2026-05-15-giornata-famiglie-piano-emergenza-insieme.md
+++ b/content/comunicazioni/2026-05-15-giornata-famiglie-piano-emergenza-insieme.md
@@ -1,6 +1,6 @@
 ---
 title: "15 maggio: Giornata delle Famiglie, un'occasione per un piano condiviso"
-date: 2026-05-15
+date: 2026-05-15T00:01:00+02:00
 description: "La Giornata internazionale delle famiglie, istituita dall'ONU, invita a ripensare il proprio piano di emergenza familiare come gesto di cura condiviso."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-15-iso-22322-public-warning-it-alert.md
+++ b/content/comunicazioni/2026-05-15-iso-22322-public-warning-it-alert.md
@@ -1,6 +1,6 @@
 ---
 title: "Come dovrebbe funzionare un sistema di allerta pubblica: ISO 22322 e IT-alert"
-date: 2026-05-15
+date: 2026-05-15T00:02:00+02:00
 description: "Il sistema italiano IT-alert è coerente con uno standard internazionale che dice come si progetta un'allerta pubblica davvero efficace."
 badge: "Formazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-19-iso-22329-social-media-emergenza.md
+++ b/content/comunicazioni/2026-05-19-iso-22329-social-media-emergenza.md
@@ -1,6 +1,6 @@
 ---
 title: "Social media in emergenza: cosa dice lo standard ISO 22329"
-date: 2026-05-19
+date: 2026-05-19T00:02:00+02:00
 description: "Quando arriva un'emergenza, i social diventano un canale critico. Lo standard ISO 22329 spiega come usarli istituzionalmente: monitorare, diffondere."
 badge: "Formazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-19-sicurezza-laghi-nemi-albano.md
+++ b/content/comunicazioni/2026-05-19-sicurezza-laghi-nemi-albano.md
@@ -1,6 +1,6 @@
 ---
 title: "Laghi di Nemi e Albano: sicurezza in acqua e sulle sponde"
-date: 2026-05-19
+date: 2026-05-19T00:01:00+02:00
 description: "I laghi dei Castelli Romani sono un patrimonio naturale da rispettare. Regole di sicurezza per chi nuota, pesca o frequenta le sponde in estate."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-22-giornata-biodiversita-territori-resilienti.md
+++ b/content/comunicazioni/2026-05-22-giornata-biodiversita-territori-resilienti.md
@@ -1,6 +1,6 @@
 ---
 title: "22 maggio: Giornata della Biodiversità e territori più resilienti"
-date: 2026-05-22
+date: 2026-05-22T00:01:00+02:00
 description: "La biodiversità non è solo tutela della natura: è infrastruttura di Protezione Civile. Boschi sani, fiumi curati, suoli fertili riducono il rischio."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-22-iso-22361-gestione-crisi.md
+++ b/content/comunicazioni/2026-05-22-iso-22361-gestione-crisi.md
@@ -1,6 +1,6 @@
 ---
 title: "Quando l'emergenza diventa crisi: lo standard ISO 22361"
-date: 2026-05-22
+date: 2026-05-22T00:02:00+02:00
 description: "Emergenza e crisi non sono sinonimi. Lo standard ISO 22361 aiuta a capire quando servono decisioni straordinarie, ruoli chiari e comunicazione coordinata."
 badge: "Formazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-26-check-casa-prima-estate-prevenzione.md
+++ b/content/comunicazioni/2026-05-26-check-casa-prima-estate-prevenzione.md
@@ -1,6 +1,6 @@
 ---
 title: "Check-list casa prima dell'estate: cosa verificare"
-date: 2026-05-26
+date: 2026-05-26T00:01:00+02:00
 description: "Prima dell'estate è utile controllare casa, impianti, condizionatori, scorte e vie di fuga. Una check-list semplice riduce molti rischi domestici."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-26-iso-22398-esercitazioni-protezione-civile.md
+++ b/content/comunicazioni/2026-05-26-iso-22398-esercitazioni-protezione-civile.md
@@ -1,6 +1,6 @@
 ---
 title: "Perché si fanno le esercitazioni di Protezione Civile? Lo standard ISO 22398"
-date: 2026-05-26
+date: 2026-05-26T00:02:00+02:00
 description: "Le esercitazioni non sono spettacolo: sono lo strumento principale per verificare se un piano di emergenza funziona davvero."
 badge: "Formazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-29-emilia-2012-seconda-scossa-resilienza-comunitaria.md
+++ b/content/comunicazioni/2026-05-29-emilia-2012-seconda-scossa-resilienza-comunitaria.md
@@ -1,6 +1,6 @@
 ---
 title: "29 maggio 2012: la seconda scossa in Emilia e la resilienza comunitaria"
-date: 2026-05-29
+date: 2026-05-29T00:01:00+02:00
 description: "A 14 anni dalla seconda scossa in Emilia (29 maggio 2012): cosa significa resilienza comunitaria nelle emergenze sismiche prolungate."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-29-iso-22395-persone-vulnerabili.md
+++ b/content/comunicazioni/2026-05-29-iso-22395-persone-vulnerabili.md
@@ -1,6 +1,6 @@
 ---
 title: "Nessuno indietro: ISO 22395 e il supporto inclusivo nelle emergenze"
-date: 2026-05-29
+date: 2026-05-29T00:02:00+02:00
 description: "Anziani, persone con disabilità, bambini, italiano L2, senza dimora: lo standard ISO 22395 spiega come una società resiliente raggiunge davvero tutti."
 badge: "Formazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-02-festa-repubblica-volontariato-civico.md
+++ b/content/comunicazioni/2026-06-02-festa-repubblica-volontariato-civico.md
@@ -1,6 +1,6 @@
 ---
 title: "2 giugno: Festa della Repubblica e volontariato civico"
-date: 2026-06-02
+date: 2026-06-02T00:01:00+02:00
 description: "La Festa della Repubblica ci ricorda che la Protezione Civile nasce come espressione di solidarietà costituzionale."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-02-iso-31000-gestione-rischio.md
+++ b/content/comunicazioni/2026-06-02-iso-31000-gestione-rischio.md
@@ -1,6 +1,6 @@
 ---
 title: "Cos'è davvero un rischio? ISO 31000 spiegato a chi non è tecnico"
-date: 2026-06-02
+date: 2026-06-02T00:02:00+02:00
 description: "Rischio non è la stessa cosa di pericolo. Lo standard ISO 31000 è la cornice internazionale per capire come si valuta."
 badge: "Formazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-05-giornata-ambiente-incendi-territorio.md
+++ b/content/comunicazioni/2026-06-05-giornata-ambiente-incendi-territorio.md
@@ -1,6 +1,6 @@
 ---
 title: "5 giugno: Giornata mondiale dell'ambiente e tutela del territorio"
-date: 2026-06-05
+date: 2026-06-05T00:01:00+02:00
 description: "La Giornata mondiale dell'ambiente cade all'inizio della stagione degli incendi."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-05-iso-22327-allerta-frane-comunita.md
+++ b/content/comunicazioni/2026-06-05-iso-22327-allerta-frane-comunita.md
@@ -1,6 +1,6 @@
 ---
 title: "Frane e allerta locale: ISO 22327 e il ruolo della comunità"
-date: 2026-06-05
+date: 2026-06-05T00:02:00+02:00
 description: "Lo standard ISO 22327 spiega come si costruisce un sistema di allerta frane che funziona davvero a livello locale."
 badge: "Formazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-09-iso-7010-segnaletica-sicurezza.md
+++ b/content/comunicazioni/2026-06-09-iso-7010-segnaletica-sicurezza.md
@@ -1,6 +1,6 @@
 ---
 title: "Quei segnali che vediamo ovunque: ISO 7010 spiega perché sono uguali in tutto il mondo"
-date: 2026-06-09
+date: 2026-06-09T00:02:00+02:00
 description: "L'omino verso la porta verde, il cerchio rosso barrato, il triangolo giallo: lo standard ISO 7010 codifica la segnaletica mondiale."
 badge: "Formazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-09-zanzara-tigre-arbovirosi-prevenzione.md
+++ b/content/comunicazioni/2026-06-09-zanzara-tigre-arbovirosi-prevenzione.md
@@ -1,6 +1,6 @@
 ---
 title: "Zanzara tigre e arbovirosi: prevenzione domestica"
-date: 2026-06-09
+date: 2026-06-09T00:01:00+02:00
 description: "Con l'arrivo del caldo torna il problema delle zanzare tigre e delle malattie che possono trasmettere. La prevenzione inizia a casa, giardino per giardino."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-12-contrasto-sfruttamento-minorile-emergenza-umanitaria.md
+++ b/content/comunicazioni/2026-06-12-contrasto-sfruttamento-minorile-emergenza-umanitaria.md
@@ -1,6 +1,6 @@
 ---
 title: "12 giugno: contrasto al lavoro minorile ed emergenze umanitarie"
-date: 2026-06-12
+date: 2026-06-12T00:01:00+02:00
 description: "Giornata mondiale contro il lavoro minorile: nei campi profughi internazionali i bambini sono particolarmente a rischio di sfruttamento."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-12-iso-14090-adattamento-clima.md
+++ b/content/comunicazioni/2026-06-12-iso-14090-adattamento-clima.md
@@ -1,6 +1,6 @@
 ---
 title: "Quando il clima cambia, cambia anche la PC: ISO 14090 e l'adattamento"
-date: 2026-06-12
+date: 2026-06-12T00:02:00+02:00
 description: "Ondate di calore, siccità, eventi meteo estremi: il cambiamento climatico modifica i rischi della Protezione Civile."
 badge: "Formazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-25-cartografia-operativa-piano-comunale.md
+++ b/content/comunicazioni/2026-06-25-cartografia-operativa-piano-comunale.md
@@ -132,7 +132,7 @@ Alcuni elementi chiave da riconoscere:
 
 - Articolo: [Piano Comunale di Protezione Civile](/piano-emergenza/)
 - Articolo: [Microzonazione sismica nei Castelli](/comunicazioni/2026-06-19-microzonazione-sismica-castelli-romani/)
-- Pagina: [Aree di emergenza](/aree-emergenza/)
+- Pagina: [Cartografia e aree di emergenza](/cartografia/)
 - [ISPRA — Portale Cartografico](https://www.isprambiente.gov.it/)
 - [Geoportale Nazionale](https://www.pcn.minambiente.it/)
 - [Dipartimento Protezione Civile](https://www.protezionecivile.gov.it/)

--- a/content/podcast/_index.md
+++ b/content/podcast/_index.md
@@ -14,6 +14,6 @@ Tutti gli articoli pubblicati sul sito possono essere **ascoltati ad alta voce**
 
 **Trascrizione PDF.** Su ogni articolo è disponibile un bottone **"Scarica trascrizione PDF"** che apre la finestra di stampa del browser: scegli "Salva come PDF" per avere il testo dell'articolo su carta digitale, formato A4, senza il chrome del sito.
 
-**Versione Braille (BRF).** Ogni articolo ha anche una versione [Braille Ready Format](/manuali/) scaricabile, compatibile con display braille e stampanti braille (Index, ViewPlus). Pensata per ciechi e ipovedenti che usano lettori tattili.
+**Versione Braille (BRF).** Ogni articolo ha anche una versione Braille Ready Format scaricabile, compatibile con display braille e stampanti braille (Index, ViewPlus). Pensata per ciechi e ipovedenti che usano lettori tattili.
 
 Sotto trovi l'elenco completo degli articoli ascoltabili, con la **durata stimata** di lettura ad alta voce.

--- a/content/rischi-prevenzione/_index.md
+++ b/content/rischi-prevenzione/_index.md
@@ -39,9 +39,9 @@ Consulta la scheda del rischio che ti interessa.
 | Temporali intensi | Fulmini, grandine, raffiche, piogge brevi e violente | [Temporali intensi](/rischi-prevenzione/temporali-intensi/) |
 | Vento forte | Caduta rami, oggetti instabili, danni a tetti e coperture | [Vento forte](/rischi-prevenzione/vento-forte/) |
 | Incendio | Fumo, fiamme, incendio boschivo o urbano | [Rischio incendio](/rischi-prevenzione/rischio-incendio/) |
-| Caldo intenso | Ondate di calore, fragilità, bambini, anziani e animali | [Caldo e ondate di calore](/rischi-prevenzione/caldo/) |
+| Caldo intenso | Ondate di calore, fragilità, bambini, anziani e animali | [Caldo e ondate di calore](/rischi-prevenzione/ondate-di-calore/) |
 | Blackout | Mancanza di corrente, dispositivi elettrici, sicurezza domestica | [Blackout](/rischi-prevenzione/blackout/) |
-| Evacuazione | Uscita rapida da casa o scuola, kit, aree di attesa | [Evacuazione](/rischi-prevenzione/evacuazione/) |
+| Evacuazione | Uscita rapida da casa o scuola, kit, aree di attesa | [Kit di emergenza ed evacuazione](/rischi-prevenzione/kit-emergenza/) |
 
 ## Kit di emergenza essenziale
 

--- a/content/rischi-prevenzione/scuole-genzano-rischi-locali.md
+++ b/content/rischi-prevenzione/scuole-genzano-rischi-locali.md
@@ -97,7 +97,6 @@ Per le famiglie è utile anche il [Kit di emergenza: casa, evacuazione e auto](/
 Il sito mette a disposizione schede A4 per aiutare bambini, famiglie e operatori a parlare di emergenza in modo semplice e non traumatico:
 
 - [Kit Calamità per Bambini](/formazione/kit-calamita-bambini/);
-- [Kit Calamità per Adolescenti](/formazione/kit-calamita-adolescenti/);
 - [Kit Calamità — raccolta completa](/formazione/kit-calamita/);
 - [Piano di emergenza familiare](/piano-familiare/).
 

--- a/content/trasparenza/_index.md
+++ b/content/trasparenza/_index.md
@@ -19,7 +19,7 @@ Dal **28 ottobre 2024** il Gruppo è anche **iscritto al RUNTS** (Registro Unico
 | Soggetto costituente | Consiglio Comunale di Genzano di Roma |
 | Forma giuridica | Ente del Terzo Settore (ETS) — articolazione del Comune di Genzano |
 | Iscrizione RUNTS | Sezione *"Altri Enti del Terzo Settore"*, determina n. G14230 del 28/10/2024 |
-| Coordinamento operativo | 14° C.O.I. — Centro Operativo Intercomunale della Provincia di Roma |
+| Coordinamento operativo | 14° COI — Centro Operativo Intercomunale della Provincia di Roma |
 | Coordinamento regionale | Aderente al coordinamento **FEPIVOL** |
 | Quadro normativo | D.Lgs. 117/2017 (Codice del Terzo Settore) + D.Lgs. 1/2018 (Codice della Protezione Civile) + L.R. Lazio 9/2017 + Direttiva PCM 30/04/2021 |
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -45,7 +45,7 @@ enableGitInfo = true
   # Link alla dichiarazione di accessibilità su form.agid.gov.it
   dichiarazioneAccessibilita = ""
   # Informazioni istituzionali
-  coi = "14° C.O.I. Prov. di Roma"
+  coi = "14° COI Prov. di Roma"
   registroRegionale = "n.184"
   runts = "Iscritta al RUNTS sez. 'Altri Enti del Terzo Settore' con determina n. G14230 del 28/10/2024"
   coordinamento = "FEPIVOL"

--- a/manuale/parte-21-aggiornamenti-contenuti-didattici-prevenzione.md
+++ b/manuale/parte-21-aggiornamenti-contenuti-didattici-prevenzione.md
@@ -114,13 +114,13 @@ Quando vengono aggiunte nuove pagine informative importanti, aggiornare anche la
 
 Il file tecnico `sitemap.xml` è generato automaticamente da Hugo e non deve essere modificato a mano.
 
-## Regola C.O.I.
+## Regola COI
 
 Il riferimento corretto indicato dall'utente è:
 
-**14° C.O.I.**
+**14° COI**
 
-Non usare “15° C.O.I.” nei testi pubblici, nei manuali o nelle regole di governance.
+Non usare “15° COI” nei testi pubblici, nei manuali o nelle regole di governance.
 
 ## Regola generale sulle fonti
 
@@ -139,7 +139,7 @@ Audit strutturale completo del sito (le 7 Fasi del modello di lavoro). Esiti pri
 
 ### Fix di drift documentale e fact errors
 
-- **C.O.I. 14°** allineato in 4 file che avevano l'asserzione invertita (`README.md`, `audit-sito.yml`, `pc-article-reviewer`, `pc-deploy-validator`).
+- **COI 14°** allineato in 4 file che avevano l'asserzione invertita (`README.md`, `audit-sito.yml`, `pc-article-reviewer`, `pc-deploy-validator`).
 - **Bandiera SPQR di Reggio Emilia** rimossa dall'articolo 1996: era spacciata come "foto storica del terremoto del 15 ottobre 1996". Pubblicata prima che il filtro anti-bandiere fosse aggiunto a `foto-da-wikipedia.sh`.
 - **Caption ShakeMap INGV** corrette in 5 articoli (Emilia 2012 + Amatrice 2016): la stessa foto md5-identica era usata in più articoli con caption diverse che dichiaravano "capannone industriale crollato a Mirandola" o "Amatrice in macerie", mentre la foto è una mappa di intensità macrosismica INGV.
 - **Duplicato editoriale 24 agosto** sul decimo anniversario di Amatrice 2016: due articoli con stessa data, stesso evento, badge diversi. Tenuto `2026-08-24-amatrice-2016-centro-italia-decimo-anniversario.md` (Comunicazione, taglio narrativo cronologico). Aliases nel file mantenuto preserva l'URL del file rimosso per SEO.

--- a/scripts/fix-ordering-articoli-stesso-giorno.py
+++ b/scripts/fix-ordering-articoli-stesso-giorno.py
@@ -9,7 +9,7 @@ basati sull'ordine reale di prima pubblicazione (git first commit timestamp).
 Risolve il bug di ordering instabile dell'archivio /comunicazioni/: con due
 articoli a `date: 2026-04-30` Hugo li ordina alfabeticamente per filename,
 non per ordine di pubblicazione. Aggiungendo orario crescente nello stesso
-giorno (08:00, 14:00, 18:00 a seconda del numero), Hugo ordina Date desc
+giorno (00:01, 00:02, ... a seconda del numero), Hugo ordina Date desc
 correttamente e l'ultimo scritto finisce in cima.
 
 Articoli singoli giornalieri restano `date: AAAA-MM-GG` (no modifica).


### PR DESCRIPTION
## Audit approfondito del sito + correzioni

Audit reale (build Hugo, parsing 388 articoli + 100 sezioni, 19 workflow, 11 data file, ~2.500 link interni). **Nessun bug bloccante.** Build pulito prima e dopo.

### Correzioni applicate (34 file)

| Blocco | Cosa | File |
|---|---|---|
| Ordering | 9 giornate con 2 articoli in formato solo-data → orari crescenti `T00:01/T00:02` (rule 02) | 18 articoli |
| Link rotti | 6 target interni inesistenti corretti | 6 file content |
| CI | Pin Hugo `0.143.1` (era `latest`, fragile) | deploy / audit-sito / validate-pr |
| Sigla COI | Uniformata senza punti (footer mostrava `C.O.I.`, contenuti `COI`) — forma AGID | hugo.toml, README, manuale/parte-21, 2 agent, audit-sito |
| Docs | Docstring `fix-ordering` allineata al codice | 1 script |

### Link interni corretti

- `/rischi-prevenzione/caldo/` → `/rischi-prevenzione/ondate-di-calore/`
- `/rischi-prevenzione/evacuazione/` → `/rischi-prevenzione/kit-emergenza/`
- `/aree-emergenza/` → `/cartografia/`
- `/manuali/` rimosso da `accessibilita` e `podcast` (manuale interno, non pubblicato)
- `kit-calamita-adolescenti` rimosso (kit inesistente)
- `Piano_AIB_Lazio.pdf` da path relativo rotto → URL assoluto Aruba

### Verificato e lasciato invariato

- 4 link `http://` (idrografico.roma.it, zonesismiche.mi.ingv.it, parcocastelliromani.it ×2): testati, **non supportano HTTPS** → forzarli romperebbe i link. Sono hyperlink, non sotto-risorse → non è mixed content.
- 280/388 articoli calendarizzati nel futuro: coerente con `pubblica-programmata.yml`.

Pre-commit check: `git diff | grep '^[+-]image'` vuoto — campo `image:` mai toccato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)