### PR TITLE
#21 — Filtro alfabetico + ricerca live sulla pagina /glossario/

### DIFF
--- a/content/glossario/_index.md
+++ b/content/glossario/_index.md
@@ -12,9 +12,12 @@ dataUltimaRevisione: "2026-05-06"
 
 Le sigle della protezione civile possono sembrare difficili. Questo glossario le spiega in modo semplice, con esempi collegati al territorio quando utile.
 
+<div id="glossario-strumenti" class="glossario-strumenti"></div>
+<noscript>
 <div class="alert alert-info" role="note">
 <p class="mb-0"><i class="bi bi-search me-2" aria-hidden="true"></i><strong>Suggerimento:</strong> usa la ricerca del browser: <kbd>Ctrl+F</kbd> su Windows e Linux, <kbd>Cmd+F</kbd> su Mac.</p>
 </div>
+</noscript>
 
 Se cerchi un termine che non trovi, scrivi a [segreteria@protezionecivilegenzano.it](mailto:segreteria@protezionecivilegenzano.it).
 

--- a/static/js/glossario-pagina.js
+++ b/static/js/glossario-pagina.js
@@ -1,0 +1,153 @@
+/* glossario-pagina.js — Filtro alfabetico + ricerca live per la pagina /glossario/.
+ *
+ * Enhancement progressivo: la pagina funziona già senza JS (voci A-Z statiche +
+ * suggerimento Ctrl+F nel <noscript>). Con JS aggiunge:
+ *   - una barra di lettere A-Z che filtra le voci per iniziale
+ *   - un campo di ricerca che filtra le voci in tempo reale (termine + definizione)
+ *   - conteggio risultati annunciato a screen reader (aria-live)
+ *
+ * Si attiva solo se trova il contenitore #glossario-strumenti nella pagina.
+ * Lavora sulla struttura esistente di .article-body: H2 = lettera, H3 = termine,
+ * contenuto del termine = elementi fra un H3 e il successivo H3/H2.
+ *
+ * Accessibilità: <button> e <input type="search"> nativi, focus visibile dal
+ * tema, stato premuto via aria-pressed, conteggio via aria-live="polite".
+ */
+(function () {
+  "use strict";
+
+  var strumenti = document.getElementById("glossario-strumenti");
+  if (!strumenti) return;
+
+  var body = document.querySelector(".article-body") || strumenti.parentElement;
+  if (!body) return;
+
+  // ── Raccoglie le sezioni-lettera (H2) e le voci (H3 + contenuto) ──────────
+  var sezioni = [];   // { letter, h2, voci: [...] }
+  var voci = [];      // { h3, nodi: [...], lettera, testo }
+  var sezioneCorr = null;
+
+  Array.prototype.forEach.call(body.children, function (el) {
+    var tag = el.tagName;
+    if (tag === "H2") {
+      sezioneCorr = { letter: el.textContent.trim().toUpperCase(), h2: el, voci: [] };
+      sezioni.push(sezioneCorr);
+    } else if (tag === "H3" && sezioneCorr) {
+      var voce = {
+        h3: el,
+        nodi: [el],
+        lettera: sezioneCorr.letter,
+        testo: el.textContent.toLowerCase()
+      };
+      sezioneCorr.voci.push(voce);
+      voci.push(voce);
+    } else if (voci.length && sezioneCorr && sezioneCorr.voci.length) {
+      // elemento di contenuto: appartiene all'ultima voce della sezione corrente
+      var ultima = sezioneCorr.voci[sezioneCorr.voci.length - 1];
+      ultima.nodi.push(el);
+      ultima.testo += " " + el.textContent.toLowerCase();
+    }
+  });
+
+  if (!voci.length) return; // struttura non riconosciuta: lascia la pagina com'è
+
+  var lettere = sezioni.map(function (s) { return s.letter; });
+
+  // ── Costruisce l'interfaccia ─────────────────────────────────────────────
+  strumenti.innerHTML = "";
+
+  var label = document.createElement("label");
+  label.className = "form-label fw-bold";
+  label.setAttribute("for", "glossario-cerca");
+  label.textContent = "Cerca un termine o una sigla";
+  strumenti.appendChild(label);
+
+  var input = document.createElement("input");
+  input.type = "search";
+  input.id = "glossario-cerca";
+  input.className = "form-control";
+  input.placeholder = "Es. COC, allerta, evacuazione…";
+  input.setAttribute("autocomplete", "off");
+  input.setAttribute("aria-describedby", "glossario-conteggio");
+  strumenti.appendChild(input);
+
+  var barra = document.createElement("div");
+  barra.className = "glossario-lettere";
+  barra.setAttribute("role", "group");
+  barra.setAttribute("aria-label", "Filtra il glossario per lettera iniziale");
+  strumenti.appendChild(barra);
+
+  function creaBottone(testo, valore, premuto) {
+    var b = document.createElement("button");
+    b.type = "button";
+    b.className = "glossario-lettera-btn";
+    b.textContent = testo;
+    b.dataset.lettera = valore;
+    b.setAttribute("aria-pressed", premuto ? "true" : "false");
+    return b;
+  }
+
+  var btnTutte = creaBottone("Tutte", "", true);
+  barra.appendChild(btnTutte);
+  lettere.forEach(function (l) {
+    barra.appendChild(creaBottone(l, l, false));
+  });
+
+  var conteggio = document.createElement("p");
+  conteggio.id = "glossario-conteggio";
+  conteggio.className = "glossario-conteggio";
+  conteggio.setAttribute("aria-live", "polite");
+  strumenti.appendChild(conteggio);
+
+  // ── Logica di filtro ─────────────────────────────────────────────────────
+  var letteraAttiva = "";
+
+  function applica() {
+    var q = input.value.trim().toLowerCase();
+    var visibili = 0;
+
+    voci.forEach(function (voce) {
+      var okLettera = !letteraAttiva || voce.lettera === letteraAttiva;
+      var okTesto = !q || voce.testo.indexOf(q) > -1;
+      var mostra = okLettera && okTesto;
+      voce.nodi.forEach(function (n) {
+        n.style.display = mostra ? "" : "none";
+      });
+      if (mostra) visibili++;
+    });
+
+    // Nasconde gli H2 delle sezioni senza voci visibili
+    sezioni.forEach(function (s) {
+      var qualcunaVisibile = s.voci.some(function (v) {
+        return v.nodi[0].style.display !== "none";
+      });
+      s.h2.style.display = qualcunaVisibile ? "" : "none";
+    });
+
+    if (visibili === voci.length) {
+      conteggio.textContent = voci.length + " termini nel glossario";
+    } else if (visibili === 0) {
+      conteggio.textContent = "Nessun termine trovato. Prova un'altra parola o scrivi a segreteria@protezionecivilegenzano.it";
+    } else {
+      conteggio.textContent = visibili + (visibili === 1 ? " termine trovato" : " termini trovati");
+    }
+  }
+
+  barra.addEventListener("click", function (ev) {
+    var btn = ev.target.closest(".glossario-lettera-btn");
+    if (!btn) return;
+    letteraAttiva = btn.dataset.lettera;
+    Array.prototype.forEach.call(barra.children, function (b) {
+      b.setAttribute("aria-pressed", b === btn ? "true" : "false");
+    });
+    applica();
+  });
+
+  var debounce;
+  input.addEventListener("input", function () {
+    window.clearTimeout(debounce);
+    debounce = window.setTimeout(applica, 120);
+  });
+
+  applica(); // stato iniziale: conteggio totale
+})();

