### PR TITLE
Cartina meteo: cache-busting sull'SVG (mappa restava in cache)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/shortcodes/meteo-lazio.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/meteo-lazio.html
@@ -5,10 +5,15 @@
        Privacy-first: immagine auto-ospitata, nessun cookie di terzi. */ -}}
 {{- $img := "images/meteo-lazio.svg" | relURL -}}
 {{- $m := .Site.Data.meteo_genzano -}}
+{{- /* cache-busting: l'SVG ha URL fisso, ma cambia ogni ora. Senza versione il
+       browser/CDN servirebbe la copia vecchia in cache (mappa "ferma"). Aggancio
+       la versione al timestamp dei dati, rigenerati nello stesso run dello SVG. */ -}}
+{{- $ver := "" -}}
+{{- with $m }}{{ with .aggiornato }}{{ $ver = printf "?v=%s" (. | replaceRE `[^0-9]` "") }}{{ end }}{{ end -}}
 
 <div class="meteo-lazio">
   <figure class="meteo-mappa">
-    <img src="{{ $img }}" loading="lazy"
+    <img src="{{ $img }}{{ $ver }}" loading="lazy"
          alt="Cartina del Lazio con la temperatura massima e il cielo previsti oggi per ogni provincia: Viterbo, Rieti, Roma, Latina, Frosinone. Genzano di Roma è evidenziata con una stella.">
     <figcaption>Temperatura e cielo previsti oggi nelle province del Lazio. Elaborazione del Gruppo su dati aperti Open-Meteo (modelli ECMWF).</figcaption>
   </figure>


### PR DESCRIPTION
## Cosa cambia

L'immagine `static/images/meteo-lazio.svg` viene rigenerata ogni ora dal workflow `meteo-lazio.yml`, ma ha **URL fisso senza versione**: browser e CDN servivano la copia vecchia in cache e la mappa sembrava "ferma" anche con il file aggiornato sul server.

Aggancio un parametro di cache-busting `?v=<timestamp>` all'URL dell'SVG, derivato dal campo `aggiornato` dei dati (rigenerati nello stesso run dello SVG). A ogni aggiornamento orario l'URL cambia → il browser scarica la versione nuova senza refresh manuale.

- **Non crea file nuovi**: il file fisico resta uno solo (`meteo-lazio.svg`), sovrascritto in place. Nessuno spazio sprecato.
- **Difensivo**: se il dato manca, nessuna versione aggiunta (nessuna rottura).

## Verifica

- `hugo --minify` pulita (exit 0).
- URL reso: `/images/meteo-lazio.svg?v=202605240108`.

https://claude.ai/code/session_01ExjHKfeGmBYLCBijvBw3HE

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExjHKfeGmBYLCBijvBw3HE)_