### PR TITLE
Hub rischi: 'Pagine di consultazione rapida' come griglia di card

### DIFF
--- a/.claude/rules/04a-hugo-shortcode-partial.md
+++ b/.claude/rules/04a-hugo-shortcode-partial.md
@@ -96,6 +96,21 @@ CSS scoped sezione **CHI CHIAMARE BOX v1.0** in `custom.css`. In stampa il numer
 
 **Struttura uniforme finale delle pagine rischio**: dopo l'introduzione "Perché è rilevante sul nostro territorio" e gli eventuali "Segnali e situazioni tipiche", ogni pagina ha l'ordine fisso **Cosa fare PRIMA → Cosa fare DURANTE → Cosa fare DOPO → `cosa-non-fare` → `chi-chiamare`**. Modello di riferimento per nuovi rischi che dovessero essere aggiunti in futuro.
 
+## Shortcode `link-card` (griglia di card link nei contenuti)
+
+Card link visibile (icona + titolo + descrizione) per griglie di consultazione dentro le pagine markdown, in alternativa all'elenco puntato anonimo. Nato per la sezione "Pagine di consultazione rapida" dell'hub `/rischi-prevenzione/` (la scheda scuolabus non si trovava in un bullet — maggio 2026).
+
+```go-html-template
+<div class="consulta-rapida">
+{{</* link-card url="/rischi-prevenzione/sicurezza-scuolabus/" icon="bi-bus-front" titolo="Sicurezza sullo scuolabus" desc="Cosa fare in emergenza durante il tragitto." */>}}
+... altre card ...
+</div>
+```
+
+- Parametri: `url` (path interno), `icon` (classe Bootstrap Icons), `titolo`, `desc`. Tutti obbligatori.
+- **Subpath GitHub Pages**: il template fa `.Get "url" | strings.TrimPrefix "/" | relURL` (stesso pattern del render-link hook), così i link funzionano sia su Aruba (root) sia su GitHub Pages (`/sito-pc-genzano/`). Scrivere `url` con leading slash.
+- Le card vanno avvolte in `<div class="consulta-rapida">` (raw HTML nel markdown), senza righe vuote tra gli shortcode. CSS scoped sezione **CARD CONSULTAZIONE RAPIDA v1.0** in `custom.css` (hover lift, focus visibile `#ffbe2e`, `prefers-reduced-motion` + `a11y-pause-anim`, stampa).
+
 ## Render hook tabelle (`_markup/render-table.html`)
 
 Tutte le tabelle Markdown del sito sono rese dal hook `themes/flavour-pcgenzano/layouts/_default/_markup/render-table.html`. Comportamento:

--- a/content/rischi-prevenzione/_index.md
+++ b/content/rischi-prevenzione/_index.md
@@ -23,11 +23,13 @@ Conoscere i rischi del territorio aiuta a proteggere te, la tua famiglia e chi i
 
 Queste pagine aiutano a orientarsi in pochi minuti, anche senza conoscenze tecniche.
 
