### PR TITLE
Crosslink: schede-didattiche-giochi ↔ percorsi-didattici

### DIFF
--- a/content/formazione/percorsi-didattici/_index.md
+++ b/content/formazione/percorsi-didattici/_index.md
@@ -427,6 +427,15 @@ Scrivere a **[segreteria@protezionecivilegenzano.it](mailto:segreteria@protezion
 
 </details>
 
+## Vedi anche
+
+- [Schede didattiche dei giochi](/formazione/schede-didattiche-giochi/) — catalogo dei 33 giochi con obiettivi, durata, competenze e accessibilità (per scegliere un gioco singolo)
+- [Per le scuole](/scuole/) — landing per docenti, dirigenti, genitori, studenti
+- [Educazione Civica](/formazione/educazione-civica/) — collegamenti normativi e calendario 33 ore
+- [Formazione](/formazione/) — hub completo dei materiali
+- [Schede stampabili A4](/formazione/schede-stampabili/) — materiali fotocopiabili per la classe
+- [Storie e racconti](/formazione/storie-e-racconti/) — fiabe per fascia d'età
+
 ---
 
 **Ultimo aggiornamento**: 1 maggio 2026.

--- a/content/formazione/schede-didattiche-giochi.md
+++ b/content/formazione/schede-didattiche-giochi.md
@@ -131,6 +131,7 @@ Scrivi a [segreteria@protezionecivilegenzano.it](mailto:segreteria@protezioneciv
 
 - [Arena PC Genzano](/giochi/) — pagina principale per giocare
 - [Per le scuole](/scuole/) — landing per docenti, dirigenti, genitori, studenti
+- [Percorsi didattici pronti](/formazione/percorsi-didattici/) — 6 unità di Educazione Civica già strutturate (4 ore, obiettivi, valutazione)
 - [Formazione](/formazione/) — hub completo dei materiali
 - [Schede stampabili A4](/formazione/schede-stampabili/) — materiali fotocopiabili per la classe
 - [Storie e racconti](/formazione/storie-e-racconti/) — fiabe e racconti per fascia d'età


### PR DESCRIPTION
## Sommario

Crosslink fra le due pagine didattiche complementari per evitare che un docente arrivi su una via Google senza scoprire l'altra.

## Modifiche

- `content/formazione/schede-didattiche-giochi.md` — aggiunta voce "Vedi anche" verso `/formazione/percorsi-didattici/`
- `content/formazione/percorsi-didattici/_index.md` — nuova sezione "Vedi anche" che linka a `/formazione/schede-didattiche-giochi/` + 5 risorse complementari

## Why due pagine separate (non consolidate)

Approcci ortogonali, scope diverso:

| Pagina | Approccio | Bisogno docente |
|---|---|---|
| `/formazione/percorsi-didattici/` | **Top-down**: 6 unità da 4 ore strutturate con obiettivi, articolazione, valutazione | "Voglio fare una lezione completa" |
| `/formazione/schede-didattiche-giochi/` | **Bottom-up**: catalogo di 33 giochi con metadati | "Voglio scegliere un gioco singolo" |

Consolidare sarebbe stato 570 righe, TOC ingestibile, perdita di focus. Pattern già usato altrove nel sito (es. `/aree-attesa/` snapshot vs `/cartografia/` interattiva, `/scuole/` 4-card vs `/formazione/` hub completo).

## Test plan

- [x] Diff minimo (2 file, +10 righe)
- [x] Link verificati esistenti
- [ ] Build Hugo CI pulito

---
_Generated by [Claude Code](https://claude.ai/code/session_01994Zx5QNm5ZHn18X6Yfp2p)_