### PR TITLE
Approfondimento video Geopop su Seveso nell'articolo rischio chimico-industriale

### DIFF
--- a/content/comunicazioni/2026-05-24-rischio-chimico-industriale-cittadini.md
+++ b/content/comunicazioni/2026-05-24-rischio-chimico-industriale-cittadini.md
@@ -129,4 +129,8 @@ Fonti istituzionali:
 - [Dipartimento della Protezione Civile — Rischio industriale](https://www.protezionecivile.gov.it/it/pagina/rischio-chimico-industriale).
 - [D.Lgs. 105/2015 — recepimento Seveso III](https://www.gazzettaufficiale.it/eli/id/2015/07/14/15G00121/sg).
 
+Approfondimenti divulgativi (Geopop):
+
+- [Disastro di Seveso, uno degli incidenti ambientali più grandi d'Italia: cos'è accaduto e perché](https://youtu.be/zAmEhiOrk6w) — ricostruzione divulgativa di Geopop sull'incidente dell'ICMESA del 1976 che ha dato origine alla Direttiva Seveso.
+
 Un rischio conosciuto è un rischio **gestibile**. La trasparenza delle informazioni e la preparazione dei cittadini sono la migliore difesa contro gli incidenti industriali.


### PR DESCRIPTION
## Sintesi

- Aggiunto, nell'articolo di oggi `2026-05-24-rischio-chimico-industriale-cittadini.md`, il link al video divulgativo Geopop sul disastro di Seveso (ICMESA 1976, origine della Direttiva Seveso).
- Inserito nella sezione "Per approfondire" come sottosezione "Approfondimenti divulgativi (Geopop)", rispettando l'ordine AGID (interni → istituzionali → divulgativi) e con etichetta della fonte.
- URL pulito senza parametri di tracking; gate di pertinenza rispettato (video su Seveso ↔ articolo su rischio chimico/Direttiva Seveso).

## Verifiche

- Campo `image:` non modificato (anti-pattern rispettato).
- Nessuno shortcode toccato: aggiunta solo di un link Markdown.

https://claude.ai/code/session_019crjj5Z3teM8TZvemGsuoy

---
_Generated by [Claude Code](https://claude.ai/code/session_019crjj5Z3teM8TZvemGsuoy)_