### PR TITLE
Schede letto-scrittura PC: alfabetiere A-Z + 4 schede leggere/scrivere

### DIFF
--- a/content/formazione/kit-scuola-infanzia.md
+++ b/content/formazione/kit-scuola-infanzia.md
@@ -262,6 +262,7 @@ Le altre schede di questa sezione sono <strong>spunti operativi</strong> con cui
 **Schede di letto-scrittura** a tema Protezione Civile per il pre-grafismo e il riconoscimento delle prime parole (5-6 anni):
 
 - 👉 [**ABC delle Vocali — Le parole che salvano**](/formazione/schede-stampabili/abc-vocali-infanzia/) — le 5 vocali abbinate a parole della Protezione Civile (A→AIUTO, E→ELMETTO, I→IDRANTE, O→OSPEDALE, U→USCITA), lettera da ricalcare e parola da ricopiare.
+- 👉 [**L'Alfabetiere della Sicurezza (A→Z)**](/formazione/schede-stampabili/alfabetiere-pc-infanzia/) — l'alfabeto completo: ogni lettera abbinata a una parola della Protezione Civile (A→ACQUA, C→CASCO, P→POMPIERE…) con la lettera da ricalcare. Completa l'ABC delle Vocali con tutte le 21 lettere. Adatta anche per la classe 1ª.
 - 👉 [**Riconosci l'Iniziale**](/formazione/schede-stampabili/riconosci-iniziale-infanzia/) — per ogni immagine il bambino cerchia la lettera con cui inizia la parola, fra tre opzioni. 10 parole-chiave della sicurezza.
 - 👉 [**Collega la Parola all'Immagine**](/formazione/schede-stampabili/collega-parola-immagine-infanzia/) — 8 parole in stampatello da collegare con una linea alle 8 immagini in colonna a destra. Adatta anche per la classe 1ª.
 

--- a/content/formazione/kit-scuola-primaria.md
+++ b/content/formazione/kit-scuola-primaria.md
@@ -496,6 +496,10 @@ Le altre schede di questa sezione sono <strong>spunti operativi</strong> con cui
 - 👉 [**Sillabe della Protezione Civile**](/formazione/schede-stampabili/sillabe-protezione-civile-primaria/) — parole-chiave divise in sillabe (CA·SCO, SI·RE·NA, POM·PIE·RE…), esercizio di divisione, ricomposizione di puzzle sillabici e copiatura di una frase. Soluzioni per il docente.
 - 👉 [**Completa la Parola**](/formazione/schede-stampabili/completa-parola-primaria/) — 10 parole con una lettera mancante da completare usando la "banca delle lettere", più 4 parole intere da scrivere a partire dall'indizio. Soluzioni incluse.
 - 👉 [**Copia la Frase — Le parole della sicurezza**](/formazione/schede-stampabili/copia-frase-primaria/) — 5 frasi semplici sulle regole di autoprotezione (chiamata 112, posizione tartaruga, evacuazione, volontariato) da ricopiare in stampatello su righe con linea-guida.
+- 👉 [**Ricalca e Scrivi le Parole**](/formazione/schede-stampabili/ricalca-scrivi-parole-primaria/) — l'alunno ricalca la parola tratteggiata (CASA, ACQUA, 112, ZAINO, CASCO, AIUTO, USCITA, RADIO) e poi la riscrive da solo sulla riga. Il primo passo per imparare a scrivere in stampatello.
+- 👉 [**Maiuscolo e Minuscolo**](/formazione/schede-stampabili/maiuscolo-minuscolo-primaria/) — collega ogni lettera grande alla sua piccola, scrivi la minuscola accanto alla maiuscola e scopri che CASCO e casco sono la stessa parola. Soluzioni incluse.
+- 👉 [**Dettato Illustrato**](/formazione/schede-stampabili/dettato-illustrato-primaria/) — guarda la figura e scrivi da solo il nome dell'oggetto della sicurezza (pompiere, ambulanza, casco…), con la prima lettera come aiuto. Anche come dettato letto dall'insegnante. Soluzioni incluse.
+- 👉 [**Le Prime Frasi della Sicurezza**](/formazione/schede-stampabili/prime-frasi-sicurezza-primaria/) — rimetti in ordine le parole e scrivi frasi vere di autoprotezione ("Chiamo il 112.", "Metto il casco."), con maiuscola all'inizio e punto alla fine. Soluzioni incluse.
 
 **Schede curriculari trasversali** a tema Protezione Civile (classi 1ª-4ª):
 

--- a/scripts/dizionario-pc.txt
+++ b/scripts/dizionario-pc.txt
@@ -292,3 +292,4 @@ raffrescamento
 phon
 gazpacho
 evapotraspirazione
+alfabetiere

--- a/static/formazione/schede-stampabili/alfabetiere-pc-infanzia/index.html
+++ b/static/formazione/schede-stampabili/alfabetiere-pc-infanzia/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="it" dir="ltr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Scheda stampabile: Alfabetiere della Protezione Civile (A→Z)</title>
+  <meta name="description" content="Scheda fotocopiabile: l'alfabeto completo dalla A alla Z, ogni lettera abbinata a una parola della Protezione Civile, con la lettera da ricalcare. Per imparare a leggere e scrivere.">
+  <meta name="robots" content="index, follow">
+  <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
+  <link rel="stylesheet" href="/formazione/schede-stampabili/assets/scheda-print.css">
+  <style>
+    .alf-griglia {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 0.45rem;
+      margin: 0.5rem 0;
+    }
+    .alf-cella {
+      border: 1.5px solid var(--scheda-bordo);
+      border-radius: 8px;
+      padding: 0.4rem 0.5rem;
+      display: flex;
+      align-items: center;
+      gap: 0.55rem;
+    }
+    .alf-lettera {
+      font-family: "Trebuchet MS", "Arial Rounded MT Bold", sans-serif;
+      font-weight: 700;
+      font-size: 1.7rem;
+      line-height: 1;
+      color: var(--scheda-blu);
+      width: 2.5rem;
+      text-align: center;
+      flex-shrink: 0;
+    }
+    .alf-lettera small { display: block; font-size: 1.05rem; color: var(--scheda-grigio); }
+    .alf-corpo { flex: 1; min-width: 0; }
+    .alf-parola {
+      font-family: "Trebuchet MS", "Arial Rounded MT Bold", sans-serif;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      font-size: 0.92rem;
+      line-height: 1.1;
+    }
+    .alf-parola b { color: var(--scheda-rosso); }
+    .alf-emo { font-size: 1.25rem; line-height: 1; }
+    .alf-traccia {
+      margin-top: 0.15rem;
+      font-family: "Trebuchet MS", "Arial Rounded MT Bold", sans-serif;
+      font-size: 1.25rem;
+      letter-spacing: 0.45em;
+      color: #cfd5db;
+      border-bottom: 1px dashed var(--scheda-bordo);
+    }
+    .alf-nota-cella {
+      font-size: 0.72rem;
+      color: #495057;
+      line-height: 1.25;
+    }
+    .alf-straniere {
+      margin-top: 0.7rem;
+      background: #eaf2fb;
+      border: 2px dashed var(--scheda-blu);
+      border-radius: 8px;
+      padding: 0.5rem 0.7rem;
+      font-size: 0.85rem;
+      line-height: 1.45;
+    }
+    .alf-straniere .lett {
+      font-family: "Trebuchet MS", "Arial Rounded MT Bold", sans-serif;
+      font-weight: 700;
+      color: var(--scheda-blu);
+      font-size: 1.1rem;
+      letter-spacing: 0.1em;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="scheda-toolbar no-print">
+    <a href="/formazione/schede-stampabili/" aria-label="Torna alle schede">← Torna alle schede</a>
+    <span class="scheda-titolo">Alfabetiere della PC — Infanzia / 1ª</span>
+    <button type="button" onclick="window.print()">🖨️ Stampa o salva come PDF</button>
+  </div>
+
+  <article class="scheda-page">
+
+    <header class="scheda-header">
+      <div class="scheda-logo" aria-hidden="true">PC</div>
+      <div class="scheda-intestazione">
+        <div class="scheda-ente">Protezione Civile — Genzano di Roma</div>
+        <h1 class="scheda-titolo-principale">L'alfabetiere della sicurezza</h1>
+        <div class="scheda-sottotitolo">Scheda fotocopiabile — dall'ultimo anno della Scuola dell'Infanzia alla 1ª Primaria</div>
+      </div>
+    </header>
+
+    <div class="scheda-meta">
+      <span><strong>Destinatari:</strong> 5-6 anni</span>
+      <span><strong>Obiettivo:</strong> riconoscere le lettere e leggere le prime parole</span>
+      <span><strong>Servono:</strong> matita e colori</span>
+    </div>
+
+    <p class="scheda-intro">
+      Ogni lettera dell'alfabeto è abbinata a una <strong>parola della Protezione Civile</strong>. Leggi la lettera grande e quella piccola, dì la parola ad alta voce e <strong>ricalca la lettera tratteggiata</strong> in basso.
+    </p>
+
+    <div class="alf-griglia">
+      <div class="alf-cella"><div class="alf-lettera">A<small>a</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">💧</span> <b>A</b>CQUA</div><div class="alf-traccia" aria-hidden="true">A A A</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">B<small>b</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🧭</span> <b>B</b>USSOLA</div><div class="alf-traccia" aria-hidden="true">B B B</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">C<small>c</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">⛑️</span> <b>C</b>ASCO</div><div class="alf-traccia" aria-hidden="true">C C C</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">D<small>d</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🦺</span> <b>D</b>IVISA</div><div class="alf-traccia" aria-hidden="true">D D D</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">E<small>e</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🧯</span> <b>E</b>STINTORE</div><div class="alf-traccia" aria-hidden="true">E E E</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">F<small>f</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🔥</span> <b>F</b>UOCO</div><div class="alf-traccia" aria-hidden="true">F F F</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">G<small>g</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🧤</span> <b>G</b>UANTI</div><div class="alf-traccia" aria-hidden="true">G G G</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">H<small>h</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🤫</span> <b>H</b> muta</div><div class="alf-nota-cella">La H non ha suono: aiuta altre lettere (es. <em>chiamo</em>).</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">I<small>i</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🚰</span> <b>I</b>DRANTE</div><div class="alf-traccia" aria-hidden="true">I I I</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">L<small>l</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🚨</span> <b>L</b>AMPEGGIANTE</div><div class="alf-traccia" aria-hidden="true">L L L</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">M<small>m</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🗺️</span> <b>M</b>APPA</div><div class="alf-traccia" aria-hidden="true">M M M</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">N<small>n</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">❄️</span> <b>N</b>EVE</div><div class="alf-traccia" aria-hidden="true">N N N</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">O<small>o</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🏥</span> <b>O</b>SPEDALE</div><div class="alf-traccia" aria-hidden="true">O O O</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">P<small>p</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">👨‍🚒</span> <b>P</b>OMPIERE</div><div class="alf-traccia" aria-hidden="true">P P P</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">Q<small>q</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">💧</span> ac<b>Q</b>UA</div><div class="alf-nota-cella">La Q va sempre con la U: ac<strong>QU</strong>a.</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">R<small>r</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">📻</span> <b>R</b>ADIO</div><div class="alf-traccia" aria-hidden="true">R R R</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">S<small>s</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🆘</span> <b>S</b>OCCORSO</div><div class="alf-traccia" aria-hidden="true">S S S</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">T<small>t</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🔦</span> <b>T</b>ORCIA</div><div class="alf-traccia" aria-hidden="true">T T T</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">U<small>u</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🚪</span> <b>U</b>SCITA</div><div class="alf-traccia" aria-hidden="true">U U U</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">V<small>v</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🤝</span> <b>V</b>OLONTARIO</div><div class="alf-traccia" aria-hidden="true">V V V</div></div></div>
+      <div class="alf-cella"><div class="alf-lettera">Z<small>z</small></div><div class="alf-corpo"><div class="alf-parola"><span class="alf-emo" aria-hidden="true">🎒</span> <b>Z</b>AINO</div><div class="alf-traccia" aria-hidden="true">Z Z Z</div></div></div>
+    </div>
+
+    <div class="alf-straniere">
+      <strong style="color: var(--scheda-blu);">Le 5 lettere "ospiti"</strong> — non sono nell'alfabeto italiano, ma le trovi in alcune parole utili:
+      <span class="lett">J K W X Y</span>. Per esempio la <strong>K</strong> di <strong>KIT</strong> (il kit di emergenza che tieni in casa).
+    </div>
+
+    <div class="scheda-docente">
+      <strong>Per la maestra/maestro:</strong>
+      <ul style="margin: 0.3rem 0 0 1rem; padding: 0;">
+        <li>Far leggere la lettera (maiuscola e minuscola), poi la parola scandendo le sillabe; infine ricalcare la lettera tratteggiata e provare a riscriverla a fianco.</li>
+        <li><strong>Estensione orale:</strong> chiedere un'altra parola che inizia con la stessa lettera; per le parole della sicurezza, spiegare a cosa serve l'oggetto (es. il casco protegge la testa).</li>
+        <li>La scheda completa l'<em>ABC delle Vocali</em> (solo A, E, I, O, U): qui ci sono tutte le 21 lettere dell'alfabeto italiano più le 5 lettere straniere.</li>
+      </ul>
+    </div>
+
+    <footer class="scheda-footer">
+      <span class="scheda-site">protezionecivilegenzano.it</span>
+      <span>Scheda "Alfabetiere della sicurezza" · Infanzia 5-6 anni / 1ª Primaria · letto-scrittura · rev. 2026</span>
+    </footer>
+
+  </article>
+
+</body>
+</html>

--- a/static/formazione/schede-stampabili/assets/scheda-print.css
+++ b/static/formazione/schede-stampabili/assets/scheda-print.css
@@ -383,7 +383,7 @@ ol.scheda-elenco li {
   margin: 0.5rem 0;
 }
 .scheda-soluzioni strong {
-  color: var(--scheda-verde);
+  color: #0f5132;
 }
 
 /* Box nota locale "Approfondimenti per Genzano" */
@@ -501,7 +501,7 @@ table.scheda-tabella th {
   border-left: 4px solid var(--scheda-verde);
   font-size: 0.85rem;
 }
-.scheda-docente strong { color: var(--scheda-verde); }
+.scheda-docente strong { color: #0f5132; }
 
 /* Box "Pro / Contro / Lezioni" delle schede caso studio (3 colonne) */
 .scheda-pro-contro {

--- a/static/formazione/schede-stampabili/dettato-illustrato-primaria/index.html
+++ b/static/formazione/schede-stampabili/dettato-illustrato-primaria/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="it" dir="ltr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Scheda stampabile: Dettato illustrato (Primaria 1ª-2ª)</title>
+  <meta name="description" content="Scheda fotocopiabile per la Scuola Primaria: guarda l'immagine e scrivi da solo il nome dell'oggetto della Protezione Civile. Esercizio di scrittura autonoma.">
+  <meta name="robots" content="index, follow">
+  <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
+  <link rel="stylesheet" href="/formazione/schede-stampabili/assets/scheda-print.css">
+  <style>
+    .di-griglia {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 0.7rem;
+      margin: 0.6rem 0;
+    }
+    .di-cella {
+      border: 1.5px solid var(--scheda-bordo);
+      border-radius: 10px;
+      padding: 0.6rem 0.5rem 0.7rem;
+      text-align: center;
+    }
+    .di-emo { font-size: 2.6rem; line-height: 1; }
+    .di-riga {
+      margin-top: 0.6rem;
+      border-bottom: 2px solid var(--scheda-bordo);
+      min-height: 1.7rem;
+    }
+    .di-iniziale {
+      font-size: 0.78rem;
+      color: var(--scheda-grigio);
+      margin-top: 0.2rem;
+    }
+    .di-iniziale b { color: var(--scheda-blu); font-size: 0.95rem; }
+  </style>
+</head>
+<body>
+
+  <div class="scheda-toolbar no-print">
+    <a href="/formazione/schede-stampabili/" aria-label="Torna alle schede">← Torna alle schede</a>
+    <span class="scheda-titolo">Dettato illustrato — Primaria 1ª-2ª</span>
+    <button type="button" onclick="window.print()">🖨️ Stampa o salva come PDF</button>
+  </div>
+
+  <article class="scheda-page">
+
+    <header class="scheda-header">
+      <div class="scheda-logo" aria-hidden="true">PC</div>
+      <div class="scheda-intestazione">
+        <div class="scheda-ente">Protezione Civile — Genzano di Roma</div>
+        <h1 class="scheda-titolo-principale">Dettato illustrato</h1>
+        <div class="scheda-sottotitolo">Scheda fotocopiabile — Scuola Primaria (classi 1ª-2ª)</div>
+      </div>
+    </header>
+
+    <div class="scheda-meta">
+      <span><strong>Destinatari:</strong> 6-7 anni</span>
+      <span><strong>Obiettivo:</strong> scrivere da soli la parola giusta guardando l'immagine</span>
+      <span><strong>Servono:</strong> matita</span>
+    </div>
+
+    <p class="scheda-intro">
+      Guarda ogni figura, dì il suo nome ad alta voce e <strong>scrivilo sulla riga</strong>. Sotto ogni riga c'è la <strong>prima lettera</strong> per aiutarti a partire.
+    </p>
+
+    <div class="di-griglia">
+      <div class="di-cella"><div class="di-emo" aria-hidden="true">👨‍🚒</div><div class="di-riga" aria-hidden="true"></div><div class="di-iniziale">inizia con <b>P</b></div></div>
+      <div class="di-cella"><div class="di-emo" aria-hidden="true">🚑</div><div class="di-riga" aria-hidden="true"></div><div class="di-iniziale">inizia con <b>A</b></div></div>
+      <div class="di-cella"><div class="di-emo" aria-hidden="true">⛑️</div><div class="di-riga" aria-hidden="true"></div><div class="di-iniziale">inizia con <b>C</b></div></div>
+      <div class="di-cella"><div class="di-emo" aria-hidden="true">🧭</div><div class="di-riga" aria-hidden="true"></div><div class="di-iniziale">inizia con <b>B</b></div></div>
+      <div class="di-cella"><div class="di-emo" aria-hidden="true">🎒</div><div class="di-riga" aria-hidden="true"></div><div class="di-iniziale">inizia con <b>Z</b></div></div>
+      <div class="di-cella"><div class="di-emo" aria-hidden="true">🔦</div><div class="di-riga" aria-hidden="true"></div><div class="di-iniziale">inizia con <b>T</b></div></div>
+      <div class="di-cella"><div class="di-emo" aria-hidden="true">🗺️</div><div class="di-riga" aria-hidden="true"></div><div class="di-iniziale">inizia con <b>M</b></div></div>
+      <div class="di-cella"><div class="di-emo" aria-hidden="true">📻</div><div class="di-riga" aria-hidden="true"></div><div class="di-iniziale">inizia con <b>R</b></div></div>
+      <div class="di-cella"><div class="di-emo" aria-hidden="true">🏥</div><div class="di-riga" aria-hidden="true"></div><div class="di-iniziale">inizia con <b>O</b></div></div>
+    </div>
+
+    <div style="background: #eaf2fb; border-left: 4px solid var(--scheda-blu); padding: 0.55rem 0.85rem; border-radius: 0 8px 8px 0; margin: 0.5rem 0; font-size: 0.92rem;">
+      <strong style="color: var(--scheda-blu);">🆘 Il numero più importante</strong><br>
+      Scrivi nel riquadro il numero da chiamare in caso di emergenza:
+      <span style="display:inline-block; min-width:5rem; border-bottom:2px solid var(--scheda-blu); height:1.6rem; vertical-align:bottom;" aria-hidden="true"></span>
+    </div>
+
+    <div class="scheda-docente">
+      <strong>Per la maestra/maestro — soluzioni:</strong>
+      <ul style="margin: 0.3rem 0 0 1rem; padding: 0;">
+        <li>POMPIERE (o VIGILE DEL FUOCO), AMBULANZA, CASCO, BUSSOLA, ZAINO, TORCIA, MAPPA, RADIO, OSPEDALE.</li>
+        <li>Il numero da scrivere è <strong>112</strong>.</li>
+        <li>Si può svolgere come <strong>dettato</strong> (l'insegnante legge la parola, l'alunno la scrive) o in autonomia guardando solo l'immagine e l'iniziale.</li>
+      </ul>
+    </div>
+
+    <footer class="scheda-footer">
+      <span class="scheda-site">protezionecivilegenzano.it</span>
+      <span>Scheda "Dettato illustrato" · Primaria 1ª-2ª · letto-scrittura · rev. 2026</span>
+    </footer>
+
+  </article>
+
+</body>
+</html>

--- a/static/formazione/schede-stampabili/index.html
+++ b/static/formazione/schede-stampabili/index.html
@@ -701,6 +701,16 @@
         </div>
         <div class="col-md-6 col-lg-4">
           <div class="scheda-card">
+            <div class="scheda-card-icon infanzia"><i class="bi bi-alphabet" aria-hidden="true"></i></div>
+            <span class="scheda-fascia">Infanzia 5-6 / 1ª · letto-scrittura</span>
+            <h3>L'Alfabetiere della Sicurezza</h3>
+            <div class="scheda-meta"><span><i class="bi bi-pencil me-1" aria-hidden="true"></i>matita, colori</span><span><i class="bi bi-clock me-1" aria-hidden="true"></i>20-30 min</span></div>
+            <p class="scheda-desc">L'alfabeto completo dalla A alla Z: ogni lettera abbinata a una parola della Protezione Civile (A→ACQUA, C→CASCO, P→POMPIERE…) con la lettera da ricalcare. Completa l'ABC delle Vocali con tutte le 21 lettere.</p>
+            <a href="alfabetiere-pc-infanzia/" class="btn btn-primary"><i class="bi bi-printer me-1" aria-hidden="true"></i>Apri e stampa</a>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <div class="scheda-card">
             <div class="scheda-card-icon infanzia"><i class="bi bi-circle" aria-hidden="true"></i></div>
             <span class="scheda-fascia">Infanzia · 5-6 anni · letto-scrittura</span>
             <h3>Riconosci l'Iniziale</h3>
@@ -894,6 +904,46 @@
             <div class="scheda-meta"><span><i class="bi bi-clock me-1" aria-hidden="true"></i>20-30 min</span><span><i class="bi bi-pencil me-1" aria-hidden="true"></i>matita</span></div>
             <p class="scheda-desc">10 parole con una lettera mancante (C__SCO, S_R_NA…) da completare usando la "banca delle lettere". Seconda sezione: scrivi tu la parola intera dato l'indizio. Soluzioni incluse.</p>
             <a href="completa-parola-primaria/" class="btn btn-primary"><i class="bi bi-printer me-1" aria-hidden="true"></i>Apri e stampa</a>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <div class="scheda-card">
+            <div class="scheda-card-icon primaria"><i class="bi bi-pencil-square" aria-hidden="true"></i></div>
+            <span class="scheda-fascia">Primaria · classe 1ª · letto-scrittura</span>
+            <h3>Ricalca e Scrivi le Parole</h3>
+            <div class="scheda-meta"><span><i class="bi bi-clock me-1" aria-hidden="true"></i>20-30 min</span><span><i class="bi bi-pencil me-1" aria-hidden="true"></i>matita</span></div>
+            <p class="scheda-desc">L'alunno ricalca la parola tratteggiata (CASA, ACQUA, 112, ZAINO, CASCO…) e poi la riscrive da solo sulla riga. Per imparare a scrivere in stampatello.</p>
+            <a href="ricalca-scrivi-parole-primaria/" class="btn btn-primary"><i class="bi bi-printer me-1" aria-hidden="true"></i>Apri e stampa</a>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <div class="scheda-card">
+            <div class="scheda-card-icon primaria"><i class="bi bi-type" aria-hidden="true"></i></div>
+            <span class="scheda-fascia">Primaria · classe 1ª · letto-scrittura</span>
+            <h3>Maiuscolo e Minuscolo</h3>
+            <div class="scheda-meta"><span><i class="bi bi-clock me-1" aria-hidden="true"></i>20 min</span><span><i class="bi bi-pencil me-1" aria-hidden="true"></i>matita</span></div>
+            <p class="scheda-desc">Collega ogni lettera grande alla sua piccola, scrivi la minuscola accanto alla maiuscola e scopri che CASCO e casco sono la stessa parola. Soluzioni incluse.</p>
+            <a href="maiuscolo-minuscolo-primaria/" class="btn btn-primary"><i class="bi bi-printer me-1" aria-hidden="true"></i>Apri e stampa</a>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <div class="scheda-card">
+            <div class="scheda-card-icon primaria"><i class="bi bi-image" aria-hidden="true"></i></div>
+            <span class="scheda-fascia">Primaria · classi 1ª-2ª · letto-scrittura</span>
+            <h3>Dettato Illustrato</h3>
+            <div class="scheda-meta"><span><i class="bi bi-clock me-1" aria-hidden="true"></i>20-30 min</span><span><i class="bi bi-pencil me-1" aria-hidden="true"></i>matita</span></div>
+            <p class="scheda-desc">Guarda la figura e scrivi da solo il nome dell'oggetto della sicurezza (pompiere, ambulanza, casco…). C'è la prima lettera come aiuto. Soluzioni incluse.</p>
+            <a href="dettato-illustrato-primaria/" class="btn btn-primary"><i class="bi bi-printer me-1" aria-hidden="true"></i>Apri e stampa</a>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <div class="scheda-card">
+            <div class="scheda-card-icon primaria"><i class="bi bi-card-text" aria-hidden="true"></i></div>
+            <span class="scheda-fascia">Primaria · classi 1ª-2ª · letto-scrittura</span>
+            <h3>Le Prime Frasi della Sicurezza</h3>
+            <div class="scheda-meta"><span><i class="bi bi-clock me-1" aria-hidden="true"></i>20-30 min</span><span><i class="bi bi-pencil me-1" aria-hidden="true"></i>matita</span></div>
+            <p class="scheda-desc">Rimetti in ordine le parole e scrivi frasi vere di autoprotezione ("Chiamo il 112.", "Metto il casco."), con maiuscola e punto. Soluzioni incluse.</p>
+            <a href="prime-frasi-sicurezza-primaria/" class="btn btn-primary"><i class="bi bi-printer me-1" aria-hidden="true"></i>Apri e stampa</a>
           </div>
         </div>
         <div class="col-md-6 col-lg-4">

--- a/static/formazione/schede-stampabili/maiuscolo-minuscolo-primaria/index.html
+++ b/static/formazione/schede-stampabili/maiuscolo-minuscolo-primaria/index.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="it" dir="ltr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Scheda stampabile: Maiuscolo e minuscolo (Primaria 1ª)</title>
+  <meta name="description" content="Scheda fotocopiabile per la Scuola Primaria: collega ogni lettera maiuscola alla sua minuscola e scrivi le coppie, usando parole della Protezione Civile.">
+  <meta name="robots" content="index, follow">
+  <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
+  <link rel="stylesheet" href="/formazione/schede-stampabili/assets/scheda-print.css">
+  <style>
+    .sezione-titolo { display: flex; align-items: baseline; gap: 0.6rem; margin: 1rem 0 0.5rem 0; }
+    .sezione-titolo .num {
+      width: 1.8rem; height: 1.8rem; background: var(--scheda-blu); color: #fff;
+      border-radius: 50%; display: inline-flex; align-items: center; justify-content: center;
+      font-weight: 700; font-size: 1rem; flex-shrink: 0;
+    }
+    .sezione-titolo h2 { font-size: 1.05rem; color: var(--scheda-blu); margin: 0; }
+
+    .mm-collega { display: flex; justify-content: space-between; gap: 2rem; margin: 0.6rem 0; }
+    .mm-col { display: flex; flex-direction: column; gap: 0.55rem; }
+    .mm-pallino {
+      font-family: "Trebuchet MS", "Arial Rounded MT Bold", sans-serif;
+      font-weight: 700; font-size: 1.5rem; color: var(--scheda-blu);
+      border: 1.5px solid var(--scheda-bordo); border-radius: 8px;
+      width: 3.4rem; height: 2.6rem; display: flex; align-items: center; justify-content: center;
+    }
+    .mm-col.min .mm-pallino { color: var(--scheda-rosso); }
+
+    .mm-griglia { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.5rem; margin: 0.5rem 0; }
+    .mm-cella {
+      border: 1.5px solid var(--scheda-bordo); border-radius: 8px; padding: 0.4rem;
+      display: flex; align-items: center; justify-content: center; gap: 0.5rem;
+    }
+    .mm-cella .grande {
+      font-family: "Trebuchet MS", "Arial Rounded MT Bold", sans-serif;
+      font-weight: 700; font-size: 1.6rem; color: var(--scheda-blu);
+    }
+    .mm-cella .sep { color: var(--scheda-grigio); }
+    .mm-cella .vuoto { display: inline-block; min-width: 1.6rem; border-bottom: 2px solid var(--scheda-bordo); height: 1.6rem; }
+  </style>
+</head>
+<body>
+
+  <div class="scheda-toolbar no-print">
+    <a href="/formazione/schede-stampabili/" aria-label="Torna alle schede">← Torna alle schede</a>
+    <span class="scheda-titolo">Maiuscolo e minuscolo — Primaria 1ª</span>
+    <button type="button" onclick="window.print()">🖨️ Stampa o salva come PDF</button>
+  </div>
+
+  <article class="scheda-page">
+
+    <header class="scheda-header">
+      <div class="scheda-logo" aria-hidden="true">PC</div>
+      <div class="scheda-intestazione">
+        <div class="scheda-ente">Protezione Civile — Genzano di Roma</div>
+        <h1 class="scheda-titolo-principale">Maiuscolo e minuscolo</h1>
+        <div class="scheda-sottotitolo">Scheda fotocopiabile — Scuola Primaria (classe 1ª)</div>
+      </div>
+    </header>
+
+    <div class="scheda-meta">
+      <span><strong>Destinatari:</strong> 6 anni</span>
+      <span><strong>Obiettivo:</strong> riconoscere la stessa lettera in grande e in piccolo</span>
+      <span><strong>Servono:</strong> matita</span>
+    </div>
+
+    <p class="scheda-intro">
+      Ogni lettera si scrive in due modi: <strong>grande</strong> (maiuscola) e <strong>piccola</strong> (minuscola). Sono la stessa lettera! Impara a riconoscerle: ti servono per leggere ogni parola.
+    </p>
+
+    <div class="sezione-titolo">
+      <span class="num">1</span>
+      <h2>Collega ogni lettera grande alla sua piccola</h2>
+    </div>
+
+    <div class="mm-collega">
+      <div class="mm-col grande" role="list" aria-label="Lettere maiuscole">
+        <span class="mm-pallino" role="listitem">C</span>
+        <span class="mm-pallino" role="listitem">A</span>
+        <span class="mm-pallino" role="listitem">P</span>
+        <span class="mm-pallino" role="listitem">R</span>
+        <span class="mm-pallino" role="listitem">M</span>
+        <span class="mm-pallino" role="listitem">Z</span>
+      </div>
+      <div class="mm-col min" role="list" aria-label="Lettere minuscole">
+        <span class="mm-pallino" role="listitem">r</span>
+        <span class="mm-pallino" role="listitem">z</span>
+        <span class="mm-pallino" role="listitem">a</span>
+        <span class="mm-pallino" role="listitem">m</span>
+        <span class="mm-pallino" role="listitem">c</span>
+        <span class="mm-pallino" role="listitem">p</span>
+      </div>
+    </div>
+    <p style="font-size: 0.82rem; color: #495057; margin: 0.2rem 0;">Tira una linea con la matita dalla lettera grande alla sua lettera piccola.</p>
+
+    <div class="sezione-titolo">
+      <span class="num">2</span>
+      <h2>Scrivi tu la lettera piccola accanto alla grande</h2>
+    </div>
+
+    <div class="mm-griglia">
+      <div class="mm-cella"><span class="grande">S</span><span class="sep" aria-hidden="true">→</span><span class="vuoto" aria-hidden="true"></span></div>
+      <div class="mm-cella"><span class="grande">O</span><span class="sep" aria-hidden="true">→</span><span class="vuoto" aria-hidden="true"></span></div>
+      <div class="mm-cella"><span class="grande">T</span><span class="sep" aria-hidden="true">→</span><span class="vuoto" aria-hidden="true"></span></div>
+      <div class="mm-cella"><span class="grande">U</span><span class="sep" aria-hidden="true">→</span><span class="vuoto" aria-hidden="true"></span></div>
+      <div class="mm-cella"><span class="grande">F</span><span class="sep" aria-hidden="true">→</span><span class="vuoto" aria-hidden="true"></span></div>
+      <div class="mm-cella"><span class="grande">I</span><span class="sep" aria-hidden="true">→</span><span class="vuoto" aria-hidden="true"></span></div>
+      <div class="mm-cella"><span class="grande">N</span><span class="sep" aria-hidden="true">→</span><span class="vuoto" aria-hidden="true"></span></div>
+      <div class="mm-cella"><span class="grande">G</span><span class="sep" aria-hidden="true">→</span><span class="vuoto" aria-hidden="true"></span></div>
+    </div>
+
+    <div class="sezione-titolo">
+      <span class="num">3</span>
+      <h2>La stessa parola, scritta nei due modi</h2>
+    </div>
+    <p style="font-size: 0.95rem; margin: 0.2rem 0;">
+      <span style="font-family:'Trebuchet MS',sans-serif; font-weight:700; letter-spacing:0.1em; color:var(--scheda-blu);">CASCO</span>
+      &nbsp;è uguale a&nbsp;
+      <span style="font-family:'Trebuchet MS',sans-serif; font-weight:700; letter-spacing:0.1em; color:var(--scheda-rosso);">casco</span>.
+      Leggile: dicono la stessa cosa. Ora prova con <strong>ACQUA / acqua</strong> e <strong>RADIO / radio</strong>.
+    </p>
+
+    <div class="scheda-docente">
+      <strong>Per la maestra/maestro — soluzioni:</strong>
+      <ul style="margin: 0.3rem 0 0 1rem; padding: 0;">
+        <li><strong>Sezione 1:</strong> C–c, A–a, P–p, R–r, M–m, Z–z.</li>
+        <li><strong>Sezione 2:</strong> S→s, O→o, T→t, U→u, F→f, I→i, N→n, G→g.</li>
+        <li><strong>Estensione orale:</strong> mostrare che alcune minuscole somigliano molto alla maiuscola (C/c, O/o, S/s, U/u, Z/z), altre cambiano forma (A/a, R/r, G/g): far notare le differenze.</li>
+      </ul>
+    </div>
+
+    <footer class="scheda-footer">
+      <span class="scheda-site">protezionecivilegenzano.it</span>
+      <span>Scheda "Maiuscolo e minuscolo" · Primaria 1ª · letto-scrittura · rev. 2026</span>
+    </footer>
+
+  </article>
+
+</body>
+</html>

--- a/static/formazione/schede-stampabili/prime-frasi-sicurezza-primaria/index.html
+++ b/static/formazione/schede-stampabili/prime-frasi-sicurezza-primaria/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="it" dir="ltr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Scheda stampabile: Le prime frasi della sicurezza (Primaria 1ª-2ª)</title>
+  <meta name="description" content="Scheda fotocopiabile per la Scuola Primaria: rimetti in ordine le parole e scrivi frasi semplici sulle regole di autoprotezione della Protezione Civile.">
+  <meta name="robots" content="index, follow">
+  <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
+  <link rel="stylesheet" href="/formazione/schede-stampabili/assets/scheda-print.css">
+  <style>
+    .pf-item { margin: 0.7rem 0; }
+    .pf-emo-titolo { display: flex; align-items: center; gap: 0.5rem; font-weight: 700; color: var(--scheda-blu); font-size: 0.95rem; margin-bottom: 0.3rem; }
+    .pf-emo-titolo .e { font-size: 1.4rem; }
+    .pf-tessere { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.4rem; }
+    .pf-tessera {
+      font-family: "Trebuchet MS", "Arial Rounded MT Bold", sans-serif;
+      font-weight: 700; font-size: 1rem; letter-spacing: 0.04em;
+      background: #eaf2fb; border: 1.5px solid var(--scheda-blu); color: var(--scheda-blu);
+      border-radius: 6px; padding: 0.25rem 0.6rem;
+    }
+    .pf-riga { border-bottom: 2px solid var(--scheda-bordo); min-height: 1.7rem; margin-top: 0.2rem; }
+    .pf-libera .pf-riga { margin-top: 0.5rem; }
+  </style>
+</head>
+<body>
+
+  <div class="scheda-toolbar no-print">
+    <a href="/formazione/schede-stampabili/" aria-label="Torna alle schede">← Torna alle schede</a>
+    <span class="scheda-titolo">Le prime frasi della sicurezza — Primaria 1ª-2ª</span>
+    <button type="button" onclick="window.print()">🖨️ Stampa o salva come PDF</button>
+  </div>
+
+  <article class="scheda-page">
+
+    <header class="scheda-header">
+      <div class="scheda-logo" aria-hidden="true">PC</div>
+      <div class="scheda-intestazione">
+        <div class="scheda-ente">Protezione Civile — Genzano di Roma</div>
+        <h1 class="scheda-titolo-principale">Le prime frasi della sicurezza</h1>
+        <div class="scheda-sottotitolo">Scheda fotocopiabile — Scuola Primaria (classi 1ª-2ª)</div>
+      </div>
+    </header>
+
+    <div class="scheda-meta">
+      <span><strong>Destinatari:</strong> 6-7 anni</span>
+      <span><strong>Obiettivo:</strong> mettere in ordine le parole e scrivere una frase compiuta</span>
+      <span><strong>Servono:</strong> matita</span>
+    </div>
+
+    <p class="scheda-intro">
+      Le parole sono in disordine. Rimettile nell'ordine giusto e <strong>scrivi la frase</strong> sulla riga. Inizia con la <strong>lettera maiuscola</strong> e finisci con il <strong>punto</strong>.
+    </p>
+
+    <div class="pf-item">
+      <div class="pf-emo-titolo"><span class="e" aria-hidden="true">📞</span> Frase 1</div>
+      <div class="pf-tessere"><span class="pf-tessera">il</span><span class="pf-tessera">112</span><span class="pf-tessera">chiamo</span></div>
+      <div class="pf-riga" aria-hidden="true"></div>
+    </div>
+
+    <div class="pf-item">
+      <div class="pf-emo-titolo"><span class="e" aria-hidden="true">⛑️</span> Frase 2</div>
+      <div class="pf-tessere"><span class="pf-tessera">casco</span><span class="pf-tessera">metto</span><span class="pf-tessera">il</span></div>
+      <div class="pf-riga" aria-hidden="true"></div>
+    </div>
+
+    <div class="pf-item">
+      <div class="pf-emo-titolo"><span class="e" aria-hidden="true">🚶</span> Frase 3</div>
+      <div class="pf-tessere"><span class="pf-tessera">la</span><span class="pf-tessera">seguo</span><span class="pf-tessera">maestra</span></div>
+      <div class="pf-riga" aria-hidden="true"></div>
+    </div>
+
+    <div class="pf-item">
+      <div class="pf-emo-titolo"><span class="e" aria-hidden="true">🛗</span> Frase 4</div>
+      <div class="pf-tessere"><span class="pf-tessera">uso</span><span class="pf-tessera">non</span><span class="pf-tessera">l'ascensore</span></div>
+      <div class="pf-riga" aria-hidden="true"></div>
+    </div>
+
+    <div class="pf-item">
+      <div class="pf-emo-titolo"><span class="e" aria-hidden="true">😌</span> Frase 5</div>
+      <div class="pf-tessere"><span class="pf-tessera">calmo</span><span class="pf-tessera">resto</span></div>
+      <div class="pf-riga" aria-hidden="true"></div>
+    </div>
+
+    <div class="pf-item pf-libera">
+      <div class="pf-emo-titolo"><span class="e" aria-hidden="true">✏️</span> Ora scrivi tu una frase sulla sicurezza</div>
+      <div class="pf-riga" aria-hidden="true"></div>
+      <div class="pf-riga" aria-hidden="true"></div>
+    </div>
+
+    <div class="scheda-docente">
+      <strong>Per la maestra/maestro — soluzioni:</strong>
+      <ul style="margin: 0.3rem 0 0 1rem; padding: 0;">
+        <li><strong>1.</strong> Chiamo il 112. &nbsp; <strong>2.</strong> Metto il casco. &nbsp; <strong>3.</strong> Seguo la maestra. &nbsp; <strong>4.</strong> Non uso l'ascensore. &nbsp; <strong>5.</strong> Resto calmo.</li>
+        <li>Far notare le due regole della frase scritta: <strong>maiuscola</strong> all'inizio e <strong>punto</strong> alla fine.</li>
+        <li>Le frasi sono regole vere di autoprotezione: dopo la scrittura, commentarle insieme (perché non si usa l'ascensore? perché si segue chi guida l'evacuazione?).</li>
+      </ul>
+    </div>
+
+    <footer class="scheda-footer">
+      <span class="scheda-site">protezionecivilegenzano.it</span>
+      <span>Scheda "Le prime frasi della sicurezza" · Primaria 1ª-2ª · letto-scrittura · rev. 2026</span>
+    </footer>
+
+  </article>
+
+</body>
+</html>

--- a/static/formazione/schede-stampabili/ricalca-scrivi-parole-primaria/index.html
+++ b/static/formazione/schede-stampabili/ricalca-scrivi-parole-primaria/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="it" dir="ltr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Scheda stampabile: Ricalca e scrivi le parole della sicurezza (Primaria 1ª)</title>
+  <meta name="description" content="Scheda fotocopiabile per la Scuola Primaria: l'alunno ricalca la parola tratteggiata della Protezione Civile e poi la riscrive sulla riga. Per imparare a scrivere.">
+  <meta name="robots" content="index, follow">
+  <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
+  <link rel="stylesheet" href="/formazione/schede-stampabili/assets/scheda-print.css">
+  <style>
+    .rs-blocco {
+      display: flex;
+      align-items: center;
+      gap: 0.8rem;
+      padding: 0.5rem 0.7rem;
+      border: 1.5px solid var(--scheda-bordo);
+      border-radius: 8px;
+      margin: 0.5rem 0;
+    }
+    .rs-emo { font-size: 1.8rem; line-height: 1; flex-shrink: 0; width: 2.2rem; text-align: center; }
+    .rs-testo { flex: 1; min-width: 0; }
+    .rs-modello {
+      font-family: "Trebuchet MS", "Arial Rounded MT Bold", sans-serif;
+      font-weight: 700;
+      font-size: 1.55rem;
+      letter-spacing: 0.28em;
+      color: #cfd5db;
+      line-height: 1.1;
+    }
+    .rs-riga {
+      margin-top: 0.55rem;
+      border-bottom: 1.5px solid var(--scheda-bordo);
+      min-height: 1.7rem;
+    }
+    .rs-numero {
+      font-family: "Trebuchet MS", "Arial Rounded MT Bold", sans-serif;
+      font-weight: 700;
+      font-size: 1.55rem;
+      letter-spacing: 0.2em;
+      color: #cfd5db;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="scheda-toolbar no-print">
+    <a href="/formazione/schede-stampabili/" aria-label="Torna alle schede">← Torna alle schede</a>
+    <span class="scheda-titolo">Ricalca e scrivi — Primaria 1ª</span>
+    <button type="button" onclick="window.print()">🖨️ Stampa o salva come PDF</button>
+  </div>
+
+  <article class="scheda-page">
+
+    <header class="scheda-header">
+      <div class="scheda-logo" aria-hidden="true">PC</div>
+      <div class="scheda-intestazione">
+        <div class="scheda-ente">Protezione Civile — Genzano di Roma</div>
+        <h1 class="scheda-titolo-principale">Ricalca e scrivi le parole della sicurezza</h1>
+        <div class="scheda-sottotitolo">Scheda fotocopiabile — Scuola Primaria (classe 1ª)</div>
+      </div>
+    </header>
+
+    <div class="scheda-meta">
+      <span><strong>Destinatari:</strong> 6 anni</span>
+      <span><strong>Obiettivo:</strong> imparare a scrivere le prime parole in stampatello</span>
+      <span><strong>Servono:</strong> matita</span>
+    </div>
+
+    <p class="scheda-intro">
+      Per ogni parola: prima <strong>ricalca</strong> con la matita le lettere grigie tratteggiate, poi <strong>riscrivi tu</strong> la stessa parola sulla riga vuota. Leggi sempre la parola ad alta voce.
+    </p>
+
+    <div class="rs-blocco">
+      <span class="rs-emo" aria-hidden="true">🏠</span>
+      <div class="rs-testo"><div class="rs-modello" aria-hidden="true">C A S A</div><div class="rs-riga" aria-hidden="true"></div></div>
+    </div>
+    <div class="rs-blocco">
+      <span class="rs-emo" aria-hidden="true">💧</span>
+      <div class="rs-testo"><div class="rs-modello" aria-hidden="true">A C Q U A</div><div class="rs-riga" aria-hidden="true"></div></div>
+    </div>
+    <div class="rs-blocco">
+      <span class="rs-emo" aria-hidden="true">📞</span>
+      <div class="rs-testo"><div class="rs-numero" aria-hidden="true">1 1 2</div><div class="rs-riga" aria-hidden="true"></div></div>
+    </div>
+    <div class="rs-blocco">
+      <span class="rs-emo" aria-hidden="true">🎒</span>
+      <div class="rs-testo"><div class="rs-modello" aria-hidden="true">Z A I N O</div><div class="rs-riga" aria-hidden="true"></div></div>
+    </div>
+    <div class="rs-blocco">
+      <span class="rs-emo" aria-hidden="true">⛑️</span>
+      <div class="rs-testo"><div class="rs-modello" aria-hidden="true">C A S C O</div><div class="rs-riga" aria-hidden="true"></div></div>
+    </div>
+    <div class="rs-blocco">
+      <span class="rs-emo" aria-hidden="true">🤝</span>
+      <div class="rs-testo"><div class="rs-modello" aria-hidden="true">A I U T O</div><div class="rs-riga" aria-hidden="true"></div></div>
+    </div>
+    <div class="rs-blocco">
+      <span class="rs-emo" aria-hidden="true">🚪</span>
+      <div class="rs-testo"><div class="rs-modello" aria-hidden="true">U S C I T A</div><div class="rs-riga" aria-hidden="true"></div></div>
+    </div>
+    <div class="rs-blocco">
+      <span class="rs-emo" aria-hidden="true">📻</span>
+      <div class="rs-testo"><div class="rs-modello" aria-hidden="true">R A D I O</div><div class="rs-riga" aria-hidden="true"></div></div>
+    </div>
+
+    <div class="scheda-docente">
+      <strong>Per la maestra/maestro:</strong>
+      <ul style="margin: 0.3rem 0 0 1rem; padding: 0;">
+        <li>Le parole sono in <strong>stampato maiuscolo</strong>, il carattere con cui i bambini iniziano a scrivere. Far ricalcare lentamente, una lettera alla volta, partendo dal punto giusto.</li>
+        <li>Il numero <strong>112</strong> è inserito di proposito: è la prima "parola" della sicurezza che ogni bambino deve saper scrivere e riconoscere.</li>
+        <li><strong>Estensione:</strong> sul retro del foglio l'alunno scrive il proprio nome e il nome della via di casa — informazioni utili in caso di emergenza.</li>
+      </ul>
+    </div>
+
+    <footer class="scheda-footer">
+      <span class="scheda-site">protezionecivilegenzano.it</span>
+      <span>Scheda "Ricalca e scrivi" · Primaria 1ª · letto-scrittura · rev. 2026</span>
+    </footer>
+
+  </article>
+
+</body>
+</html>


### PR DESCRIPTION
5 nuove schede stampabili a tema Protezione Civile per **imparare a leggere e scrivere** (progressione lettera→parola→frase):

1. **L'Alfabetiere della Sicurezza (A→Z)** — infanzia 5-6 / 1ª
2. **Ricalca e Scrivi le Parole** — primaria 1ª
3. **Maiuscolo e Minuscolo** — primaria 1ª
4. **Dettato Illustrato** — primaria 1ª-2ª
5. **Le Prime Frasi della Sicurezza** — primaria 1ª-2ª

Registrate nell'indice `/formazione/schede-stampabili/` e collegate dai kit infanzia/primaria (regola coerenza kit↔schede). QA `pc-print-card-qa` superata; corretti doppione iniziale (dettato) ed emoji ambigua (alfabetiere). Bonus: contrasto WCAG del verde nei box docente migliorato (3.49→7.17:1) su tutte le 19 schede. Build Hugo pulita.