### PR TITLE
Refusi lessicali: coltre, videogiochi, rinaturalizza, torcia

### DIFF
--- a/content/comunicazioni/2026-04-22-giornata-della-terra-clima-eventi-estremi-castelli-romani.md
+++ b/content/comunicazioni/2026-04-22-giornata-della-terra-clima-eventi-estremi-castelli-romani.md
@@ -64,7 +64,7 @@ La Protezione Civile non si occupa solo di intervenire quando il danno è fatto.
 
 ### Nelle scelte collettive
 
-La transizione ecologica è anche una **politica di protezione civile**. Più il sistema nel suo complesso riduce le emissioni e rinatura il territorio, meno frequenti saranno gli eventi estremi di cui poi tocca gestire le conseguenze.
+La transizione ecologica è anche una **politica di protezione civile**. Più il sistema nel suo complesso riduce le emissioni e rinaturalizza il territorio, meno frequenti saranno gli eventi estremi di cui poi tocca gestire le conseguenze.
 
 ## Conoscere il territorio è prevenzione
 

--- a/content/comunicazioni/2026-04-29-nascita-dipartimento-protezione-civile-italia.md
+++ b/content/comunicazioni/2026-04-29-nascita-dipartimento-protezione-civile-italia.md
@@ -14,7 +14,7 @@ draft: false
 toc: true
 ---
 
-C'è una fotografia che racconta meglio di ogni discorso da cosa nasce il Dipartimento della Protezione Civile italiana. La scattano le agenzie nei giorni successivi al **23 novembre 1980**, lungo le strade dell'Irpinia. Si vedono case spaccate a metà, coperte da una garbatella di polvere e cemento, e ai bordi della strada uomini in abiti civili che scavano a mani nude. Non sono soccorritori: sono parenti delle vittime. I soccorsi organizzati arriveranno **dopo cinque giorni**. Gli abitanti di **Sant'Angelo dei Lombardi**, di **Conza della Campania**, di **Lioni**, di **Laviano**, in quei cinque giorni sentono ancora qualcuno respirare sotto le macerie. Poi, lentamente, sentono solo il silenzio.
+C'è una fotografia che racconta meglio di ogni discorso da cosa nasce il Dipartimento della Protezione Civile italiana. La scattano le agenzie nei giorni successivi al **23 novembre 1980**, lungo le strade dell'Irpinia. Si vedono case spaccate a metà, coperte da una coltre di polvere e cemento, e ai bordi della strada uomini in abiti civili che scavano a mani nude. Non sono soccorritori: sono parenti delle vittime. I soccorsi organizzati arriveranno **dopo cinque giorni**. Gli abitanti di **Sant'Angelo dei Lombardi**, di **Conza della Campania**, di **Lioni**, di **Laviano**, in quei cinque giorni sentono ancora qualcuno respirare sotto le macerie. Poi, lentamente, sentono solo il silenzio.
 
 Quel silenzio diventa un atto di accusa. Diventa la domanda che farà il presidente Sandro Pertini in televisione, due settimane dopo, con la voce che gli si rompe più volte: «**Dove sono stati lo Stato e i suoi Vigili del Fuoco?**».
 

--- a/content/comunicazioni/2026-05-15-giornata-famiglie-piano-emergenza-insieme.md
+++ b/content/comunicazioni/2026-05-15-giornata-famiglie-piano-emergenza-insieme.md
@@ -35,7 +35,7 @@ Un **contatto fuori zona** — un parente o un amico che vive in un'altra città
 
 Preparare insieme lo **zaino di emergenza domestico** è un'attività da fare **in famiglia**, non delegata a uno solo. I bambini:
 
-- Partecipano con qualcosa di loro (una torcina, un gioco preferito, un libro).
+- Partecipano con qualcosa di loro (una torcia, un gioco preferito, un libro).
 - Imparano dove si trova lo zaino.
 - Ricordano meglio il senso del kit.
 

--- a/content/comunicazioni/2026-12-06-san-nicola-tradizione-bambini.md
+++ b/content/comunicazioni/2026-12-06-san-nicola-tradizione-bambini.md
@@ -115,7 +115,7 @@ Cogliamo l'occasione per ripassare alcuni principi di **sicurezza dei bambini** 
 - **contenuti** inappropriati;
 - **cyberbullismo**;
 - **predatori** online;
-- **gaming** addictivi;
+- **videogiochi** che creano dipendenza;
 - **social** e immagine di sé.
 
 ### Strumenti di protezione


### PR DESCRIPTION
Le 4 correzioni di significato dallo sweep refusi, confermate dall'utente:
- garbatella di polvere → **coltre** di polvere (nascita DPC)
- gaming addictivi → **videogiochi che creano dipendenza** (San Nicola)
- rinatura il territorio → **rinaturalizza** il territorio (Giornata Terra)
- una torcina → una **torcia** (Giornata famiglie)

Build Hugo pulita.