-- [Rischi principali in parole semplici](/rischi-prevenzione/rischi-in-parole-semplici/) — spiegazione accessibile per bambini, persone con bisogni cognitivi e parlanti italiano L2.
-- [Scuole di Genzano e rischi locali](/rischi-prevenzione/scuole-genzano-rischi-locali/) — riferimenti generali per famiglie e personale scolastico, da integrare con il piano di emergenza del singolo istituto.
-- [Sicurezza sullo scuolabus](/rischi-prevenzione/sicurezza-scuolabus/) — cosa fare in emergenza durante il tragitto: regole per bambini, autista e genitori.
-- [Kit di emergenza economico e progressivo](/rischi-prevenzione/kit-emergenza-economico-progressivo/) — come comporre il kit un pezzo alla volta, senza marchi né prodotti specifici.
-- [Dopo l'emergenza](/rischi-prevenzione/dopo-emergenza/) — rientro sicuro, verifica di gas, luce e acqua, animali e notizie false quando l'evento è passato.
+<div class="consulta-rapida">
+{{< link-card url="/rischi-prevenzione/rischi-in-parole-semplici/" icon="bi-chat-square-text" titolo="Rischi principali in parole semplici" desc="Spiegazione accessibile per bambini, persone con bisogni cognitivi e parlanti italiano L2." >}}
+{{< link-card url="/rischi-prevenzione/scuole-genzano-rischi-locali/" icon="bi-mortarboard" titolo="Scuole di Genzano e rischi locali" desc="Riferimenti per famiglie e personale scolastico, da integrare con il piano di emergenza del singolo istituto." >}}
+{{< link-card url="/rischi-prevenzione/sicurezza-scuolabus/" icon="bi-bus-front" titolo="Sicurezza sullo scuolabus" desc="Cosa fare in emergenza durante il tragitto: regole per bambini, autista e genitori." >}}
+{{< link-card url="/rischi-prevenzione/kit-emergenza-economico-progressivo/" icon="bi-bag-check" titolo="Kit di emergenza economico e progressivo" desc="Come comporre il kit un pezzo alla volta, senza marchi né prodotti specifici." >}}
+{{< link-card url="/rischi-prevenzione/dopo-emergenza/" icon="bi-house-check" titolo="Dopo l'emergenza" desc="Rientro sicuro, verifica di gas, luce e acqua, animali e notizie false quando l'evento è passato." >}}
+</div>
 
 ## Principali rischi
 

--- a/themes/flavour-pcgenzano/layouts/shortcodes/link-card.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/link-card.html
@@ -1,0 +1,8 @@
+{{- /* Card link per griglie di consultazione (es. hub /rischi-prevenzione/).
+       Uso: {{< link-card url="/percorso/" icon="bi-bus-front" titolo="Titolo" desc="Descrizione" >}}
+       url passato senza leading slash a relURL per compatibilità subpath GitHub Pages. */ -}}
+{{- $url := .Get "url" | strings.TrimPrefix "/" | relURL -}}
+<a class="cr-card" href="{{ $url }}">
+  <span class="cr-icon" aria-hidden="true"><i class="bi {{ .Get "icon" }}"></i></span>
+  <span class="cr-corpo"><span class="cr-titolo">{{ .Get "titolo" }}</span><span class="cr-desc">{{ .Get "desc" }}</span></span>
+</a>

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6378,3 +6378,82 @@ html.a11y-pause-anim .quiz-barra span { transition: none; }
   .scheda-1-min h2, .scheda-1-min-112, .scheda-1-min-url { color: #000; }
 }
 /* fine SCHEDE 1 MINUTO v1.0 */
+
+/* ==========================================================================
+   CARD CONSULTAZIONE RAPIDA v1.0 — griglia link (shortcode link-card)
+   usata su hub /rischi-prevenzione/ § "Pagine di consultazione rapida" (mag 2026)
+   ========================================================================== */
+.consulta-rapida {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(255px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 1.6rem;
+}
+.consulta-rapida .cr-card {
+  display: flex;
+  gap: 0.85rem;
+  align-items: flex-start;
+  background: #fff;
+  border: 1px solid #d4dce6;
+  border-left: 4px solid #003366;
+  border-radius: 8px;
+  padding: 1rem 1.05rem;
+  text-decoration: none !important;
+  color: inherit;
+  transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
+}
+.consulta-rapida .cr-card:hover,
+.consulta-rapida .cr-card:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 6px 18px rgba(0, 51, 102, 0.15);
+  border-color: #003366;
+}
+.consulta-rapida .cr-card:focus-visible {
+  outline: 3px solid #ffbe2e;
+  outline-offset: 2px;
+}
+.consulta-rapida .cr-icon {
+  flex-shrink: 0;
+  width: 2.6rem;
+  height: 2.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #e7f0fa;
+  color: #003366;
+  border-radius: 50%;
+  font-size: 1.3rem;
+}
+.consulta-rapida .cr-corpo { display: block; }
+.consulta-rapida .cr-titolo {
+  display: block;
+  font-weight: 700;
+  color: #003366;
+  font-size: 1.02rem;
+  line-height: 1.25;
+  margin-bottom: 0.25rem;
+}
+.consulta-rapida .cr-desc {
+  display: block;
+  font-size: 0.9rem;
+  color: #43484d;
+  line-height: 1.4;
+}
+@media (prefers-reduced-motion: reduce) {
+  .consulta-rapida .cr-card { transition: none; }
+  .consulta-rapida .cr-card:hover,
+  .consulta-rapida .cr-card:focus-visible { transform: none; }
+}
+html.a11y-pause-anim .consulta-rapida .cr-card { transition: none; }
+html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
+@media print {
+  .consulta-rapida { display: block; }
+  .consulta-rapida .cr-card {
+    border: 1px solid #999;
+    box-shadow: none;
+    transform: none;
+    margin-bottom: 0.4rem;
+    page-break-inside: avoid;
+  }
+}
+/* fine CARD CONSULTAZIONE RAPIDA v1.0 */


### PR DESCRIPTION
L'elenco puntato anonimo rendeva poco visibili le pagine (la scheda **scuolabus** non si trovava). Sostituito con una **griglia di card** (icona + titolo + descrizione) in stile istituzionale.

- Nuovo shortcode `link-card` (icona Bootstrap Icons + titolo + desc), con `relURL` per compatibilità subpath GitHub Pages.
- CSS scoped **CARD CONSULTAZIONE RAPIDA v1.0** (hover lift, focus visibile, prefers-reduced-motion, stampa).
- Doc shortcode in rule 04a. Build pulita; card verificate nel rendering.