### PR TITLE
fix: la notifica Telegram non parte al cambio di allerta meteo

### DIFF
--- a/.github/workflows/check-allerta.yml
+++ b/.github/workflows/check-allerta.yml
@@ -97,3 +97,17 @@ jobs:
         run: |
           echo "Triggering deploy workflow..."
           gh workflow run deploy.yml --ref main
+
+      # I push fatti con il GITHUB_TOKEN NON auto-triggerano i workflow `push`:
+      # notifica-telegram.yml ascolta su push -> data/allerta.json, ma non si
+      # sveglia da solo per i commit automatici di questo workflow. Va avviato
+      # esplicitamente, come deploy.yml qui sopra. notifica-telegram.py ha la
+      # sua logica di de-duplica (confronta con HEAD~1, invia solo se il
+      # livello e' davvero cambiato): chiamarlo a ogni commit e' sicuro.
+      - name: "📲 Avvia notifica Telegram"
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering notifica-telegram workflow..."
+          gh workflow run notifica-telegram.yml --ref main


### PR DESCRIPTION
## Il bug

Il messaggio automatico Telegram al cambio di allerta meteo **non partiva**.

## Causa

`check-allerta.yml` committa `data/allerta.json` con il `GITHUB_TOKEN`. I push fatti dal `GITHUB_TOKEN` **non auto-triggerano i workflow `push`** — gotcha noto di GitHub Actions, già documentato nel progetto per `scarica-foto-automatica.yml`.

`notifica-telegram.yml` ascolta su `push → data/allerta.json`, ma non si svegliava per i commit automatici di `check-allerta.yml`. `check-allerta.yml` faceva già il trigger esplicito per `deploy.yml` — ma **non** per `notifica-telegram.yml`.

**Prova:** ultimi cambi di livello nel git log (`verde → gialla`, `gialla → verde`) ma ultimo run di `notifica-telegram.yml` del 13 maggio, per un commit umano. I cambi automatici successivi non l'hanno fatto partire.

## Fix

Nuovo step in `check-allerta.yml`: `gh workflow run notifica-telegram.yml` quando c'è stato un commit — identico al trigger di `deploy.yml` già presente.

**Sicuro contro lo spam:** `notifica-telegram.py` ha già la sua de-duplica (confronta con `HEAD~1`, invia solo se il  è davvero cambiato). Sui commit "controllo periodico invariato" lo script esce pulito senza inviare.

YAML validato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)