### PR TITLE
Fase A audit 13/05: hardening blocchi allerta homepage

### DIFF
--- a/themes/flavour-pcgenzano/layouts/index.html
+++ b/themes/flavour-pcgenzano/layouts/index.html
@@ -54,12 +54,16 @@
 {{ $domaniRischi := "" }}
 {{ with $allerta.domani }}
   {{ if in $domaniLivelliVisibili .livello }}
+    {{/* Difesa: blocco visibile SOLO se livello rilevante E titolo non vuoto.
+         Evita render "Previsto domani: — gialla" se dati popolati a metà. */}}
+    {{ if .titolo }}
     {{ $domaniVisibile = true }}
     {{ $domaniLiv = .livello }}
     {{ $domaniTitolo = .titolo }}
     {{ $domaniRischi = delimit .rischi ", " }}
     {{ $td := time.AsTime .data }}
     {{ $domaniDataLeg = printf "%d %s %d" $td.Day (index $mesi (int $td.Month)) $td.Year }}
+    {{ end }}
   {{ end }}
 {{ end }}
 <div id="allerta-bar-domani" class="allerta-bar-domani allerta-bar-domani-{{ $domaniLiv }}" role="status" aria-label="Pre-allerta meteo per domani"{{ if not $domaniVisibile }} style="display:none"{{ end }}>
@@ -76,11 +80,15 @@
 {{ $avvisoUrl := "" }}
 {{ $avvisoVisibile := false }}
 {{ with $allerta.avviso_meteo }}
+  {{/* Difesa: blocco visibile SOLO se tipo non vuoto.
+       Evita render "Avviso meteo: — allerta verde" se dati popolati a metà. */}}
+  {{ if .tipo }}
   {{ $avvisoLiv = .livello }}
   {{ $avvisoTipo = .tipo }}
   {{ $avvisoDescr = .descrizione }}
   {{ $avvisoUrl = .url }}
   {{ $avvisoVisibile = true }}
+  {{ end }}
 {{ end }}
 <div id="avviso-meteo-bar" class="avviso-meteo-bar avviso-meteo-bar-{{ $avvisoLiv }}" role="alert" aria-label="Avviso meteo avverso"{{ if not $avvisoVisibile }} style="display:none"{{ end }}>
   <div class="container">


### PR DESCRIPTION
## Sommario

**Fase A** del piano di 7 fasi recepito dall'audit ChatGPT 13/05/2026.

Hardening dei blocchi "Previsto domani" e "Avviso meteo" sulla homepage. Difesa preventiva contro il pattern "Avviso meteo: — allerta verde" segnalato dall'audit: aggiunti controlli `if .titolo` e `if .tipo` che richiedono dati popolati per rendere visibili i blocchi.

## Effetto

- Flussi normali: zero impatto, comportamento identico.
- Caso degenere (`data/allerta.json` con campo vuoto): blocco resta `display:none` invece di mostrare formato sgrammaticato.

## File modificati

- `themes/flavour-pcgenzano/layouts/index.html` (+8 righe)

## Test plan

- [x] Diff minimo (1 file, 2 controlli aggiuntivi)
- [x] Sintassi Go template `{{ if }}…{{ end }}` chiusa correttamente
- [ ] Build Hugo CI pulito

---
_Generated by [Claude Code](https://claude.ai/code/session_01994Zx5QNm5ZHn18X6Yfp2p)_