### PR TITLE
Cartina meteo: dicitura "aggiornata ogni ora" (frequenza reale del workflow)

### DIFF
--- a/content/allerte-meteo/_index.md
+++ b/content/allerte-meteo/_index.md
@@ -39,7 +39,7 @@ Lo stato sotto è letto direttamente dai **bollettini ufficiali del Centro Funzi
 
 ## Previsione meteo di oggi
 
-Temperatura massima e cielo previsti **oggi** nelle cinque province del Lazio, con il dettaglio per Genzano di Roma e i prossimi giorni. La cartina è una **nostra elaborazione** su dati aperti [Open-Meteo](https://open-meteo.com/) (modelli ECMWF), aggiornata ogni mattina. È un dato **indicativo**: per le allerte valgono i bollettini ufficiali del Centro Funzionale Regionale del Lazio.
+Temperatura massima e cielo previsti **oggi** nelle cinque province del Lazio, con il dettaglio per Genzano di Roma e i prossimi giorni. La cartina è una **nostra elaborazione** su dati aperti [Open-Meteo](https://open-meteo.com/) (modelli ECMWF), aggiornata ogni ora. È un dato **indicativo**: per le allerte valgono i bollettini ufficiali del Centro Funzionale Regionale del Lazio.
 
 {{< meteo-lazio >}}
 

--- a/scripts/genera-meteo-lazio.py
+++ b/scripts/genera-meteo-lazio.py
@@ -10,7 +10,7 @@ Output:
 
 Geometria: data/meteo-lazio-geo.json (province del Lazio + contesto regioni confinanti),
 estratto una tantum dai confini ISTAT (openpolis/geojson-italy), così il generatore
-giornaliero non scarica i grandi file nazionali.
+orario non scarica i grandi file nazionali.
 
 Uso:
   python3 scripts/genera-meteo-lazio.py            # fetch live (runner CI / locale con rete)

--- a/themes/flavour-pcgenzano/layouts/shortcodes/meteo-lazio.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/meteo-lazio.html
@@ -1,6 +1,6 @@
 {{- /* Shortcode meteo-lazio — cartina del Lazio (aree colorate per provincia) +
        riquadro meteo di Genzano di Roma. Dati: data/meteo_genzano.json e
-       static/images/meteo-lazio.svg, rigenerati ogni giorno da
+       static/images/meteo-lazio.svg, rigenerati ogni ora da
        scripts/genera-meteo-lazio.py (workflow meteo-lazio.yml) da Open-Meteo.
        Privacy-first: immagine auto-ospitata, nessun cookie di terzi. */ -}}
 {{- $img := "images/meteo-lazio.svg" | relURL -}}


### PR DESCRIPTION
## Cosa cambia

Il workflow `meteo-lazio.yml` rigenera la cartina meteo **ogni ora** (`cron: "8 * * * *"`), ma il testo della pagina `/allerte-meteo/` diceva ancora "aggiornata ogni mattina". Allineata la dicitura alla frequenza reale in 3 punti:

- testo visibile della pagina → **"aggiornata ogni ora"**
- commento dello shortcode `meteo-lazio.html`
- docstring dello script `genera-meteo-lazio.py`

## Verifica

- `hugo --minify` pulita (exit 0); testo reso = "aggiornata ogni ora"; nessun residuo "ogni mattina".

https://claude.ai/code/session_01ExjHKfeGmBYLCBijvBw3HE

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExjHKfeGmBYLCBijvBw3HE)_