### PR TITLE
Schede: logo header più piccolo per più spazio al contenuto

### DIFF
--- a/static/formazione/schede-stampabili/assets/scheda-print.css
+++ b/static/formazione/schede-stampabili/assets/scheda-print.css
@@ -96,23 +96,23 @@ body {
 .scheda-header {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.8rem;
   border-bottom: 3px solid var(--scheda-blu);
-  padding-bottom: 0.8rem;
-  margin-bottom: 1.2rem;
+  padding-bottom: 0.6rem;
+  margin-bottom: 0.9rem;
 }
 .scheda-header .scheda-logo {
   flex-shrink: 0;
-  width: 60px;
-  height: 60px;
+  width: 44px;
+  height: 44px;
   background: var(--scheda-blu);
   color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.8rem;
+  font-size: 1.3rem;
   font-weight: 700;
-  border-radius: 8px;
+  border-radius: 6px;
 }
 .scheda-header .scheda-intestazione {
   flex: 1;


### PR DESCRIPTION
Ridotto il logo 'PC' nell'header delle schede da 60×60 a 44×44px (font 1.8→1.3rem) e stretto l'header (gap/padding/margin) nel CSS condiviso. Più spazio per disegni e testi su tutte le schede template; logo ancora ben visibile. Riduzione moderata come richiesto.