### PR TITLE
Cartina meteo Lazio: più dati per Genzano (raffiche, mm, UV, alba/tramonto)

### DIFF
--- a/scripts/genera-meteo-lazio.py
+++ b/scripts/genera-meteo-lazio.py
@@ -153,8 +153,9 @@ def fetch_map():
 
 def fetch_card():
     url = (f"https://api.open-meteo.com/v1/forecast?latitude={GENZANO[0]}&longitude={GENZANO[1]}"
-           "&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,weather_code"
-           "&daily=temperature_2m_max,temperature_2m_min,weather_code,precipitation_probability_max"
+           "&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,wind_gusts_10m,weather_code"
+           "&daily=temperature_2m_max,temperature_2m_min,weather_code,precipitation_probability_max,"
+           "precipitation_sum,wind_gusts_10m_max,uv_index_max,sunrise,sunset"
            "&timezone=Europe%2FRome&forecast_days=4")
     return _get(url)
 
@@ -268,6 +269,19 @@ def build_svg(map_data, card_data, oggi):
     return svg
 
 # ---------------------------------------------------------------- card Genzano
+# Indice UV: bande standard WHO (Global Solar UV Index) -> etichetta italiana.
+def uv_label(v):
+    v = round(v or 0)
+    if v <= 2:  return "basso"
+    if v <= 5:  return "moderato"
+    if v <= 7:  return "alto"
+    if v <= 10: return "molto alto"
+    return "estremo"
+
+def _hhmm(iso):
+    # "2026-05-23T05:39" -> "05:39"
+    return iso.split("T")[1][:5] if iso and "T" in iso else (iso or "")
+
 def build_card(card_data, now):
     cur = card_data["current"]
     d = card_data["daily"]
@@ -284,12 +298,18 @@ def build_card(card_data, now):
             "tmax": round(d["temperature_2m_max"][i]),
             "tmin": round(d["temperature_2m_min"][i]),
             "pioggia": d["precipitation_probability_max"][i],
+            "pioggia_mm": round(d["precipitation_sum"][i] or 0, 1),
+            "raffiche": round(d["wind_gusts_10m_max"][i] or 0),
+            "uv": round(d["uv_index_max"][i] or 0),
+            "uv_label": uv_label(d["uv_index_max"][i]),
         })
     data_lunga = f"{GIORNI_IT[now.weekday()]} {now.day} {MESI_IT[now.month]} {now.year}"
     return {
         "aggiornato": now.strftime("%Y-%m-%dT%H:%M"),
         "data_lunga": data_lunga,
         "aggiornato_label": f"{data_lunga}, ore {now.strftime('%H:%M')}",
+        "alba": _hhmm(d["sunrise"][0]),
+        "tramonto": _hhmm(d["sunset"][0]),
         "corrente": {
             "temp": round(cur["temperature_2m"], 1),
             "percepita": round(cur["apparent_temperature"], 1),
@@ -297,6 +317,7 @@ def build_card(card_data, now):
             "icona": icona_svg(ico_cur, 28, 28, 16),
             "umidita": round(cur["relative_humidity_2m"]),
             "vento": round(cur["wind_speed_10m"]),
+            "raffiche": round(cur["wind_gusts_10m"] or 0),
         },
         "giorni": giorni,
         "fonte": "Open-Meteo (modelli ECMWF)",

--- a/themes/flavour-pcgenzano/layouts/shortcodes/meteo-lazio.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/meteo-lazio.html
@@ -15,7 +15,13 @@
 
 {{- with $m }}
 {{- $c := .corrente }}
-  <div class="meteo-gz no-gloss" role="img" aria-label="Meteo a Genzano di Roma, {{ .data_lunga }}: ora {{ $c.temp }} gradi, {{ $c.cielo | lower }}, percepita {{ $c.percepita }} gradi, umidità {{ $c.umidita }} per cento, vento {{ $c.vento }} chilometri orari. Previsione dei prossimi giorni a seguire.">
+{{- $oggi := index .giorni 0 }}
+{{- /* descrizione estesa per screen reader: aggiunge i nuovi dati solo se presenti */ -}}
+{{- $extra := "" }}
+{{- with $c.raffiche }}{{ $extra = printf "%s Raffiche di vento fino a %v chilometri orari." $extra . }}{{ end }}
+{{- with $oggi.uv }}{{ $extra = printf "%s Indice UV di oggi %v, %s." $extra . $oggi.uv_label }}{{ end }}
+{{- if and .alba .tramonto }}{{ $extra = printf "%s Alba alle %s, tramonto alle %s." $extra .alba .tramonto }}{{ end }}
+  <div class="meteo-gz no-gloss" role="img" aria-label="Meteo a Genzano di Roma, {{ .data_lunga }}: ora {{ $c.temp }} gradi, {{ $c.cielo | lower }}, percepita {{ $c.percepita }} gradi, umidità {{ $c.umidita }} per cento, vento {{ $c.vento }} chilometri orari.{{ $extra }} Previsione dei prossimi giorni a seguire.">
     <div class="meteo-gz-head">
       <span class="meteo-gz-icona" aria-hidden="true"><svg viewBox="0 0 56 56" width="58" height="58">{{ $c.icona | safeHTML }}</svg></span>
       <div>
@@ -27,14 +33,25 @@
     <div class="meteo-gz-sotto">
       <span><i class="bi bi-droplet-half" aria-hidden="true"></i> Umidità {{ $c.umidita }}%</span>
       <span><i class="bi bi-wind" aria-hidden="true"></i> Vento {{ $c.vento }} km/h</span>
+      {{- with $c.raffiche }}<span><i class="bi bi-wind" aria-hidden="true"></i> Raffiche {{ . }} km/h</span>{{- end }}
     </div>
+    {{- if or $oggi.uv .alba .tramonto }}
+    <div class="meteo-gz-sotto meteo-gz-oggi">
+      {{- with $oggi.uv }}<span><i class="bi bi-brightness-high" aria-hidden="true"></i> UV oggi {{ . }} ({{ $oggi.uv_label }})</span>{{- end }}
+      {{- with .alba }}<span><i class="bi bi-sunrise" aria-hidden="true"></i> Alba {{ . }}</span>{{- end }}
+      {{- with .tramonto }}<span><i class="bi bi-sunset" aria-hidden="true"></i> Tramonto {{ . }}</span>{{- end }}
+    </div>
+    {{- end }}
     <div class="meteo-gz-giorni">
     {{- range .giorni }}
+      {{- $prob := .pioggia }}
+      {{- $mm := .pioggia_mm }}
       <div class="meteo-gz-g">
         <div class="d">{{ .label }}</div>
         <div class="e" aria-hidden="true"><svg viewBox="0 0 32 32" width="42" height="42">{{ .icona | safeHTML }}</svg></div>
         <div class="t">{{ .tmax }}°<small>/{{ .tmin }}°</small></div>
-        {{- if gt .pioggia 20 }}<div class="p"><i class="bi bi-umbrella" aria-hidden="true"></i> {{ .pioggia }}%</div>{{- end }}
+        {{- if or (gt $prob 20) $mm }}<div class="p"><i class="bi bi-umbrella" aria-hidden="true"></i> {{ if gt $prob 20 }}{{ $prob }}%{{ end }}{{ with $mm }}{{ if gt $prob 20 }} · {{ end }}{{ . }} mm{{ end }}</div>{{- end }}
+        {{- with .raffiche }}<div class="r"><i class="bi bi-wind" aria-hidden="true"></i> {{ . }} km/h</div>{{- end }}
       </div>
     {{- end }}
     </div>

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6459,7 +6459,9 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 /* fine CARD CONSULTAZIONE RAPIDA v1.0 */
 
 /* =========================================================================
-   METEO LAZIO v1.0 — cartina province (shortcode meteo-lazio) + riquadro Genzano
+   METEO LAZIO v1.1 — cartina province (shortcode meteo-lazio) + riquadro Genzano
+   v1.1 (2026-05-23): riquadro Genzano arricchito con raffiche di vento, pioggia
+   in mm, indice UV (bande WHO), alba/tramonto. Dati Open-Meteo, card difensiva.
    ========================================================================= */
 /* contenitore unico: cartina e riquadro condividono larghezza e bordi (allineati) */
 .meteo-lazio { max-width: 640px; margin: 1.2rem auto; }
@@ -6493,6 +6495,7 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
   display: flex; gap: 1.4rem; flex-wrap: wrap;
   margin-top: 0.6rem; font-size: 0.92rem; opacity: 0.95;
 }