--- a/themes/flavour-pcgenzano/layouts/_default/baseof.html
+++ b/themes/flavour-pcgenzano/layouts/_default/baseof.html
@@ -103,6 +103,7 @@
   <script src="{{ "js/share.js" | relURL }}" defer></script>
   <script src="{{ "js/galleria-auto.js" | relURL }}" defer></script>
   {{ if .IsHome }}<script src="{{ "js/homepage-reveal.js" | relURL }}" defer></script>{{ end }}
+  {{ if eq .Section "glossario" }}<script src="{{ "js/glossario-pagina.js" | relURL }}" defer></script>{{ end }}
   <script>
     // Back to top — se la pagina ha un indice (#indice), salta direttamente lì,
     // altrimenti torna in cima. La label aria si adatta al contesto.

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -4665,3 +4665,70 @@ html.a11y-hide-translate-button #lang-modal { display: none !important; }
  * fine RICERCA PAGEFIND v1.0
  * ==========================================================================
  */
+
+/* ==========================================================================
+ * GLOSSARIO PAGINA v1.0 — filtro alfabetico + ricerca live su /glossario/
+ * JS: static/js/glossario-pagina.js — enhancement progressivo (la pagina
+ * funziona anche senza JS). Palette istituzionale #003366.
+ * ==========================================================================
+ */
+
+.glossario-strumenti {
+  margin: 1rem 0 1.75rem;
+}
+
+#glossario-cerca {
+  max-width: 32rem;
+}
+
+.glossario-lettere {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.85rem;
+}
+
+.glossario-lettera-btn {
+  min-width: 2.1rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: #003366;
+  background: #ffffff;
+  border: 1px solid #c9d3e0;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.glossario-lettera-btn:hover {
+  background: #eef2f7;
+  border-color: #003366;
+}
+
+.glossario-lettera-btn:focus-visible {
+  outline: 3px solid #ffbe2e;
+  outline-offset: 2px;
+}
+
+.glossario-lettera-btn[aria-pressed="true"] {
+  color: #ffffff;
+  background: #003366;
+  border-color: #003366;
+}
+
+.glossario-conteggio {
+  margin: 0.85rem 0 0;
+  font-size: 0.9rem;
+  color: #555555;
+}
+
+@media print {
+  .glossario-strumenti {
+    display: none;
+  }
+}
+/* ==========================================================================
+ * fine GLOSSARIO PAGINA v1.0
+ * ==========================================================================
+ */


