### PR TITLE
Area Download: peso dei file (KB/MB) su tutti i download

### DIFF
--- a/content/area-download/_index.md
+++ b/content/area-download/_index.md
@@ -19,23 +19,23 @@ In questa sezione puoi consultare e scaricare documenti relativi all'attività d
 
 | Documento | Formato |
 |---|---|
-| [Piano di Emergenza Comunale di PC](https://www.protezionecivilegenzano.it/area-download/normativa/Piano_Emergenza_Comunale_PC_Genzano.pdf) | PDF |
-| [Carta delle Aree di Emergenza e degli Edifici Strategici](https://www.protezionecivilegenzano.it/area-download/normativa/Aree_Emergenza_Edifici_Strategici_PC_Genzano.pdf) | PDF |
-| [Carta di Inquadramento Territoriale](https://www.protezionecivilegenzano.it/area-download/normativa/Inquadramento_Territoriale_PC_Genzano.pdf) | PDF |
-| [Carta Rischio Idrogeologico](https://www.protezionecivilegenzano.it/area-download/normativa/Rischio_Idrogeologico_PC_Genzano.pdf) | PDF |
-| [Carta Rischio Incendio](https://www.protezionecivilegenzano.it/area-download/normativa/Rischio_Incendio_PC_Genzano.pdf) | PDF |
-| [Carta Rischio Sismico](https://www.protezionecivilegenzano.it/area-download/normativa/Rischio_Sismico_PC_Genzano.pdf) | PDF |
-| [Cartina Genzano di Roma](https://www.protezionecivilegenzano.it/area-download/normativa/Cartina_Genzano_di_Roma.pdf) | PDF |
+| [Piano di Emergenza Comunale di PC](https://www.protezionecivilegenzano.it/area-download/normativa/Piano_Emergenza_Comunale_PC_Genzano.pdf) | PDF · 5,6 MB |
+| [Carta delle Aree di Emergenza e degli Edifici Strategici](https://www.protezionecivilegenzano.it/area-download/normativa/Aree_Emergenza_Edifici_Strategici_PC_Genzano.pdf) | PDF · 5,7 MB |
+| [Carta di Inquadramento Territoriale](https://www.protezionecivilegenzano.it/area-download/normativa/Inquadramento_Territoriale_PC_Genzano.pdf) | PDF · 5,7 MB |
+| [Carta Rischio Idrogeologico](https://www.protezionecivilegenzano.it/area-download/normativa/Rischio_Idrogeologico_PC_Genzano.pdf) | PDF · 5,4 MB |
+| [Carta Rischio Incendio](https://www.protezionecivilegenzano.it/area-download/normativa/Rischio_Incendio_PC_Genzano.pdf) | PDF · 5,8 MB |
+| [Carta Rischio Sismico](https://www.protezionecivilegenzano.it/area-download/normativa/Rischio_Sismico_PC_Genzano.pdf) | PDF · 7,3 MB |
+| [Cartina Genzano di Roma](https://www.protezionecivilegenzano.it/area-download/normativa/Cartina_Genzano_di_Roma.pdf) | PDF · 3,0 MB |
 
 ## Documenti Operativi e Regolamenti
 
 | Documento | Formato |
 |---|---|
-| [Schema Ordinanza Sindacale](https://www.protezionecivilegenzano.it/area-download/normativa/Schema_Ordinanza_Sindacale_PC_Genzano.pdf) | PDF |
-| [Ordinanza Sindacale AIB 2024](https://www.protezionecivilegenzano.it/area-download/normativa/Ordinanza_Sindacale_AIB_2024.pdf) | PDF |
-| [Ordinanza Sindacale AIB 2025](https://www.protezionecivilegenzano.it/area-download/normativa/Ordinanza_Sindacale_AIB_2025.pdf) | PDF |
-| [Regolamento del Gruppo di P.C. Genzano](https://www.protezionecivilegenzano.it/area-download/normativa/Regolamento_Gruppo_Comunale_PC_Genzano.pdf) | PDF |
-| [Domanda di ammissione al Gruppo Comunale](/manuali/moduli/domanda-ammissione-volontari.pdf) | PDF (298 KB) |
+| [Schema Ordinanza Sindacale](https://www.protezionecivilegenzano.it/area-download/normativa/Schema_Ordinanza_Sindacale_PC_Genzano.pdf) | PDF · 103 KB |
+| [Ordinanza Sindacale AIB 2024](https://www.protezionecivilegenzano.it/area-download/normativa/Ordinanza_Sindacale_AIB_2024.pdf) | PDF · 126 KB |
+| [Ordinanza Sindacale AIB 2025](https://www.protezionecivilegenzano.it/area-download/normativa/Ordinanza_Sindacale_AIB_2025.pdf) | PDF · 163 KB |
+| [Regolamento del Gruppo di P.C. Genzano](https://www.protezionecivilegenzano.it/area-download/normativa/Regolamento_Gruppo_Comunale_PC_Genzano.pdf) | PDF · 1,0 MB |
+| [Domanda di ammissione al Gruppo Comunale](/manuali/moduli/domanda-ammissione-volontari.pdf) | PDF · 298 KB |
 
 ## Normativa Regionale (Lazio)
 
@@ -53,11 +53,11 @@ Documenti regionali disponibili localmente:
 
 | Documento | Formato |
 |---|---|
-| [Piano AIB Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Piano_AIB_Lazio.pdf) | PDF |
-| [Piano Triennale di Protezione Civile Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Piano_Triennale_PC_Lazio.pdf) | PDF |
-| [Direttive Allertamento di Protezione Civile Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Direttive_Allertamento_PC_Lazio.pdf) | PDF |
-| [Norme di comportamento Protezione Civile Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Norme_comportamento_PC_Lazio.pdf) | PDF |
-| [Tabella Comuni di Protezione Civile Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Tabella_Comuni_PC_Lazio.pdf) | PDF |
+| [Piano AIB Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Piano_AIB_Lazio.pdf) | PDF · 31,0 MB |
+| [Piano Triennale di Protezione Civile Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Piano_Triennale_PC_Lazio.pdf) | PDF · 26,4 MB |
+| [Direttive Allertamento di Protezione Civile Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Direttive_Allertamento_PC_Lazio.pdf) | PDF · 1,3 MB |
+| [Norme di comportamento Protezione Civile Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Norme_comportamento_PC_Lazio.pdf) | PDF · 212 KB |
+| [Tabella Comuni di Protezione Civile Lazio](https://www.protezionecivilegenzano.it/area-download/normativa/Tabella_Comuni_PC_Lazio.pdf) | PDF · 220 KB |
 
 ## Normativa Nazionale
 
@@ -90,10 +90,10 @@ Per segnalare un link non funzionante scrivi a <a href="mailto:segreteria@protez
 
 | Documento | Descrizione | Formato |
 |---|---|---|
-| [La Protezione Civile nella scuola](https://www.protezionecivilegenzano.it/documenti/download/PC_scuola.pdf) | Manuale redatto dal DPC e dal Ministero dell'Istruzione | PDF |
-| [Il Volontariato di Protezione Civile](https://www.protezionecivilegenzano.it/documenti/download/Volontariato_PC.pdf) | Il ruolo del volontariato nel sistema nazionale | PDF |
-| [La Protezione Civile in famiglia](https://www.protezionecivilegenzano.it/documenti/download/PC_famiglia.pdf) | Buone pratiche da adottare in famiglia | PDF |
-| [Il ruolo del DPC](https://www.protezionecivilegenzano.it/documenti/download/Ruolo_DPC.pdf) | Pieghevole informativo | PDF |
+| [La Protezione Civile nella scuola](https://www.protezionecivilegenzano.it/documenti/download/PC_scuola.pdf) | Manuale redatto dal DPC e dal Ministero dell'Istruzione | PDF · 6,8 MB |
+| [Il Volontariato di Protezione Civile](https://www.protezionecivilegenzano.it/documenti/download/Volontariato_PC.pdf) | Il ruolo del volontariato nel sistema nazionale | PDF · 243 KB |
+| [La Protezione Civile in famiglia](https://www.protezionecivilegenzano.it/documenti/download/PC_famiglia.pdf) | Buone pratiche da adottare in famiglia | PDF · 4,5 MB |
+| [Il ruolo del DPC](https://www.protezionecivilegenzano.it/documenti/download/Ruolo_DPC.pdf) | Pieghevole informativo | PDF · 883 KB |
 
 ## Formazione e solidarietà
 
@@ -101,9 +101,9 @@ Manuali tecnici prodotti da enti del Terzo Settore in collaborazione con il sist
 
 | Documento | Descrizione | Formato |
 |---|---|---|
-| [Manuale di Cucina in Emergenza](/manuali/DSEFIC_Manuale_Cucina_Emergenza_FIC.pdf) | A cura del DSEFIC — Dipartimento Solidarietà Emergenze della Federazione Italiana Cuochi. Protocolli per cucine da campo: zone, HACCP, alimentazioni speciali, ricette (3,8 MB) | PDF |
-| [Il Libro del Risparmio — 120 azioni contro lo spreco alimentare](/manuali/FondazioneBarilla_Libro_del_Risparmio.pdf) | A cura di Fondazione Barilla con Università di Bologna. Guida pratica per ridurre lo spreco di cibo in casa e fuori casa: conservazione, cucina a zero spreco, avanzi, spesa consapevole (27,3 MB) | PDF |
-| [Recupero, raccolta e distribuzione di cibo per solidarietà sociale](/manuali/Caritas_Banco_Alimentare_Manuale_Emporio_Solidale.pdf) | A cura di Caritas Italiana e Fondazione Banco Alimentare. Manuale di corrette prassi operative per le organizzazioni caritative, validato dal Ministero della Salute: HACCP semplificato, semaforo di attenzione, tracciabilità (4,1 MB) | PDF |
+| [Manuale di Cucina in Emergenza](/manuali/DSEFIC_Manuale_Cucina_Emergenza_FIC.pdf) | A cura del DSEFIC — Dipartimento Solidarietà Emergenze della Federazione Italiana Cuochi. Protocolli per cucine da campo: zone, HACCP, alimentazioni speciali, ricette | PDF · 3,8 MB |
+| [Il Libro del Risparmio — 120 azioni contro lo spreco alimentare](/manuali/FondazioneBarilla_Libro_del_Risparmio.pdf) | A cura di Fondazione Barilla con Università di Bologna. Guida pratica per ridurre lo spreco di cibo in casa e fuori casa: conservazione, cucina a zero spreco, avanzi, spesa consapevole | PDF · 27,3 MB |
+| [Recupero, raccolta e distribuzione di cibo per solidarietà sociale](/manuali/Caritas_Banco_Alimentare_Manuale_Emporio_Solidale.pdf) | A cura di Caritas Italiana e Fondazione Banco Alimentare. Manuale di corrette prassi operative per le organizzazioni caritative, validato dal Ministero della Salute: HACCP semplificato, semaforo di attenzione, tracciabilità | PDF · 4,1 MB |
 
 ## Campagna "Io Non Rischio"
 
@@ -111,20 +111,20 @@ Materiali informativi della campagna nazionale [Io Non Rischio](https://www.iono
 
 | Documento | Descrizione | Formato |
 |---|---|---|
-| [Terremoto — Pieghevole](https://www.protezionecivilegenzano.it/documenti/download/INR_terremoto_pieghevole.pdf) | Cosa fare prima, durante e dopo un terremoto | PDF |
-| [Terremoto — Scheda](https://www.protezionecivilegenzano.it/documenti/download/INR_terremoto_scheda.pdf) | Approfondimento sul rischio sismico | PDF |
-| [Alluvione — Pieghevole](https://www.protezionecivilegenzano.it/documenti/download/INR_alluvione_pieghevole.pdf) | Cosa fare prima, durante e dopo un'alluvione | PDF |
-| [Alluvione — Scheda](https://www.protezionecivilegenzano.it/documenti/download/INR_alluvione_scheda.pdf) | Approfondimento sul rischio alluvione | PDF |
-| [Incendi — Pieghevole](https://www.protezionecivilegenzano.it/documenti/download/INR_incendi_pieghevole.pdf) | Cosa fare prima, durante e dopo un incendio boschivo | PDF |
-| [Incendi — Scheda](https://www.protezionecivilegenzano.it/documenti/download/INR_incendi_scheda.pdf) | Approfondimento sul rischio incendi | PDF |
-| [Maremoto — Pieghevole](https://www.protezionecivilegenzano.it/documenti/download/INR_maremoto_pieghevole.pdf) | Cosa fare prima, durante e dopo un maremoto | PDF |
-| [Maremoto — Scheda](https://www.protezionecivilegenzano.it/documenti/download/INR_maremoto_scheda.pdf) | Approfondimento sul rischio maremoto | PDF |
+| [Terremoto — Pieghevole](https://www.protezionecivilegenzano.it/documenti/download/INR_terremoto_pieghevole.pdf) | Cosa fare prima, durante e dopo un terremoto | PDF · 1,9 MB |
+| [Terremoto — Scheda](https://www.protezionecivilegenzano.it/documenti/download/INR_terremoto_scheda.pdf) | Approfondimento sul rischio sismico | PDF · 2,9 MB |
+| [Alluvione — Pieghevole](https://www.protezionecivilegenzano.it/documenti/download/INR_alluvione_pieghevole.pdf) | Cosa fare prima, durante e dopo un'alluvione | PDF · 2,2 MB |
+| [Alluvione — Scheda](https://www.protezionecivilegenzano.it/documenti/download/INR_alluvione_scheda.pdf) | Approfondimento sul rischio alluvione | PDF · 1,7 MB |
+| [Incendi — Pieghevole](https://www.protezionecivilegenzano.it/documenti/download/INR_incendi_pieghevole.pdf) | Cosa fare prima, durante e dopo un incendio boschivo | PDF · 2,1 MB |
+| [Incendi — Scheda](https://www.protezionecivilegenzano.it/documenti/download/INR_incendi_scheda.pdf) | Approfondimento sul rischio incendi | PDF · 508 KB |
+| [Maremoto — Pieghevole](https://www.protezionecivilegenzano.it/documenti/download/INR_maremoto_pieghevole.pdf) | Cosa fare prima, durante e dopo un maremoto | PDF · 1,1 MB |
+| [Maremoto — Scheda](https://www.protezionecivilegenzano.it/documenti/download/INR_maremoto_scheda.pdf) | Approfondimento sul rischio maremoto | PDF · 1,6 MB |
 
 ## Atlante dei Territori
 
 | Documento | Descrizione | Formato |
 |---|---|---|
-| [Atlante 2025 — Territori in trasformazione](https://www.protezionecivilegenzano.it/documenti/download/ATLANTE-2025-TERRITORI-IN-TRASFORMAZIONE-12-05.pdf) | Rapporto nazionale sui territori e i rischi ambientali (124 MB) | PDF |
+| [Atlante 2025 — Territori in trasformazione](https://www.protezionecivilegenzano.it/documenti/download/ATLANTE-2025-TERRITORI-IN-TRASFORMAZIONE-12-05.pdf) | Rapporto nazionale sui territori e i rischi ambientali | PDF · 118,7 MB |
 
 ## Loghi e stemmi del Gruppo
 
@@ -139,16 +139,16 @@ I loghi e gli stemmi ufficiali del Gruppo sono disponibili al download per **per
 
 | Logo / stemma | Descrizione | Formato |
 |---|---|---|
-| [Stemma circolare classico PC Genzano](/manuali/loghi/stemma-pc-genzano-circolare-classico.png) | Stemma istituzionale del Gruppo Comunale: cerchio con scritta "Protezione Civile — Genzano di Roma" e stemma del Comune al centro. Sfondo trasparente, alta risoluzione. | PNG |
-| [Stemma circolare con trinacria PC Genzano](/manuali/loghi/stemma-pc-genzano-circolare-trinacria.jpg) | Variante con il simbolo nazionale della Protezione Civile (trinacria tricolore) al centro. | JPG |
-| [Logo PC Genzano + stemma del Comune](/manuali/loghi/logo-pc-genzano-volontariato-comune.jpg) | Logo composito verticale: stemma del Comune di Genzano + simbolo nazionale Protezione Civile, fascia "Volontariato" e dicitura completa "Gruppo Comunale Volontari di Protezione Civile — Genzano di Roma". | JPG |
-| [Logo Servizio Nazionale di Protezione Civile — Volontariato](/manuali/loghi/logo-dpc-volontariato-nazionale.jpg) | Logo ufficiale del Servizio Nazionale di Protezione Civile, settore Volontariato. Per uso istituzionale dei volontari del Sistema. | JPG |
+| [Stemma circolare classico PC Genzano](/manuali/loghi/stemma-pc-genzano-circolare-classico.png) | Stemma istituzionale del Gruppo Comunale: cerchio con scritta "Protezione Civile — Genzano di Roma" e stemma del Comune al centro. Sfondo trasparente, alta risoluzione. | PNG · 181 KB |
+| [Stemma circolare con trinacria PC Genzano](/manuali/loghi/stemma-pc-genzano-circolare-trinacria.jpg) | Variante con il simbolo nazionale della Protezione Civile (trinacria tricolore) al centro. | JPG · 89 KB |
+| [Logo PC Genzano + stemma del Comune](/manuali/loghi/logo-pc-genzano-volontariato-comune.jpg) | Logo composito verticale: stemma del Comune di Genzano + simbolo nazionale Protezione Civile, fascia "Volontariato" e dicitura completa "Gruppo Comunale Volontari di Protezione Civile — Genzano di Roma". | JPG · 122 KB |
+| [Logo Servizio Nazionale di Protezione Civile — Volontariato](/manuali/loghi/logo-dpc-volontariato-nazionale.jpg) | Logo ufficiale del Servizio Nazionale di Protezione Civile, settore Volontariato. Per uso istituzionale dei volontari del Sistema. | JPG · 75 KB |
 
 ## Locandine ufficiali
 
 | Locandina | Descrizione | Formato |
 |---|---|---|
-| [Diventa Volontario — Aiutaci ad aiutare](/manuali/locandine/locandina-diventa-volontario.pdf) | Locandina ufficiale di reclutamento. Affiggibile in negozi, scuole, parrocchie, condomini. Riporta sede, telefono, email e requisiti minimi. (109 KB) | PDF |
+| [Diventa Volontario — Aiutaci ad aiutare](/manuali/locandine/locandina-diventa-volontario.pdf) | Locandina ufficiale di reclutamento. Affiggibile in negozi, scuole, parrocchie, condomini. Riporta sede, telefono, email e requisiti minimi. | PDF · 109 KB |
 
 ## Materiali per le scuole
 


### PR DESCRIPTION
## Cosa cambia

Su `/area-download/` ogni file scaricabile ora mostra il **peso** nella colonna *Formato* — es. `PDF · 5,6 MB`, `JPG · 122 KB`. Richiesta ricorrente dell'utente: chi scarica sa quanto pesa il file prima di farlo (utile su mobile / connessioni lente). Allineato a **WCAG 3.3.5 Help** e al campo `dimensione` già previsto dall'archetipo per gli allegati.

## Come sono stati ricavati i pesi

- **28 file sul server Aruba** (`/area-download/normativa/`, `/documenti/download/`): peso letto via richiesta HTTP HEAD (`Content-Length`). Tutti rispondono 200.
- **10 file nel repo** (`/manuali/...`): peso dal filesystem.

## Pulizia collaterale

- Rimossi i pesi che erano già scritti **dentro le descrizioni** di 5 voci (Cucina FIC, Libro del Risparmio, Caritas, Atlante, Locandina) — ora il peso sta in un solo posto, la colonna *Formato*.
- **Correzione dato**: l'Atlante 2025 era indicato "124 MB" — il file reale è **118,7 MB**.

## Non toccato

I 2 link di *Normativa Nazionale* puntano a Normattiva (pagine web, non file da scaricare) → restano con la colonna *Fonte*, senza peso.

Build Hugo pulito. 38 inserzioni / 38 cancellazioni (1 riga per file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)