### PR TITLE
Revisione AGID pagine: contatti, numeri utili e microtesti

### DIFF
--- a/content/contatti/_index.md
+++ b/content/contatti/_index.md
@@ -5,9 +5,8 @@ layout: "single"
 aliases:
   - /contatti.html
 tts: true
-dataUltimaRevisione: "2026-05-06"
+dataUltimaRevisione: "2026-05-16"
 ---
-<!-- cache-bust: 2026-05-13 forza re-upload FTP per allineare header/footer (audit 13/05) -->
 
 <div class="card border-danger mb-4">
 <div class="card-body bg-danger bg-opacity-10 p-4">
@@ -69,23 +68,39 @@ Segui i canali ufficiali per aggiornamenti, allerte e comunicazioni del Gruppo.
 
 ## Quando contattarci
 
-<div class="table-responsive">
-<table>
-<caption>Canali corretti da usare in base alla situazione</caption>
-<thead>
-<tr><th scope="col">Situazione</th><th scope="col">Cosa fare</th></tr>
-</thead>
-<tbody>
-<tr><td><strong>Emergenza in corso</strong> (incendio, alluvione, terremoto, persona in pericolo)</td><td>Chiama il <strong>112</strong></td></tr>
-<tr><td><strong>Pericolo immediato</strong> (albero caduto su strada, smottamento, cavi pericolanti, incendio)</td><td>Chiama il <strong>112</strong></td></tr>
-<tr><td><strong>Comunicazioni di protezione civile regionale</strong></td><td>Fai riferimento alla Sala Operativa Regionale <strong>803&nbsp;555</strong>, secondo le indicazioni ufficiali</td></tr>
-<tr><td><strong>Informazioni sul Gruppo</strong></td><td>Chiama o scrivi ai recapiti ordinari</td></tr>
-<tr><td><strong>Diventare volontario</strong></td><td>Vieni in sede, chiama o <a href="mailto:segreteria@protezionecivilegenzano.it">scrivi un'email</a></td></tr>
-<tr><td><strong>Collaborazione con scuole</strong></td><td>Scrivi a <a href="mailto:segreteria@protezionecivilegenzano.it">segreteria@protezionecivilegenzano.it</a></td></tr>
-<tr><td><strong>Segnalazione problema sul sito</strong></td><td>Scrivi a <a href="mailto:segreteria@protezionecivilegenzano.it">segreteria@protezionecivilegenzano.it</a></td></tr>
-<tr><td><strong>Media e giornalisti</strong> (interviste, dichiarazioni, immagini)</td><td>Scrivi a <a href="mailto:segreteria@protezionecivilegenzano.it">segreteria@protezionecivilegenzano.it</a></td></tr>
-</tbody>
-</table>
+<div class="row g-3 my-3">
+<div class="col-md-6">
+<div class="card h-100 border-danger">
+<div class="card-body">
+<h3 class="h5 text-danger">Emergenza o pericolo immediato</h3>
+<p class="mb-0">Chiama il <strong>112</strong> per incendio, alluvione, terremoto, persona in pericolo, albero caduto su strada, smottamento, cavi pericolanti o altra situazione urgente.</p>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="card h-100 border-warning">
+<div class="card-body">
+<h3 class="h5 text-warning">Comunicazioni regionali di Protezione Civile</h3>
+<p class="mb-0">Fai riferimento alla Sala Operativa Regionale <strong>803&nbsp;555</strong>, secondo le indicazioni ufficiali. Per pericolo immediato resta prioritario il 112.</p>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="card h-100">
+<div class="card-body">
+<h3 class="h5">Informazioni sul Gruppo o volontariato</h3>
+<p class="mb-0">Chiama la segreteria, vieni in sede o scrivi a <a href="mailto:segreteria@protezionecivilegenzano.it">segreteria@protezionecivilegenzano.it</a>.</p>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="card h-100">
+<div class="card-body">
+<h3 class="h5">Scuole, sito, media e collaborazioni</h3>
+<p class="mb-0">Per progetti scolastici, segnalazioni sul sito, richieste media o collaborazioni scrivi a <a href="mailto:segreteria@protezionecivilegenzano.it">segreteria@protezionecivilegenzano.it</a>.</p>
+</div>
+</div>
+</div>
 </div>
 
 ## Mappa della sede
@@ -104,4 +119,3 @@ Segui i canali ufficiali per aggiornamenti, allerte e comunicazioni del Gruppo.
 - [Cosa fare adesso](/cosa-fare-adesso/) — azioni immediate per il cittadino
 - [Diventa volontario](/diventa-volontario/) — iscrizione, requisiti e formazione
 - [Mappa del sito](/mappa-sito/) — tutte le sezioni del sito
-

--- a/content/numeri-utili/_index.md
+++ b/content/numeri-utili/_index.md
@@ -5,8 +5,8 @@ tts: true
 layout: "single"
 aliases:
   - /numeri-utili/
+dataUltimaRevisione: "2026-05-16"
 ---
-<!-- cache-bust: 2026-05-13 forza re-upload FTP per allineare header/footer (audit 13/05) -->
 
 <div class="card border-danger mb-4">
 <div class="card-body bg-danger bg-opacity-10 p-4">
@@ -20,18 +20,34 @@ aliases:
 
 Nel Lazio il numero da chiamare in caso di emergenza è il **112**. La centrale indirizza la chiamata verso il servizio competente in base alla situazione: soccorso sanitario, Vigili del Fuoco, Forze dell'Ordine o altro servizio di emergenza.
 
