### PR TITLE
Audit follow-up: precisa perimetro accessibilità (P2) e frase cookie (P4)

### DIFF
--- a/.claude/rules/04b-hugo-template-css.md
+++ b/.claude/rules/04b-hugo-template-css.md
@@ -108,6 +108,14 @@ Il menu Hugo (`hugo.toml [[menus.main]]` + `themes/flavour-pcgenzano/layouts/par
 
 Se trova drift, apre un'issue di manutenzione. Ma **non aspettare l'issue**: allinea al momento della modifica al menu.
 
+### `site-chrome.js` inietta anche SOS 112 + toolbar accessibilità (dal 22/05/2026)
+
+Oltre a header/navbar/footer, `site-chrome.js` inietta sulle pagine statiche anche il **pulsante SOS 112** (con modal di conferma) e la **toolbar Strumenti di accessibilità** (FAB), così le mini-app statiche (giochi, quizpc, formazionepc, abili-a-proteggere, schede stampabili) hanno gli stessi strumenti di sicurezza/accessibilità del resto del sito. Prima ne erano prive — drift rilevato in un audit del 22/05/2026 (un report esterno lo aveva mal-diagnosticato come "manca header/footer", che invece c'erano già perché iniettati da `site-chrome.js`).
+
+Implementazione: costanti `SOS_HTML` + `A11Y_HTML` + funzioni `wireSos()` / `injectA11yAndSos()`. Quest'ultima è **idempotente** (salta se la pagina ha già `#sos-button` o `#a11yToolbarOpen`), inietta i markup, carica `/css/a11y-toolbar.css` e `/js/a11y-toolbar.js` (che applica le preferenze salvate su `<html>` e fa il wireup del dialog appena iniettato). Gli stili SOS sono già in `custom.css` (caricato dalle pagine statiche). Possibile lieve FOUC sui contrasti perché manca l'early-script di `baseof.html` — accettato.
+
+**Vincolo di coerenza:** il markup di `SOS_HTML` e `A11Y_HTML` in `site-chrome.js` va tenuto allineato ai partial `sos-112.html` e `accessibility-toolbar.html`. Se modifichi i partial (nuovo controllo a11y, nuovo bottone nel modal SOS), replica in `site-chrome.js`. Stesso pattern del menu (duplicazione consapevole chrome Hugo ↔ statico).
+
 ## Indice della pagina (TOC) per articoli lunghi
 
 Le pagine con frontmatter `toc: true` mostrano in cima un **indice cliccabile** (Table of Contents) generato automaticamente da Hugo a partire dalle intestazioni H2/H3 del Markdown. Si applica solo a pagine che usano `_default/single.html` (Hugo richiede `layout: "single"` nel frontmatter, già usato dai kit didattici).

--- a/content/accessibilita/_index.md
+++ b/content/accessibilita/_index.md
@@ -4,7 +4,7 @@ description: "Dichiarazione di accessibilità AGID: stato di conformità, conten
 layout: "single"
 toc: true
 tts: true
-dataUltimaRevisione: "2026-05-12"
+dataUltimaRevisione: "2026-05-22"
 aliases:
   - /dichiarazione-accessibilita.html
 ---
@@ -24,15 +24,15 @@ Il sito è **parzialmente conforme** ai requisiti previsti dalla **WCAG 2.2 live
 - **SEO: 100/100** mediana stabile.
 - **Performance: 95/100** mediana stabile (LCP 2.3 s, TBT 70-130 ms, CLS 0.024-0.058 — Web Vitals tutti "Good").
 - **Contrasto colore WCAG AA**: tutti gli elementi testuali del sito hanno contrasto ≥ 4.5:1 verificato.
-- **Navigazione da tastiera**: l'intero sito è navigabile con Tab/Shift+Tab/Enter/Esc, nessuna trappola da tastiera.
+- **Navigazione da tastiera**: le pagine sono navigabili con Tab/Shift+Tab/Enter/Esc, senza trappole da tastiera. Sulle mini-app interattive (giochi, quiz, schede stampabili) la navigazione completa richiede JavaScript attivo.
 - **Focus visibile**: ogni elemento interattivo ha outline visibile (3px) al focus.
-- **Skip link**: "Vai al contenuto principale" presente in cima a tutte le pagine.
-- **Landmark ARIA**: header/nav/main/footer presenti su tutte le pagine.
+- **Skip link**: "Vai al contenuto principale" presente in cima alle pagine generate dal sito; sulle mini-app interattive è fornito via JavaScript insieme al resto dell'intestazione.
+- **Landmark ARIA**: header/nav/main/footer presenti nativamente sulle pagine generate dal sito; sulle mini-app interattive (giochi, quiz, schede stampabili) sono iniettati via JavaScript e richiedono quindi JavaScript attivo.
 - **Alt text**: tutte le immagini informative hanno descrizione testuale, le decorative hanno `alt=""`.
 - **Lingua dichiarata**: ogni pagina dichiara `<html lang>` correttamente, anche per le 7 traduzioni.
 - **`<th scope="col">` automatico**: tutte le 400+ tabelle Markdown del sito sono rese con intestazioni accessibili.
 - **Pittogrammi standardizzati**: 46 segnali ISO 7010 + 125 ARASAAC integrati per supportare comprensione cognitiva (bambini, anziani, italiano L2, persone con disabilità cognitive).
-- **TTS "Leggi ad alta voce"** nativo (Web Speech API) attivo su tutte le pagine non legali e funzionali.
+- **TTS "Leggi ad alta voce"** nativo (Web Speech API) attivo sulle pagine editoriali del sito (escluse le pagine legali e puramente funzionali).
 - **Toolbar di accessibilità** utente con 11 preferenze persistenti (dimensione testo, contrasto invertito, scala di grigi, font ad alta leggibilità, spaziatura, animazioni, evidenza link, cursore grande, ecc.).
 - **Selettore velocità TTS** (lento/normale/veloce) persistito in `localStorage`.
 - **Hreflang + `<html lang>` dinamico**: le 7 traduzioni dichiarano correttamente la lingua nel markup.

--- a/content/mappa-sito/_index.md
+++ b/content/mappa-sito/_index.md
@@ -242,6 +242,11 @@ In questa pagina trovi **tutte le sezioni del sito** organizzate per tema. Se sa
   <p class="ms-card-title">Scuole di Genzano e rischi locali</p>
   <p class="ms-card-desc">Riferimenti generali per famiglie e personale scolastico, da integrare con il piano di emergenza del singolo istituto.</p>
 </a>
+<a class="ms-card ms-emerg" href="/rischi-prevenzione/sicurezza-scuolabus/">
+  <div class="ms-card-icon"><i class="bi bi-bus-front"></i></div>
+  <p class="ms-card-title">Sicurezza sullo scuolabus</p>
+  <p class="ms-card-desc">Cosa fare in emergenza durante il tragitto: regole per bambini, autista e genitori, e quando chiamare il 112.</p>
+</a>
 </div>
 
 <div class="ms-section"><span class="ms-section-icon" style="background:#7c3aed"><i class="bi bi-mortarboard-fill"></i></span><h2>Formazione e didattica</h2></div>

--- a/content/rischi-prevenzione/_index.md
+++ b/content/rischi-prevenzione/_index.md
@@ -25,6 +25,7 @@ Queste pagine aiutano a orientarsi in pochi minuti, anche senza conoscenze tecni
 
 - [Rischi principali in parole semplici](/rischi-prevenzione/rischi-in-parole-semplici/) — spiegazione accessibile per bambini, persone con bisogni cognitivi e parlanti italiano L2.
 - [Scuole di Genzano e rischi locali](/rischi-prevenzione/scuole-genzano-rischi-locali/) — riferimenti generali per famiglie e personale scolastico, da integrare con il piano di emergenza del singolo istituto.
+- [Sicurezza sullo scuolabus](/rischi-prevenzione/sicurezza-scuolabus/) — cosa fare in emergenza durante il tragitto: regole per bambini, autista e genitori.
 - [Kit di emergenza economico e progressivo](/rischi-prevenzione/kit-emergenza-economico-progressivo/) — come comporre il kit un pezzo alla volta, senza marchi né prodotti specifici.
 
 ## Principali rischi

--- a/content/rischi-prevenzione/scuole-genzano-rischi-locali.md
+++ b/content/rischi-prevenzione/scuole-genzano-rischi-locali.md
@@ -118,6 +118,8 @@ Durante un'emergenza, la prima cosa da fare è seguire le comunicazioni ufficial
 
 Preparare un piano familiare aiuta anche i bambini. Sapere chi li viene a prendere, dove andare e quali numeri chiamare riduce paura e improvvisazione.
 
+Anche il tragitto casa-scuola fa parte della prevenzione: vedi la pagina [Sicurezza sullo scuolabus](/rischi-prevenzione/sicurezza-scuolabus/).
+
 ## Fonti e riferimenti
 
 - Dipartimento della Protezione Civile — norme di comportamento per i principali rischi;

--- a/content/rischi-prevenzione/sicurezza-scuolabus.md
+++ b/content/rischi-prevenzione/sicurezza-scuolabus.md
@@ -1,0 +1,113 @@
+---
+title: "Sicurezza sullo scuolabus"
+description: "Cosa fare in caso di emergenza sullo scuolabus: regole per bambini, autista e genitori, e quando chiamare il 112."
+tts: true
+weight: 8
+toc: true
+lis_section: "gestione-emergenza"
+---
+
+Lo scuolabus porta ogni giorno tanti bambini a scuola e a casa. Quasi sempre il viaggio è tranquillo. Ma anche qui serve sapere prima cosa fare se succede qualcosa: una scossa di terremoto, un temporale forte, fumo a bordo o una strada bloccata.
+
+Questa pagina raccoglie regole semplici per i bambini, per chi guida e per le famiglie. L'obiettivo è uno solo: mantenere la calma e seguire l'adulto responsabile.
+
+## Come è stata costruita questa pagina
+
+Questa pagina non riporta orari, percorsi, fermate, mezzi o nomi degli operatori del servizio scuolabus di un singolo Comune o istituto.
+
+Le indicazioni sono una sintesi divulgativa basata su:
+
+- norme di comportamento del Dipartimento della Protezione Civile per i principali rischi;
+- principi generali di sicurezza scolastica e di trasporto degli alunni;
+- pagine già presenti su questo sito dedicate ai rischi del territorio.
+
+Per le procedure del servizio, ogni Comune e ogni istituto ha le proprie regole. Il riferimento sono l'autista, l'eventuale accompagnatore e il Dirigente scolastico.
+
+## Le regole di sempre, prima ancora dell'emergenza
+
+Buone abitudini quotidiane rendono più sicuro qualsiasi imprevisto.
+
+- Sali e scendi con calma, uno alla volta, solo alla fermata.
+- Resta seduto al tuo posto per tutto il viaggio. Se il sedile ha la cintura, tienila allacciata.
+- Tieni lo zaino sulle ginocchia o dove indica l'autista, non nel corridoio.
+- Non distrarre chi guida e non gridare.
+- Impara a memoria il nome della tua fermata e il punto di raccolta della scuola.
+
+## Se succede qualcosa durante il viaggio
+
+In ogni caso, la prima regola è la stessa: **resta seduto, mantieni la calma e ascolta l'autista**. È l'adulto responsabile a bordo e sa cosa fare.
+
+### Scossa di terremoto
+
+L'autista accosta e ferma il mezzo in un punto sicuro, lontano da edifici, ponti, alberi e pali. I bambini restano seduti, abbassano la testa e si proteggono con le braccia. Si scende solo quando l'autista lo dice, in fila e senza correre.
+
+Vedi anche la pagina [Rischio sismico](/rischi-prevenzione/rischio-sismico/).
+
+### Pioggia forte, vento o grandine
+
+Se il tempo peggiora all'improvviso, l'autista rallenta o si ferma in un luogo sicuro. I bambini restano a bordo, lontani dai finestrini. Non si scende in mezzo all'acqua o sotto alberi che oscillano.
+
+Vedi anche la pagina [Allerte meteo](/allerte-meteo/).
+
+### Fumo o odore di bruciato a bordo
+
+L'autista ferma il mezzo, apre le porte e fa scendere tutti in un punto sicuro, lontano dal veicolo. I bambini seguono l'autista in fila, senza tornare indietro a prendere lo zaino. L'autista chiama il **112**.
+
+Vedi anche la pagina [Rischio incendi boschivi](/rischi-prevenzione/rischio-incendio/).
+
+### Strada bloccata o allagata
+
+Se la strada è interrotta da acqua, frane o alberi caduti, l'autista non prosegue e non attraversa l'allagamento. Avvisa la scuola e le famiglie e attende indicazioni dalle autorità. I bambini restano a bordo finché l'adulto non dice il contrario.
+
+Vedi anche la pagina [Rischio idrogeologico](/rischi-prevenzione/rischio-idrogeologico/).
+
+{{< cosa-non-fare titolo="Cosa NON fare sullo scuolabus in emergenza" >}}
+- **Non alzarti e non correre verso le porte** durante una scossa o una frenata.
+- **Non scendere dal mezzo da solo**, senza il via libera dell'autista.
+- **Non tornare indietro** a prendere lo zaino o gli oggetti.
+- **Non attraversare strade allagate**, nemmeno a piedi.
+- **Non chiamare i genitori per primo**: prima si ascolta l'autista e, se serve, si chiama il 112.
+{{< /cosa-non-fare >}}
+
+## Il ruolo dell'autista e dell'accompagnatore
+
+Chi guida o accompagna i bambini ha la responsabilità del gruppo durante il viaggio. In emergenza il suo compito è chiaro.
+
+- Fermare il mezzo in un punto sicuro, lontano da pericoli.
+- Tenere la calma e dare istruzioni semplici e brevi.
+- Far scendere i bambini solo se restare a bordo è più pericoloso.
+- Chiamare il **112** e descrivere cosa succede e dove si trova il mezzo.
+- Avvisare la scuola e, se previsto, il Comune.
+- Restare con i bambini fino all'arrivo dei soccorsi o dei genitori.
+
+## Messaggio alle famiglie
+
+In caso di emergenza è naturale preoccuparsi. Ma alcune scelte aiutano davvero i soccorsi.
+
+- **Non precipitarti lungo il percorso dello scuolabus**: rischi di intralciare i mezzi di soccorso.
+- **Tieni libero il telefono**: aspetta le comunicazioni ufficiali della scuola e del Comune.
+- **Concorda prima con tuo figlio** il punto di raccolta e chi può venirlo a prendere.
+- **Segui solo le fonti ufficiali**, non i messaggi non verificati sui social.
+
+Prepara con la tua famiglia un piano semplice: vedi la pagina [Piano familiare di emergenza](/piano-familiare/).
+
+## Anche in gita vale lo stesso
+
+Durante una gita scolastica i principi non cambiano: si resta con il gruppo, si ascolta l'insegnante referente e si conosce in anticipo il punto di raccolta. L'insegnante tiene i contatti con la scuola e, se serve, chiama il **112**.
+
+{{< chi-chiamare >}}
+
+## Per approfondire
+
+**Sul nostro sito**
+
+- [Scuole di Genzano e rischi locali](/rischi-prevenzione/scuole-genzano-rischi-locali/)
+- [Rischio sismico: cosa fare](/rischi-prevenzione/rischio-sismico/)
+- [Piano familiare di emergenza](/piano-familiare/)
+- [Numeri utili](/numeri-utili/)
+- [Assistente guidato: cosa fare adesso](/assistente/)
+
+**Fonti istituzionali**
+
+- [Dipartimento della Protezione Civile — Io non rischio](https://iononrischio.protezionecivile.it/)
+- [Ministero dell'Istruzione e del Merito — Sicurezza nelle scuole](https://www.mim.gov.it/)

--- a/static/app-shared/site-chrome.js
+++ b/static/app-shared/site-chrome.js
@@ -256,6 +256,193 @@
     '</footer>' +
     '<button class="back-to-top" id="backToTop" aria-label="Torna in cima alla pagina" title="Torna su"><i class="bi bi-arrow-up" aria-hidden="true"></i></button>';
 
+  /* ----------------------------------------------------------------
+     SOS 112 + Strumenti di accessibilità per le pagine statiche.
+     Sulle pagine Hugo questi componenti arrivano da baseof.html
+     (partial sos-112.html + accessibility-toolbar.html + a11y-toolbar.js).
+     Le pagine statiche (giochi, quizpc, formazionepc, schede stampabili,
+     abili-a-proteggere, ...) non passano da Hugo: senza questo blocco
+     restavano prive del pulsante SOS 112 e della toolbar a11y, a differenza
+     del resto del sito. Aggiunto dopo l'audit del 2026-05-22.
+     MARKUP DA TENERE ALLINEATO con i partial Hugo citati sopra.
+     ---------------------------------------------------------------- */
+  var SOS_HTML =
+    '<button type="button" id="sos-button" class="sos-button" aria-label="Chiama il numero unico di emergenza 112 (con conferma)" aria-haspopup="dialog" aria-controls="sos-modal">' +
+      '<span class="sos-icon" aria-hidden="true">SOS</span>' +
+      '<span class="sos-label">112</span>' +
+    '</button>' +
+    '<div id="sos-modal" class="sos-modal" role="dialog" aria-modal="true" aria-labelledby="sos-modal-title" aria-describedby="sos-modal-desc" hidden>' +
+      '<div class="sos-modal-backdrop" data-sos-close="true" aria-hidden="true"></div>' +
+      '<div class="sos-modal-dialog" role="document">' +
+        '<div class="sos-modal-header">' +
+          '<h2 id="sos-modal-title" class="sos-modal-title"><i class="bi bi-telephone-fill" aria-hidden="true"></i> Stai per chiamare il <strong>112</strong></h2>' +
+        '</div>' +
+        '<div class="sos-modal-body">' +
+          '<p id="sos-modal-desc" class="sos-modal-desc">Il <strong>112</strong> è il <strong>Numero Unico di Emergenza</strong>: chiamalo <strong>solo se c\'è una vera emergenza</strong> (incidente, incendio, ferito grave, evento naturale in corso).</p>' +
+          '<p class="sos-modal-info">Se confermi, parte la chiamata. Una volta connesso, parla con calma: di\' <strong>cosa è successo</strong> e <strong>dove sei</strong>. Non riagganciare prima dell\'operatore.</p>' +
+          '<div class="sos-modal-warning"><i class="bi bi-exclamation-triangle-fill" aria-hidden="true"></i> Le chiamate al 112 per scherzo o per motivi non urgenti sono <strong>punite per legge</strong> (art. 658 Codice penale).</div>' +
+          '<p class="sos-modal-alt"><i class="bi bi-question-circle-fill" aria-hidden="true"></i> <strong>Non sei sicuro che sia un\'emergenza?</strong> Usa l\'<strong>assistente guidato</strong>: ti accompagna con domande semplici fino alla risposta giusta.</p>' +
+        '</div>' +
+        '<div class="sos-modal-footer">' +
+          '<button type="button" id="sos-modal-cancel" class="btn btn-outline-secondary btn-lg sos-modal-btn-cancel" data-sos-close="true"><i class="bi bi-x-lg me-1" aria-hidden="true"></i> Annulla</button>' +
+          '<a href="' + SITE_URL + '/assistente/" id="sos-modal-guide" class="btn btn-outline-primary btn-lg sos-modal-btn-guide"><i class="bi bi-question-circle-fill me-1" aria-hidden="true"></i> Cosa devo fare?</a>' +
+          '<a href="tel:112" id="sos-modal-call" class="btn btn-danger btn-lg sos-modal-btn-call"><i class="bi bi-telephone-fill me-1" aria-hidden="true"></i> Sì, chiama il 112</a>' +
+        '</div>' +
+      '</div>' +
+    '</div>';
+
+  var A11Y_HTML =
+    '<button type="button" id="a11yToolbarOpen" class="a11y-fab" aria-label="Apri strumenti di accessibilità" aria-haspopup="dialog" aria-controls="a11yDialog" title="Strumenti di accessibilità">' +
+      '<i class="bi bi-universal-access" aria-hidden="true"></i><span class="visually-hidden">Strumenti di accessibilità</span>' +
+    '</button>' +
+    '<div class="a11y-backdrop" id="a11yBackdrop" hidden></div>' +
+    '<div class="a11y-dialog" id="a11yDialog" role="dialog" aria-modal="true" aria-labelledby="a11yDialogTitle" hidden>' +
+      '<header class="a11y-dialog-header">' +
+        '<h2 id="a11yDialogTitle" class="a11y-dialog-title"><i class="bi bi-universal-access me-2" aria-hidden="true"></i> Strumenti di accessibilità</h2>' +
+        '<button type="button" id="a11yDialogClose" class="a11y-close" aria-label="Chiudi strumenti di accessibilità"><i class="bi bi-x-lg" aria-hidden="true"></i></button>' +
+      '</header>' +
+      '<div class="a11y-dialog-body">' +
+        '<p class="a11y-intro">Personalizza la lettura del sito. Le tue scelte vengono ricordate sul tuo dispositivo.</p>' +
+        '<fieldset class="a11y-section">' +
+          '<legend class="a11y-section-title"><i class="bi bi-fonts me-2" aria-hidden="true"></i>Testo</legend>' +
+          '<div class="a11y-control"><span class="a11y-control-label" id="a11yLblTextSize">Dimensione del testo</span>' +
+            '<div class="a11y-segments" role="radiogroup" aria-labelledby="a11yLblTextSize">' +
+              '<button type="button" class="a11y-seg" data-pref="textSize" data-value="0" aria-pressed="true">100%</button>' +
+              '<button type="button" class="a11y-seg" data-pref="textSize" data-value="1" aria-pressed="false">110%</button>' +
+              '<button type="button" class="a11y-seg" data-pref="textSize" data-value="2" aria-pressed="false">125%</button>' +
+              '<button type="button" class="a11y-seg" data-pref="textSize" data-value="3" aria-pressed="false">150%</button>' +
+            '</div></div>' +
+          '<div class="a11y-control"><span class="a11y-control-label" id="a11yLblTextAlign">Allineamento del testo</span>' +
+            '<div class="a11y-segments" role="radiogroup" aria-labelledby="a11yLblTextAlign">' +
+              '<button type="button" class="a11y-seg" data-pref="textAlign" data-value="default" aria-pressed="true">Predefinito</button>' +
+              '<button type="button" class="a11y-seg" data-pref="textAlign" data-value="left" aria-pressed="false">A sinistra</button>' +
+              '<button type="button" class="a11y-seg" data-pref="textAlign" data-value="justify" aria-pressed="false">Giustificato</button>' +
+            '</div></div>' +
+          '<div class="a11y-control"><span class="a11y-control-label" id="a11yLblFontFamily">Tipo carattere</span>' +
+            '<div class="a11y-segments a11y-segments-stack" role="radiogroup" aria-labelledby="a11yLblFontFamily">' +
+              '<button type="button" class="a11y-seg" data-pref="fontFamily" data-value="default" aria-pressed="true">Predefinito</button>' +
+              '<button type="button" class="a11y-seg" data-pref="fontFamily" data-value="readable" aria-pressed="false">Alta leggibilità</button>' +
+              '<button type="button" class="a11y-seg" data-pref="fontFamily" data-value="dyslexic" aria-pressed="false">Per dislessia (OpenDyslexic)</button>' +
+            '</div></div>' +
+          '<button type="button" class="a11y-toggle" data-pref="spacing" aria-pressed="false"><i class="bi bi-distribute-vertical me-2" aria-hidden="true"></i><span class="a11y-toggle-text">Spaziatura ampia (righe e lettere)</span><span class="a11y-toggle-state" aria-hidden="true">Off</span></button>' +
+          '<button type="button" class="a11y-toggle" data-pref="readingMode" aria-pressed="false"><i class="bi bi-book me-2" aria-hidden="true"></i><span class="a11y-toggle-text">Modalità lettura (sfondo crema + spaziatura)</span><span class="a11y-toggle-state" aria-hidden="true">Off</span></button>' +
+        '</fieldset>' +
+        '<fieldset class="a11y-section">' +
+          '<legend class="a11y-section-title"><i class="bi bi-volume-up-fill me-2" aria-hidden="true"></i>Lettura ad alta voce</legend>' +
+          '<div class="a11y-control"><span class="a11y-control-label" id="a11yLblTtsRate">Velocità di lettura</span>' +
+            '<div class="a11y-segments" role="radiogroup" aria-labelledby="a11yLblTtsRate">' +
+              '<button type="button" class="a11y-seg" data-pref="ttsRate" data-value="0.75" aria-pressed="false">Lenta</button>' +
+              '<button type="button" class="a11y-seg" data-pref="ttsRate" data-value="0.95" aria-pressed="true">Normale</button>' +
+              '<button type="button" class="a11y-seg" data-pref="ttsRate" data-value="1.15" aria-pressed="false">Veloce</button>' +
+            '</div></div>' +
+        '</fieldset>' +
+        '<fieldset class="a11y-section">' +
+          '<legend class="a11y-section-title"><i class="bi bi-eye-fill me-2" aria-hidden="true"></i>Visivo</legend>' +
+          '<div class="a11y-control"><span class="a11y-control-label" id="a11yLblContrast">Contrasto</span>' +
+            '<div class="a11y-segments a11y-segments-stack" role="radiogroup" aria-labelledby="a11yLblContrast">' +
+              '<button type="button" class="a11y-seg" data-pref="contrast" data-value="default" aria-pressed="true">Predefinito</button>' +
+              '<button type="button" class="a11y-seg" data-pref="contrast" data-value="high" aria-pressed="false">Alto (nero su bianco)</button>' +
+              '<button type="button" class="a11y-seg" data-pref="contrast" data-value="invert" aria-pressed="false">Invertito (bianco su nero)</button>' +
+              '<button type="button" class="a11y-seg" data-pref="contrast" data-value="yellow-black" aria-pressed="false">Giallo su nero</button>' +
+              '<button type="button" class="a11y-seg" data-pref="contrast" data-value="blue-cream" aria-pressed="false">Blu su crema</button>' +
+            '</div></div>' +
+          '<button type="button" class="a11y-toggle" data-pref="grayscale" aria-pressed="false"><i class="bi bi-circle-half me-2" aria-hidden="true"></i><span class="a11y-toggle-text">Scala di grigi</span><span class="a11y-toggle-state" aria-hidden="true">Off</span></button>' +
+          '<button type="button" class="a11y-toggle" data-pref="hideImages" aria-pressed="false"><i class="bi bi-image me-2" aria-hidden="true"></i><span class="a11y-toggle-text">Nascondi immagini decorative</span><span class="a11y-toggle-state" aria-hidden="true">Off</span></button>' +
+          '<button type="button" class="a11y-toggle" data-pref="pauseAnimations" aria-pressed="false"><i class="bi bi-pause-circle me-2" aria-hidden="true"></i><span class="a11y-toggle-text">Pausa animazioni</span><span class="a11y-toggle-state" aria-hidden="true">Off</span></button>' +
+        '</fieldset>' +
+        '<fieldset class="a11y-section">' +
+          '<legend class="a11y-section-title"><i class="bi bi-compass me-2" aria-hidden="true"></i>Orientamento</legend>' +
+          '<button type="button" class="a11y-toggle" data-pref="highlightLinks" aria-pressed="false"><i class="bi bi-link-45deg me-2" aria-hidden="true"></i><span class="a11y-toggle-text">Evidenzia tutti i link</span><span class="a11y-toggle-state" aria-hidden="true">Off</span></button>' +
+          '<button type="button" class="a11y-toggle" data-pref="bigCursor" aria-pressed="false"><i class="bi bi-cursor-fill me-2" aria-hidden="true"></i><span class="a11y-toggle-text">Cursore grande</span><span class="a11y-toggle-state" aria-hidden="true">Off</span></button>' +
+          '<a class="a11y-link-page" href="' + SITE_URL + '/accessibilita/"><i class="bi bi-info-circle me-2" aria-hidden="true"></i> Vai alla pagina Accessibilità del sito <i class="bi bi-arrow-right ms-auto" aria-hidden="true"></i></a>' +
+        '</fieldset>' +
+        '<fieldset class="a11y-section">' +
+          '<legend class="a11y-section-title"><i class="bi bi-square me-2" aria-hidden="true"></i>Pulsanti flottanti</legend>' +
+          '<button type="button" class="a11y-toggle" data-pref="hideAssistantFab" aria-pressed="false"><i class="bi bi-chat-dots me-2" aria-hidden="true"></i><span class="a11y-toggle-text">Nascondi pulsante Assistente virtuale</span><span class="a11y-toggle-state" aria-hidden="true">Off</span></button>' +
+          '<button type="button" class="a11y-toggle" data-pref="hideSosFab" aria-pressed="false"><i class="bi bi-telephone me-2" aria-hidden="true"></i><span class="a11y-toggle-text">Nascondi pulsante SOS 112</span><span class="a11y-toggle-state" aria-hidden="true">Off</span></button>' +
+        '</fieldset>' +
+        '<div class="a11y-status" role="status" aria-live="polite" id="a11yStatus"></div>' +
+      '</div>' +
+      '<footer class="a11y-dialog-footer">' +
+        '<button type="button" id="a11yReset" class="a11y-btn a11y-btn-secondary"><i class="bi bi-arrow-counterclockwise me-1" aria-hidden="true"></i> Reimposta tutto</button>' +
+        '<button type="button" id="a11yDialogCloseFooter" class="a11y-btn a11y-btn-primary"><i class="bi bi-check-lg me-1" aria-hidden="true"></i> Chiudi</button>' +
+      '</footer>' +
+    '</div>';
+
+  function wireSos() {
+    var btn = document.getElementById('sos-button');
+    var modal = document.getElementById('sos-modal');
+    var cancelBtn = document.getElementById('sos-modal-cancel');
+    var callBtn = document.getElementById('sos-modal-call');
+    if (!btn || !modal) return;
+    var lastFocused = null;
+    var focusableSel = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    function openModal() {
+      lastFocused = document.activeElement;
+      modal.hidden = false;
+      document.body.style.overflow = 'hidden';
+      setTimeout(function () { if (cancelBtn) cancelBtn.focus(); }, 30);
+      document.addEventListener('keydown', onKeyDown);
+    }
+    function closeModal() {
+      modal.hidden = true;
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', onKeyDown);
+      if (lastFocused && typeof lastFocused.focus === 'function') lastFocused.focus();
+    }
+    function onKeyDown(e) {
+      if (e.key === 'Escape') { e.preventDefault(); closeModal(); return; }
+      if (e.key === 'Tab') {
+        var focusables = modal.querySelectorAll(focusableSel);
+        if (!focusables.length) return;
+        var first = focusables[0];
+        var last = focusables[focusables.length - 1];
+        if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+        else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+      }
+    }
+    btn.addEventListener('click', openModal);
+    modal.querySelectorAll('[data-sos-close="true"]').forEach(function (el) {
+      el.addEventListener('click', function (e) {
+        if (el.classList.contains('sos-modal-backdrop') && e.target !== el) return;
+        closeModal();
+      });
+    });
+    if (callBtn) callBtn.addEventListener('click', function () { setTimeout(closeModal, 800); });
+  }
+
+  function injectA11yAndSos() {
+    // Idempotente: se la pagina ha già SOS o toolbar (es. include propri), non duplico.
+    if (document.getElementById('sos-button') || document.getElementById('a11yToolbarOpen')) return;
+
+    var sosWrap = document.createElement('div');
+    sosWrap.innerHTML = SOS_HTML;
+    while (sosWrap.firstChild) document.body.appendChild(sosWrap.firstChild);
+    wireSos();
+
+    var a11yWrap = document.createElement('div');
+    a11yWrap.innerHTML = A11Y_HTML;
+    while (a11yWrap.firstChild) document.body.appendChild(a11yWrap.firstChild);
+
+    // CSS della toolbar (file dedicato, non in custom.css).
+    if (!document.querySelector('link[data-a11y-toolbar]')) {
+      var link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = SITE_URL + '/css/a11y-toolbar.css';
+      link.setAttribute('data-a11y-toolbar', '1');
+      document.head.appendChild(link);
+    }
+    // JS della toolbar: applica le preferenze salvate su <html> e fa il
+    // wireup del dialog appena iniettato. Gestisce da sé il caso DOM già
+    // pronto (else { onReady() }), quindi va bene caricarlo dopo il markup.
+    if (!document.querySelector('script[data-a11y-toolbar]')) {
+      var sc = document.createElement('script');
+      sc.src = SITE_URL + '/js/a11y-toolbar.js';
+      sc.setAttribute('data-a11y-toolbar', '1');
+      document.body.appendChild(sc);
+    }
+  }
+
   function injectChrome() {
     var main = document.querySelector('main') || document.getElementById('main-content');
     if (!main) return;
@@ -323,6 +510,9 @@
     // Si attiva SOLO se la pagina ha marker tipici di un'app interattiva
     // (schermate intro/game/end). Esclude pagine hub e statiche.
     aggiungiPulsanteEsciGioco();
+
+    // SOS 112 + toolbar accessibilità anche sulle pagine statiche (audit 2026-05-22).
+    injectA11yAndSos();
   }
 
   function aggiungiPulsanteEsciGioco() {

--- a/themes/flavour-pcgenzano/layouts/partials/cookie-banner.html
+++ b/themes/flavour-pcgenzano/layouts/partials/cookie-banner.html
@@ -4,7 +4,7 @@
     <div class="row align-items-center">
       <div class="col-lg-9">
         <p style="color:#fff;margin-bottom:0;font-size:0.9rem;">
-          Questo sito utilizza esclusivamente <strong>cookie tecnici</strong> necessari al corretto funzionamento.
+          Questo sito utilizza solo <strong>cookie tecnici propri</strong>, necessari al corretto funzionamento. Alcune pagine possono caricare risorse di terze parti (mappe, meteo), descritte nella Cookie Policy.
           Per saperne di più consulta la nostra <a href="{{ "/privacy/" | relURL }}" style="color:#fff;font-weight:700;text-decoration:underline;">Cookie Policy</a>.
         </p>
       </div>


### PR DESCRIPTION
## Sintesi

Follow-up audit esterno (22/05/2026). Due correzioni di precisione, basse di rischio.

### P2 — Dichiarazione di accessibilità: perimetro reale
Le affermazioni assolute "tutte le pagine / l'intero sito" su navigazione da tastiera, skip link, landmark ARIA e TTS erano imprecise: la cornice istituzionale è **nativa** sulle pagine generate da Hugo, ma sulle mini-app statiche interattive (giochi, quiz, schede stampabili, Abili a Proteggere) è **iniettata via JavaScript** da `site-chrome.js` e richiede JS attivo. Riformulate in modo prudente e documentabile (AGID: la dichiarazione deve riflettere il perimetro reale). `dataUltimaRevisione` → 2026-05-22.

### P4 — Banner cookie più preciso
Da "esclusivamente cookie tecnici" a "solo cookie tecnici **propri**", con menzione delle risorse di terze parti (mappe, meteo) descritte nella Cookie Policy. Coerente con quanto già spiegato nella privacy policy (OpenStreetMap/Windy).

## Nota
Il punto 1 dell'audit ("pagine giochi senza header/footer/privacy") è risultato un **abbaglio diagnostico**: header/nav/footer + link Privacy/Note Legali/Accessibilità sono presenti su 122 pagine statiche via `site-chrome.js`. L'unico gap reale (SOS 112 + toolbar a11y) è già stato chiuso in #310.

I punti P3 (etichette orari Stato del sistema) e P5 (fonti dei numeri celebrativi in homepage) restano in attesa di input editoriale.

## Test
- [x] Edit puntuali, sintassi template invariata
- [x] Frontmatter YAML valido
- [ ] Build Hugo + smoke test (post-deploy CI)

https://claude.ai/code/session_01DL8Cy3ptTGdLuVxdAHvsmH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DL8Cy3ptTGdLuVxdAHvsmH)_