### PR DESCRIPTION
## #21 — Glossario interattivo

**Scoperta:** il glossario esisteva già al ~70%. `data/glossario.yaml` (82 voci), il popover inline negli articoli (`glossario-inline.js`, con supporto tastiera), la pagina `/glossario/` con ~60 voci A-Z. Mancava **solo** ciò che il prompt #21 chiede in più: *filtri alfabetici e ricerca* sulla pagina dedicata — che prima diceva soltanto "usa Ctrl+F".

Non ho ricostruito niente: ho aggiunto il delta mancante.

| File | Cosa |
|---|---|
| `static/js/glossario-pagina.js` | Legge la struttura A-Z esistente (H2=lettera, H3=termine), costruisce barra lettere A-Z filtrante + ricerca live (cerca in termine **e** definizione), conteggio annunciato via `aria-live`. |
| `baseof.html` | Script caricato **solo** su `.Section "glossario"` — stesso pattern condizionale di `homepage-reveal.js`. |
| `custom.css` | Sezione `GLOSSARIO PAGINA v1.0`, palette istituzionale, focus visibile, nascosto in stampa. |
| `content/glossario/_index.md` | Contenitore `#glossario-strumenti` + `<noscript>` con il vecchio suggerimento Ctrl+F come fallback. |

**Enhancement progressivo:** senza JS la pagina resta quella statica A-Z di prima + il fallback Ctrl+F nel `<noscript>`. Con JS: barra A-Z + ricerca. `<button>` e `<input type="search">` nativi, accessibili da tastiera.

**Osservazione (fuori scope #21):** `glossario.yaml` (82 voci) e la pagina `/glossario/` (~60 voci) sono due fonti non sincronizzate. Unificarle (page generata da yaml) eliminerebbe il drift, ma è un intervento a sé — lo segnalo, non l'ho fatto qui.

Build Hugo pulito, script caricato solo sul glossario (verificato: assente in home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)