-<div class="table-responsive">
-<table>
-<caption>Numeri utili: quale chiamare e in quali casi</caption>
-<thead>
-<tr><th scope="col">Numero</th><th scope="col">Servizio</th><th scope="col">Quando chiamare</th></tr>
-</thead>
-<tbody>
-<tr><td><strong>112</strong></td><td>Numero Unico Europeo per le emergenze</td><td>Emergenza in corso, pericolo immediato, persone ferite, incendio, soccorso tecnico, sicurezza pubblica</td></tr>
-<tr><td><strong>803&nbsp;555</strong></td><td>Sala Operativa Regionale Protezione Civile Lazio</td><td>Numero verde regionale di Protezione Civile. Per emergenze con pericolo immediato resta prioritario il 112</td></tr>
-<tr><td><strong>1530</strong></td><td>Guardia Costiera</td><td>Emergenze e soccorso in mare e nelle acque di competenza</td></tr>
-</tbody>
-</table>
+<div class="row g-3 my-3">
+<div class="col-md-4">
+<div class="card h-100 border-danger">
+<div class="card-body">
+<p class="fs-2 fw-bold text-danger mb-1">112</p>
+<h3 class="h5">Numero Unico Europeo</h3>
+<p class="mb-0">Per emergenza in corso, pericolo immediato, persone ferite, incendio, incidente, soccorso tecnico o sicurezza pubblica.</p>
+</div>
+</div>
+</div>
+<div class="col-md-4">
+<div class="card h-100 border-warning">
+<div class="card-body">
+<p class="fs-2 fw-bold text-warning mb-1">803&nbsp;555</p>
+<h3 class="h5">Sala Operativa Regionale Lazio</h3>
+<p class="mb-0">Numero verde regionale di Protezione Civile. Per pericolo immediato resta sempre prioritario il 112.</p>
+</div>
+</div>
+</div>
+<div class="col-md-4">
+<div class="card h-100 border-primary">
+<div class="card-body">
+<p class="fs-2 fw-bold text-primary mb-1">1530</p>
+<h3 class="h5">Guardia Costiera</h3>
+<p class="mb-0">Per emergenze e soccorso in mare e nelle acque di competenza.</p>
+</div>
+</div>
+</div>
 </div>
 
 ## Recapiti del Gruppo di Protezione Civile
@@ -95,4 +111,3 @@ Il Gruppo Comunale di Protezione Civile **non può essere attivato direttamente 
 - [Contatti e sede](/contatti/) — sede, telefono, email del Gruppo
 - [Assistente virtuale](/assistente/) — guida passo-passo all'autoprotezione
 - [Allerte meteo](/allerte-meteo/) — stato di allerta in corso
-

--- a/themes/flavour-pcgenzano/layouts/_default/single.html
+++ b/themes/flavour-pcgenzano/layouts/_default/single.html
@@ -107,18 +107,17 @@
       {{ if eq .Kind "section" }}{{ range $ttsBlacklist }}{{ if eq $.Section . }}{{ $isBlacklisted = true }}{{ end }}{{ end }}{{ end }}
       {{ $ttsEnabled := and (ne .Params.tts false) (not $isBlacklisted) }}
 
-      {{/* ── BOX UNIFICATO "Leggi questo articolo in altri modi" ──
+      {{/* ── BOX UNIFICATO STRUMENTI DI LETTURA ──
            Raggruppa reading-time + TTS + braille + PDF in un riquadro blu
-           istituzionale sopra il corpo dell'articolo. Mantiene la logica
-           WCAG (strumenti di lettura PRIMA del contenuto) ma con stile
-           unificato. CSS sezione STRUMENTI ARTICOLO v1.0 in custom.css.
-           Specifiche layout: scelto dall'utente il 16/05/2026 (due box
-           gemelli, in alto lettura, in fondo condivisione). */}}
+           istituzionale sopra il contenuto. Su /comunicazioni/ usa il
+           microtesto "articolo"; sulle pagine stabili usa "pagina" per
+           evitare confusione editoriale. CSS sezione STRUMENTI ARTICOLO
+           v1.0 in custom.css. */}}
       {{ if and $ttsEnabled (gt .WordCount 30) }}
-      <div class="strumenti-articolo strumenti-lettura" role="region" aria-label="Strumenti di lettura dell'articolo">
+      <div class="strumenti-articolo strumenti-lettura" role="region" aria-label="Strumenti di lettura del contenuto">
         <div class="strumenti-articolo-header">
           <i class="bi bi-info-circle me-2" aria-hidden="true"></i>
-          Leggi questo articolo in altri modi
+          {{ if eq .Section "comunicazioni" }}Leggi questo articolo in altri modi{{ else }}Leggi questa pagina in altri modi{{ end }}
         </div>
         <div class="strumenti-articolo-body">
           <span class="reading-time" title="Tempo di lettura stimato (200 parole al minuto)">


### PR DESCRIPTION
## Sintesi

Revisione mirata delle sole pagine, senza intervenire sugli articoli.

### Modifiche
- `content/contatti/_index.md`: sostituita la tabella “Quando contattarci” con card più leggibili e responsive; aggiornata la data ultima revisione.
- `content/numeri-utili/_index.md`: sostituita la tabella dei numeri principali con card dedicate per 112, 803 555 e 1530; aggiornata la data ultima revisione.
- `themes/flavour-pcgenzano/layouts/_default/single.html`: corretto il microtesto del box strumenti: “articolo” per le comunicazioni, “pagina” per le pagine stabili.

### Note
- Prima delle modifiche sono state lette le istruzioni dedicate alle AI presenti nel repository (`AGENTS.md`).
- Non sono stati modificati gli articoli della sezione comunicazioni.
- Ho mantenuto il perimetro su modifiche testuali/strutturali a basso rischio e coerenti con leggibilità, chiarezza e fruizione mobile.
