### PR TITLE
Fix performance: cache-buster CSS/JS basato su hash contenuto

### DIFF
--- a/themes/flavour-pcgenzano/layouts/_default/baseof.html
+++ b/themes/flavour-pcgenzano/layouts/_default/baseof.html
@@ -23,17 +23,19 @@
   <link rel="icon" type="image/png" sizes="32x32" href="{{ "images/favicon.png" | relURL }}">
   <link rel="stylesheet" href="{{ "vendor/bootstrap-italia/css/bootstrap-italia.min.css" | relURL }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-  {{/* Cache-buster v=<unix build time>: Aruba serve `a11y-toolbar.css`
-       con cache-control: max-age=2592000 (30 giorni), quindi senza
-       cache-buster i cambi al toolbar accessibilità (e modalità lettura)
-       arrivano agli utenti che hanno già visitato il sito solo dopo 30
-       giorni o dopo un hard refresh. Aggiungiamo `?v={unix}` su CSS/JS
-       critici della toolbar accessibilità per invalidare la cache ad
-       ogni deploy. `custom.css` è incluso perché contiene anche stili
-       interdipendenti con a11y. */}}
-  {{- $v := now.Unix -}}
-  <link rel="stylesheet" href="{{ "css/custom.css" | relURL }}?v={{ $v }}">
-  <link rel="stylesheet" href="{{ "css/a11y-toolbar.css" | relURL }}?v={{ $v }}">
+  {{/* Cache-buster v=<hash contenuto>: Aruba serve i CSS/JS critici con
+       cache-control: max-age=2592000 (30 giorni). L'hash FNV32a sul
+       contenuto del file fa cambiare l'URL SOLO quando il file cambia
+       davvero — non a ogni build. Risultato: la cache di 30 giorni è
+       effettiva fra deploy consecutivi che non toccano questi asset,
+       e l'utente di ritorno non riscarica 211 KB di CSS ad ogni visita.
+       Storia: fino al 16/05/2026 il cache-buster era `now.Unix`, che
+       invalidava la cache ad ogni build (50+ deploy/settimana). */}}
+  {{- $vCustomCss := readFile "themes/flavour-pcgenzano/static/css/custom.css" | crypto.FNV32a -}}
+  {{- $vA11yCss := readFile "themes/flavour-pcgenzano/static/css/a11y-toolbar.css" | crypto.FNV32a -}}
+  {{- $vA11yJs := readFile "themes/flavour-pcgenzano/static/js/a11y-toolbar.js" | crypto.FNV32a -}}
+  <link rel="stylesheet" href="{{ "css/custom.css" | relURL }}?v={{ $vCustomCss }}">
+  <link rel="stylesheet" href="{{ "css/a11y-toolbar.css" | relURL }}?v={{ $vA11yCss }}">
   <link rel="canonical" href="{{ $canonicalURL }}">
   {{ partial "hreflang-tags.html" . }}
   {{/* Pre-rendering: applica subito le preferenze di accessibilità salvate
@@ -99,7 +101,7 @@
   </button>
   <script src="{{ "vendor/bootstrap-italia/js/bootstrap-italia.bundle.min.js" | relURL }}"></script>
   <script src="{{ "js/ext-widgets.js" | relURL }}" defer></script>
-  <script src="{{ "js/a11y-toolbar.js" | relURL }}?v={{ $v }}" defer></script>
+  <script src="{{ "js/a11y-toolbar.js" | relURL }}?v={{ $vA11yJs }}" defer></script>
   <script src="{{ "js/share.js" | relURL }}" defer></script>
   <script src="{{ "js/galleria-auto.js" | relURL }}" defer></script>
   {{/* Notifiche browser per l'allerta meteo (idea #2). URL endpoint + pagina

--- a/themes/flavour-pcgenzano/layouts/partials/glossario-inline.html
+++ b/themes/flavour-pcgenzano/layouts/partials/glossario-inline.html
@@ -35,5 +35,5 @@
 /* Glossario inline — dati statici dal build Hugo */
 window.PCGENZANO_GLOSSARIO = {{ $entries | jsonify | safeJS }};
 </script>
-<script src="{{ "js/glossario-inline.js" | relURL }}?v={{ now.Format "20060102150405" }}" defer></script>
+<script src="{{ "js/glossario-inline.js" | relURL }}?v={{ readFile "static/js/glossario-inline.js" | crypto.FNV32a }}" defer></script>
 {{- end -}}


### PR DESCRIPTION
## Diagnosi

Il sito risultava lento al ritorno degli utenti. Audit dei template del tema ha rivelato che il cache-buster su CSS/JS critici usava `now.Unix` / `now.Format`, invalidando la cache del browser **ad ogni build** — con ~50 deploy/settimana, gli utenti riscaricavano ~240 KB di CSS+JS a ogni visita nonostante la `max-age=2592000` (30 giorni) di Aruba.

## Fix

Sostituito il cache-buster temporale con uno basato sull'**hash FNV32a del contenuto** del file (`readFile | crypto.FNV32a`). L'URL cambia *solo* quando il file cambia davvero.

**4 asset critici interessati:**
- `css/custom.css` (181 KB)
- `css/a11y-toolbar.css` (30 KB)
- `js/a11y-toolbar.js` (16 KB)
- `js/glossario-inline.js` (12 KB)

**File modificati:**
- `themes/flavour-pcgenzano/layouts/_default/baseof.html`
- `themes/flavour-pcgenzano/layouts/partials/glossario-inline.html`

## Validazione

Build Hugo locale (v0.148.1 extended): exit 0, nessun warning.

Output HTML verificato:
- `custom.css?v=3573945461` (hash contenuto, era `?v=1747422383` epoch)
- `a11y-toolbar.css?v=3982503336`
- `a11y-toolbar.js?v=2440755046`
- `glossario-inline.js?v=1110046001` (era `?v=20260516192546` Format)

Stesso hash su `public/index.html`, `public/comunicazioni/index.html` e `public/numeri-utili/index.html` → URL dipende solo dal contenuto del file, non dal momento del build né dalla pagina servita.

## Impatto

- Prima: ad ogni deploy, utente di ritorno riscarica ~240 KB CSS+JS.
- Dopo: la cache 30gg di Aruba diventa effettiva fra deploy consecutivi che non toccano questi asset. Quando un giorno modifichi `custom.css` o `a11y-toolbar.js`, l'hash cambia da solo e il browser scarica solo il file aggiornato.

## Note

Il `bundle.min.js` di Bootstrap Italia resta `bundle` per scelta esplicita (test passati hanno mostrato che il `min.js` da solo dava problemi).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKzL2QrzzzSDyJ3sqnMqVY)_