+.meteo-gz-oggi { gap: 1.1rem; margin-top: 0.4rem; font-size: 0.86rem; opacity: 0.9; }
 .meteo-gz-giorni {
   display: grid; grid-template-columns: repeat(4, 1fr);
   gap: 0.5rem; margin-top: 1rem;
@@ -6506,6 +6509,7 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 .meteo-gz-g .t { font-size: 0.95rem; font-weight: 700; }
 .meteo-gz-g .t small { font-weight: 400; opacity: 0.8; }
 .meteo-gz-g .p { font-size: 0.74rem; opacity: 0.9; margin-top: 0.15rem; }
+.meteo-gz-g .r { font-size: 0.72rem; opacity: 0.82; margin-top: 0.1rem; }
 .meteo-gz-fonte { font-size: 0.76rem; opacity: 0.82; margin-top: 0.9rem; line-height: 1.45; }
 /* !important: batte .article-body a:not(.btn){color:#003366} che renderebbe i link
    blu scuro illeggibili sul fondo blu del riquadro */


### PR DESCRIPTION
## Cosa cambia

Arricchisce il riquadro di Genzano della cartina meteo del Lazio (`/allerte-meteo/`) con quattro nuovi dati Open-Meteo, già presenti nella stessa risposta API:

- **Raffiche di vento** — adesso + massimo per ogni giorno (rischio vento forte)
- **Pioggia in mm** prevista per giorno, accanto alla probabilità % (rischio idrogeologico/temporali)
- **Indice UV** con bande WHO (basso/moderato/alto/molto alto/estremo) — ondate di calore
- **Alba e tramonto** di oggi

## Scelte

- Dati aggiunti **solo alla card** sotto la mappa; l'**SVG resta sobrio** (leggibilità + alt text).
- **Open-Meteo, nessuna chiave API** (gratis, non commerciale, CC-BY). Le API key del progetto riguardano solo le foto stock, mai il meteo.
- **Template difensivo**: i nuovi campi compaiono solo se presenti, così il build non si rompe nell'ora di transizione prima che il workflow orario `meteo-lazio.yml` rigeneri `data/meteo_genzano.json` col nuovo schema. Nessun valore inventato viene mai mostrato.

## Verifica

- `hugo --minify` pulita (exit 0) sia con la JSON attuale (vecchio schema) sia con i nuovi campi.
- Rendering confermato: card adesso (umidità/vento/raffiche), riga oggi (UV/alba/tramonto), griglia 4 giorni (raffiche + pioggia mm), aria-label aggiornato per screen reader.
- I valori reali dei nuovi campi si popoleranno al primo run orario del workflow dopo il merge.

https://claude.ai/code/session_01ExjHKfeGmBYLCBijvBw3HE

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExjHKfeGmBYLCBijvBw3HE)_