### PR TITLE
Integra il portale Open Data dei Vigili del Fuoco come fonte istituzionale

### DIFF
--- a/.claude/rules/08-claude-code-setup.md
+++ b/.claude/rules/08-claude-code-setup.md
@@ -294,7 +294,7 @@ Estensione della whitelist con 25 ulteriori siti istituzionali testati e funzion
 
 | Sito | Dominio | Uso tipico |
 |---|---|---|
-| **Vigili del Fuoco** | `www.vigilfuoco.it` | VVF nazionale, statistiche interventi, comunicati |
+| **Vigili del Fuoco** | `www.vigilfuoco.it`, `opendata.vigilfuoco.it` | VVF nazionale, statistiche interventi, comunicati; portale Open Data (dataset aperti su interventi di soccorso) |
 | **ANPAS** | `www.anpas.org` | Pubbliche assistenze, partner DPC su "Io non rischio" |
 | **Carabinieri** | `www.carabinieri.it` | Arma dei Carabinieri (Carabinieri Forestali, ordine pubblico in emergenza) |
 

--- a/content/formazione/rischio-incendio/_index.md
+++ b/content/formazione/rischio-incendio/_index.md
@@ -61,3 +61,5 @@ Non chiamare direttamente il Gruppo Comunale per segnalare un incendio in corso:
 ## Fonte
 
 *Manuale addetti antincendio* — Corpo Nazionale dei Vigili del Fuoco (aggiornamento 2010-2019). Disponibile sul [portale vigilfuoco.it](https://www.vigilfuoco.it/).
+
+Per i dati statistici sugli interventi di soccorso e antincendio, vedi il portale **[Open Data dei Vigili del Fuoco](https://opendata.vigilfuoco.it/)** — dataset aperti del Corpo Nazionale dei Vigili del Fuoco.

--- a/content/open-data/_index.md
+++ b/content/open-data/_index.md
@@ -151,6 +151,10 @@ Per chi vuole consultare i dati senza scaricare i file:
 
 Se hai un'esigenza particolare (ricerca accademica, articolo giornalistico, comparazione tra Comuni, tesi universitaria), scrivici: <segreteria@protezionecivilegenzano.it>.
 
+## Dati aperti di altri enti
+
+Per i dati aperti su soccorso ed emergenze a livello nazionale, il riferimento istituzionale per il nostro settore è il portale **[Open Data dei Vigili del Fuoco](https://opendata.vigilfuoco.it/)**: pubblica statistiche e dataset aperti del Corpo Nazionale dei Vigili del Fuoco sugli interventi di soccorso. È una fonte utile per chi vuole inquadrare i dati locali del Gruppo nel contesto nazionale del sistema di emergenza.
+
 ## Vedi anche
 
 - [Trasparenza](/trasparenza/) — quadro istituzionale e documenti

--- a/content/siti-utili/_index.md
+++ b/content/siti-utili/_index.md
@@ -7,7 +7,7 @@ aliases:
   - /sitiutili/
 toc: true
 tts: true
-dataUltimaRevisione: "2026-05-18"
+dataUltimaRevisione: "2026-05-20"
 ---
 
 Questa pagina raccoglie link a siti istituzionali, portali operativi, fonti tecniche e risorse educative. I link sono organizzati per tema, così puoi trovare più facilmente la fonte utile.
@@ -55,6 +55,7 @@ Questa pagina raccoglie link a siti istituzionali, portali operativi, fonti tecn
 ## Enti operativi e di ricerca
 
 - [Corpo Nazionale dei Vigili del Fuoco](https://www.vigilfuoco.it/) — soccorso tecnico urgente.
+- [Open Data dei Vigili del Fuoco](https://opendata.vigilfuoco.it/) — dati aperti del Corpo Nazionale dei Vigili del Fuoco su interventi e attività di soccorso.
 - [INGV — Istituto Nazionale di Geofisica e Vulcanologia](https://www.ingv.it/) — monitoraggio sismico e vulcanico.
 - [ISPRA — Istituto Superiore per la Protezione e la Ricerca Ambientale](https://www.isprambiente.gov.it/it) — ricerca e dati ambientali.
 - [CNR — Consiglio Nazionale delle Ricerche](https://www.cnr.it/) — ente pubblico di ricerca.


### PR DESCRIPTION
## Cosa fa

Aggiunge il portale **Open Data dei Vigili del Fuoco** (`https://opendata.vigilfuoco.it/`) come fonte istituzionale, a livello di link (nessun dato riprodotto: il portale resta la fonte di verità per i dataset).

## File modificati

- `content/siti-utili/_index.md` — voce sotto "Enti operativi e di ricerca", accanto a vigilfuoco.it (+ `dataUltimaRevisione` → 2026-05-20)
- `content/open-data/_index.md` — nuova sezione "Dati aperti di altri enti"
- `content/formazione/rischio-incendio/_index.md` — riga nella sezione "Fonte" (pagina fondamenti VVF-centrica)
- `.claude/rules/08-claude-code-setup.md` — dominio `opendata.vigilfuoco.it` in whitelist (lettura dataset da sessione locale)

## Scelte editoriali

- **Esclusa** `rischi-prevenzione/rischio-incendio.md`: pagina-rischio a struttura fissa (rule 06 PRIMA→DURANTE→DOPO→cosa-non-fare→chi-chiamare), un portale di dati statistici sarebbe rumore per il cittadino in cerca di "cosa fare".
- Integrazione conservativa solo a livello di link: l'integrazione dei dati grezzi (statistiche interventi) richiede una sessione Claude Code locale che possa leggere il portale.

## Note

Modifiche markdown additive (link + 1 riga whitelist + 1 heading). Nessun tocco a `image:`, struttura pagine-rischio intatta.

https://claude.ai/code/session_01SRyqt18EjBT5QLT5EGvyLz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRyqt18EjBT5QLT5EGvyLz)_