### PR TITLE
Radar DPC: player stile piattaforma ufficiale (timeline animata + base scura + legenda)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/shortcodes/radar-dpc.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/radar-dpc.html
@@ -1,14 +1,12 @@
-{{/* Shortcode radar-dpc: radar pioggia in tempo reale del Dipartimento della
-     Protezione Civile (Radar-DPC), integrato col METODO UFFICIALE documentato
-     su dpc-radar.readthedocs.io: i prodotti sono erogati come servizi OGC WMS
-     (open-data, licenza CC-BY-SA) e "richiamabili da qualsiasi client WMS/WMTS".
-     Qui usiamo Leaflet self-hosted + base OpenStreetMap, senza iframe di terzi
-     (privacy-first, coerente con le altre mappe del sito mappa-territorio/aree).
-
-       - Endpoint WMS:  https://radar-geowebcache.protezionecivile.it/service/wms
-       - Layer:         radar:sri (pioggia al suolo) · radar:vmi (intensità in quota)
-       - Aggiornamento: ogni 5 minuti (auto-refresh con token a finestre di 5')
-       - Attribuzione:  Radar-DPC © Dipartimento della Protezione Civile (CC BY-SA)
+{{/* Shortcode radar-dpc v2 — radar pioggia DPC in stile "piattaforma radar":
+     base scura (toggle chiara), legenda colorata debole→molto forte, e una
+     TIMELINE ANIMATA dell'ultima ora (play/pausa + barra + "N min fa").
+     Metodo ufficiale (dpc-radar.readthedocs.io): servizi OGC WMTS open-data CC-BY-SA,
+     gridset EPSG:900913, con parametro TIME per i frame storici. Leaflet self-hosted,
+     niente iframe di terzi (privacy-first).
+       - Endpoint: https://radar-geowebcache.protezionecivile.it/service/wmts
+       - Layer:    radar:sri (pioggia al suolo) · radar:vmi (intensità in quota)
+       - Frame:    ultimi 60 minuti a passo di 5 minuti; auto-refresh ogni 5'
 */}}
 {{ $leafletCSS := "vendor/leaflet/leaflet.css" | relURL }}
 {{ $leafletJS  := "vendor/leaflet/leaflet.js"  | relURL }}
@@ -17,42 +15,53 @@
   <h2 id="radar-dpc-titolo" class="h3 mt-4 mb-3" style="color:#003366">
     <i class="bi bi-cloud-rain-heavy-fill me-2" aria-hidden="true"></i>Radar pioggia in tempo reale (Protezione Civile)
   </h2>
-  <p class="mb-2">Pioggia in corso e delle ultime ore dalla rete radar nazionale del Dipartimento della Protezione Civile. I dati si aggiornano ogni 5 minuti. È un dato <strong>indicativo</strong>: per le allerte valgono i bollettini ufficiali del <a href="https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti" target="_blank" rel="noopener noreferrer">Centro Funzionale Regionale del Lazio</a>.</p>
+  <p class="mb-2">Pioggia in corso e dell'ultima ora dalla rete radar nazionale del Dipartimento della Protezione Civile. Premi <strong>play</strong> per vedere il movimento delle precipitazioni. È un dato <strong>indicativo</strong>: per le allerte valgono i bollettini ufficiali del <a href="https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti" target="_blank" rel="noopener noreferrer">Centro Funzionale Regionale del Lazio</a>.</p>
 
   <link rel="stylesheet" href="{{ $leafletCSS }}" crossorigin="">
   <style>
-  .radar-dpc-toolbar{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center;margin-bottom:.75rem}
-  .radar-dpc-filter{display:inline-flex;align-items:center;gap:.4rem;border:2px solid #003366;background:#fff;color:#003366;padding:.4rem .85rem;border-radius:999px;font-size:.95rem;cursor:pointer;transition:all .15s}
+  .radar-dpc-toolbar{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center;margin-bottom:.6rem}
+  .radar-dpc-filter{display:inline-flex;align-items:center;gap:.4rem;border:2px solid #003366;background:#fff;color:#003366;padding:.4rem .85rem;border-radius:999px;font-size:.92rem;cursor:pointer;transition:all .15s}
   .radar-dpc-filter[aria-pressed="true"]{background:#003366;color:#fff}
   .radar-dpc-filter:focus-visible{outline:3px solid #ffbe2e;outline-offset:2px}
-  .radar-dpc-stato{font-size:.9rem;color:#495057;margin-left:auto}
-  #radar-dpc-mappa{height:540px;width:100%;border-radius:8px;border:2px solid #003366;box-shadow:0 4px 12px rgba(0,0,0,.08);background:#eaeaea}
-  @media (max-width:575px){#radar-dpc-mappa{height:440px}.radar-dpc-stato{margin-left:0;width:100%}}
-  .radar-dpc-legenda{display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin-top:.6rem;font-size:.82rem;color:#495057}
-  .radar-dpc-legenda .scala{display:inline-flex;height:.8rem;border-radius:3px;overflow:hidden;border:1px solid #adb5bd}
-  .radar-dpc-legenda .scala i{width:1.4rem;height:100%}
+  #radar-dpc-mappa{height:560px;width:100%;border-radius:8px 8px 0 0;border:2px solid #003366;border-bottom:0;background:#0b1622}
+  @media (max-width:575px){#radar-dpc-mappa{height:460px}}
+  .radar-dpc-overlay{position:absolute;top:10px;left:12px;z-index:600;background:rgba(11,33,56,.82);color:#fff;padding:.3rem .6rem;border-radius:6px;font-size:.85rem;font-weight:700;pointer-events:none}
   .radar-dpc-mappa-box{position:relative}
-  .radar-dpc-aggiorna{position:absolute;top:12px;left:50%;transform:translateX(-50%);z-index:1000;display:flex;align-items:center;gap:.6rem;background:#003366;color:#fff;border:2px solid #ffbe2e;border-radius:999px;padding:.45rem .9rem;box-shadow:0 4px 14px rgba(0,0,0,.25);font-size:.92rem;max-width:92%}
-  .radar-dpc-aggiorna[hidden]{display:none}
-  .radar-dpc-aggiorna button{background:#ffbe2e;color:#1a1a1a;border:0;border-radius:999px;padding:.3rem .8rem;font-weight:700;cursor:pointer;white-space:nowrap}
-  .radar-dpc-aggiorna button:focus-visible{outline:3px solid #fff;outline-offset:2px}
-  @media (prefers-reduced-motion: no-preference){.radar-dpc-aggiorna{animation:radarPulse 1.8s ease-in-out infinite}}
-  @keyframes radarPulse{0%,100%{box-shadow:0 4px 14px rgba(0,0,0,.25)}50%{box-shadow:0 4px 22px rgba(255,190,46,.7)}}
+  /* player */
+  .radar-dpc-player{display:flex;align-items:center;gap:.7rem;background:#0b2138;padding:.5rem .7rem;border:2px solid #003366;border-top:0;border-radius:0 0 8px 8px}
+  .radar-dpc-play{flex:0 0 auto;width:42px;height:42px;border-radius:50%;border:0;background:#2ecc71;color:#06351c;font-size:1.2rem;cursor:pointer;display:inline-flex;align-items:center;justify-content:center}
+  .radar-dpc-play:focus-visible{outline:3px solid #ffbe2e;outline-offset:2px}
+  .radar-dpc-slider{flex:1 1 auto;accent-color:#2ecc71;cursor:pointer}
+  .radar-dpc-time{flex:0 0 auto;color:#fff;font-variant-numeric:tabular-nums;font-size:.92rem;min-width:118px;text-align:right}
+  /* legenda colorata */
+  .radar-dpc-legenda{margin-top:.6rem}
+  .radar-dpc-legenda-barra{display:flex;height:18px;border-radius:4px;overflow:hidden;border:1px solid #adb5bd}
+  .radar-dpc-legenda-barra i{flex:1}
+  .radar-dpc-legenda-et{display:flex;justify-content:space-between;font-size:.72rem;color:#495057;margin-top:.15rem}
   </style>
 
-  <div class="radar-dpc-toolbar" role="group" aria-label="Prodotto radar">
+  <div class="radar-dpc-toolbar" role="group" aria-label="Prodotto e sfondo del radar">
     <button type="button" class="radar-dpc-filter" data-layer="radar:sri" aria-pressed="true">Pioggia al suolo (SRI)</button>
     <button type="button" class="radar-dpc-filter" data-layer="radar:vmi" aria-pressed="false">Intensità in quota (VMI)</button>
-    <button type="button" class="radar-dpc-filter" id="radar-dpc-refresh" aria-pressed="false"><i class="bi bi-arrow-clockwise" aria-hidden="true"></i> Aggiorna</button>
-    <span class="radar-dpc-stato" id="radar-dpc-stato" aria-live="polite"></span>
+    <button type="button" class="radar-dpc-filter" id="radar-dpc-base" aria-pressed="true"><i class="bi bi-moon-stars" aria-hidden="true"></i> Sfondo scuro</button>
   </div>
 
   <div class="radar-dpc-mappa-box">
-    <div id="radar-dpc-mappa" role="application" aria-label="Radar pioggia in tempo reale della Protezione Civile, centrato sull'Italia con Genzano di Roma evidenziata."></div>
-    <div id="radar-dpc-aggiorna" class="radar-dpc-aggiorna" role="status" aria-live="polite" hidden>
-      <span><i class="bi bi-arrow-repeat" aria-hidden="true"></i> È disponibile un aggiornamento del radar.</span>
-      <button type="button" id="radar-dpc-aggiorna-btn">Aggiorna ora</button>
+    <div id="radar-dpc-mappa" role="application" aria-label="Radar pioggia animato della Protezione Civile, ultima ora, centrato sull'Italia con Genzano di Roma evidenziata."></div>
+    <div class="radar-dpc-overlay" id="radar-dpc-prodotto-lbl" aria-hidden="true">Pioggia al suolo (SRI)</div>
+  </div>
+
+  <div class="radar-dpc-player">
+    <button type="button" class="radar-dpc-play" id="radar-dpc-play" aria-label="Avvia l'animazione del radar"><i class="bi bi-play-fill" aria-hidden="true"></i></button>
+    <input type="range" class="radar-dpc-slider" id="radar-dpc-slider" min="0" max="11" value="11" step="1" aria-label="Scorri i fotogrammi del radar dell'ultima ora">
+    <span class="radar-dpc-time" id="radar-dpc-time" aria-live="polite"></span>
+  </div>
+
+  <div class="radar-dpc-legenda" aria-hidden="true">
+    <div class="radar-dpc-legenda-barra">
+      <i style="background:#a6d8ff"></i><i style="background:#2ecc71"></i><i style="background:#a8e05f"></i><i style="background:#f7e359"></i><i style="background:#f5a623"></i><i style="background:#e8412b"></i><i style="background:#b5179e"></i>
     </div>
+    <div class="radar-dpc-legenda-et"><span>debole</span><span>moderato</span><span>intenso</span><span>forte</span><span>molto forte</span></div>
   </div>
 
   <noscript>
@@ -62,91 +71,110 @@
     </div>
   </noscript>
 
-  <div class="radar-dpc-legenda" aria-hidden="true">
-    <span>Pioggia debole</span>
-    <span class="scala"><i style="background:#a8d8ff"></i><i style="background:#3a8bdf"></i><i style="background:#2ecc40"></i><i style="background:#ffdc00"></i><i style="background:#ff851b"></i><i style="background:#ff4136"></i><i style="background:#b10dc9"></i></span>
-    <span>Pioggia intensa</span>
-  </div>
-  <p class="small text-muted mt-2 mb-0">Radar: <a href="https://mappe.protezionecivile.gov.it/it/mappe-e-dashboard-rischi/piattaforma-radar/" target="_blank" rel="noopener noreferrer">Radar-DPC</a> © Dipartimento della Protezione Civile, servizi WMS open-data (CC BY-SA) — base <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">© OpenStreetMap</a>, libreria <a href="https://leafletjs.com/" target="_blank" rel="noopener noreferrer">Leaflet</a> self-hosted. In emergenza chiama il <a href="tel:112">112</a>.</p>
+  <p class="small text-muted mt-2 mb-0">Radar: <a href="https://mappe.protezionecivile.gov.it/it/mappe-e-dashboard-rischi/piattaforma-radar/" target="_blank" rel="noopener noreferrer">Radar-DPC</a> © Dipartimento della Protezione Civile, servizi WMTS open-data (CC BY-SA) — base <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">© OpenStreetMap</a> / <a href="https://carto.com/attributions" target="_blank" rel="noopener noreferrer">© CARTO</a>, libreria <a href="https://leafletjs.com/" target="_blank" rel="noopener noreferrer">Leaflet</a> self-hosted. In emergenza chiama il <a href="tel:112">112</a>.</p>
 
   <script src="{{ $leafletJS }}" crossorigin=""></script>
   <script>
   (function(){
     if (typeof L === 'undefined') return;
-    // Endpoint GeoWebCache: servito come WMTS-KVP sul gridset EPSG:900913
-    // (identico allo schema XYZ di Leaflet/OSM -> le tile combaciano).
     var WMTS = 'https://radar-geowebcache.protezionecivile.it/service/wmts';
-    var prodotto = 'radar:sri';
-    function token(){ return Math.floor(Date.now() / 300000); } // finestra 5'
-    function urlFor(layer){
-      return WMTS + '?Service=WMTS&Request=GetTile&Version=1.0.0'
-        + '&Layer=' + layer + '&Style=&Format=image/png'
-        + '&TileMatrixSet=EPSG:900913&TileMatrix=EPSG:900913:{z}&TileRow={y}&TileCol={x}'
-        + '&cache=' + token();
-    }
     var GENZANO = [41.7085, 12.6916];
-    var stato = document.getElementById('radar-dpc-stato');
+    var ITALIA = L.latLngBounds([35.0, 4.44], [47.92, 20.56]);
+    var BLANK = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+    var prodotto = 'radar:sri', baseDark = true;
+    var NFRAME = 12, STEP = 300000; // 12 frame, 5 minuti
 
-    var mappa = L.map('radar-dpc-mappa', { center: [42.2, 12.6], zoom: 6, scrollWheelZoom: false });
-    mappa.on('focus', function(){ mappa.scrollWheelZoom.enable(); });
-    mappa.on('blur',  function(){ mappa.scrollWheelZoom.disable(); });
+    var map = L.map('radar-dpc-mappa', { center: [42.0, 12.5], zoom: 6, scrollWheelZoom: false });
+    map.on('focus', function(){ map.scrollWheelZoom.enable(); });
+    map.on('blur',  function(){ map.scrollWheelZoom.disable(); });
 
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      maxZoom: 12,
-      attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a>'
-    }).addTo(mappa);
+    var baseScura = L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+      subdomains: 'abcd', maxZoom: 12, attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> © <a href="https://carto.com/attributions">CARTO</a>' });
+    var baseChiara = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 12, attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>' });
+    baseScura.addTo(map);
 
-    // token a finestre di 5 minuti: dentro la finestra le tile sono cache-abili,
-    // alla finestra nuova si forza il refetch dell'ultimo campione disponibile.
-    function token(){ return Math.floor(Date.now() / 300000); }
+    function pad(n){ return ('0'+n).slice(-2); }
+    function isoZ(d){ return d.getUTCFullYear()+'-'+pad(d.getUTCMonth()+1)+'-'+pad(d.getUTCDate())+'T'+pad(d.getUTCHours())+':'+pad(d.getUTCMinutes())+':00.000Z'; }
+    function urlFor(layer, ts){
+      return WMTS + '?Service=WMTS&Request=GetTile&Version=1.0.0&Layer=' + layer
+        + '&Style=&Format=image/png&TileMatrixSet=EPSG:900913&TileMatrix=EPSG:900913:{z}&TileRow={y}&TileCol={x}'
+        + '&TIME=' + ts;
+    }
+    function buildTimes(){
+      var latest = new Date(Math.floor(Date.now()/STEP)*STEP - STEP); // -5' di latenza
+      var out = [];
+      for (var k = NFRAME-1; k >= 0; k--){ out.push(new Date(latest.getTime() - k*STEP)); }
+      return out;
+    }
 
-    var radar = L.tileLayer(urlFor(prodotto), {
-      opacity: 0.72,
-      maxZoom: 11,
-      maxNativeZoom: 9,
-      tileSize: 256,
-      bounds: L.latLngBounds([35.0, 4.44], [47.92, 20.56]),
-      attribution: 'Radar-DPC © Dipartimento della Protezione Civile (CC BY-SA)'
-    });
-    radar.addTo(mappa);
+    var times = [], layers = [], idx = NFRAME-1, playing = false, timer = null;
+    var playBtn = document.getElementById('radar-dpc-play');
+    var slider  = document.getElementById('radar-dpc-slider');
+    var timeLbl = document.getElementById('radar-dpc-time');
+    var prodLbl = document.getElementById('radar-dpc-prodotto-lbl');
+
+    function clearLayers(){ layers.forEach(function(l){ map.removeLayer(l); }); layers = []; }
+    function buildLayers(){
+      clearLayers();
+      times = buildTimes();
+      times.forEach(function(d){
+        layers.push(L.tileLayer(urlFor(prodotto, isoZ(d)), {
+          opacity: 0, maxZoom: 11, maxNativeZoom: 9, tileSize: 256,
+          bounds: ITALIA, errorTileUrl: BLANK
+        }).addTo(map));
+      });
+      if (idx > times.length-1) idx = times.length-1;
+      slider.max = times.length-1;
+      showFrame(idx);
+    }
+    function showFrame(i){
+      idx = i;
+      layers.forEach(function(l, j){ l.setOpacity(j === i ? 0.8 : 0); });
+      slider.value = i;
+      var d = times[i];
+      var mins = Math.round((Date.now() - d.getTime())/60000);
+      timeLbl.textContent = pad(d.getHours()) + ':' + pad(d.getMinutes()) + (mins > 0 ? (' · ' + mins + ' min fa') : ' · adesso');
+    }
+    function setPlay(on){
+      playing = on;
+      playBtn.innerHTML = on ? '<i class="bi bi-pause-fill" aria-hidden="true"></i>' : '<i class="bi bi-play-fill" aria-hidden="true"></i>';
+      playBtn.setAttribute('aria-label', on ? 'Metti in pausa l\'animazione del radar' : 'Avvia l\'animazione del radar');
+      if (timer){ clearInterval(timer); timer = null; }
+      if (on){ timer = setInterval(function(){ showFrame((idx+1) % times.length); }, 700); }
+    }
 
     // stella su Genzano di Roma
-    var stella = L.divIcon({
-      className: 'radar-dpc-stella',
-      html: '<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#b8860b" stroke="#fff" stroke-width="1.4"/></svg>',
-      iconSize: [26, 26], iconAnchor: [13, 13]
-    });
-    L.marker(GENZANO, { icon: stella, title: 'Genzano di Roma', keyboard: true })
-      .bindPopup('<strong>Genzano di Roma</strong>').addTo(mappa);
+    L.marker(GENZANO, { keyboard: true, icon: L.divIcon({ className: 'radar-dpc-stella',
+      html: '<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#ffd166" stroke="#0b1622" stroke-width="1.4"/></svg>',
+      iconSize: [26,26], iconAnchor: [13,13] }) }).bindPopup('<strong>Genzano di Roma</strong>').addTo(map);
 
-    function segnaAggiornato(){
-      var d = new Date();
-      stato.textContent = 'Aggiornato alle ' + ('0'+d.getHours()).slice(-2) + ':' + ('0'+d.getMinutes()).slice(-2);
-    }
-    radar.on('load', segnaAggiornato);
+    buildLayers();
 
-    // Notifica "aggiornamento disponibile" come sul sito ufficiale DPC: ogni 5'
-    // compare un avviso non bloccante; l'aggiornamento avviene al click (così
-    // l'utente sa che sta guardando il dato fresco). Versione accessibile: banner
-    // role=status aria-live, non un popup modale che obbliga.
-    var bannerAgg = document.getElementById('radar-dpc-aggiorna');
-    function mostraAggiornamento(){ if (bannerAgg) bannerAgg.hidden = false; }
-    function refresh(){ radar.setUrl(urlFor(prodotto)); if (bannerAgg) bannerAgg.hidden = true; }
-    setInterval(mostraAggiornamento, 300000); // ogni 5 minuti
+    playBtn.addEventListener('click', function(){ setPlay(!playing); });
+    slider.addEventListener('input', function(){ setPlay(false); showFrame(parseInt(slider.value, 10)); });
 
-    // cambio prodotto SRI/VMI
     document.querySelectorAll('.radar-dpc-filter[data-layer]').forEach(function(btn){
       btn.addEventListener('click', function(){
         document.querySelectorAll('.radar-dpc-filter[data-layer]').forEach(function(b){ b.setAttribute('aria-pressed','false'); });
         btn.setAttribute('aria-pressed','true');
         prodotto = btn.dataset.layer;
-        refresh();
+        prodLbl.textContent = btn.textContent.trim();
+        buildLayers();
       });
     });
-    var btnR = document.getElementById('radar-dpc-refresh');
-    if (btnR) btnR.addEventListener('click', refresh);
-    var btnA = document.getElementById('radar-dpc-aggiorna-btn');
-    if (btnA) btnA.addEventListener('click', refresh);
+    var baseBtn = document.getElementById('radar-dpc-base');
+    baseBtn.addEventListener('click', function(){
+      baseDark = !baseDark;
+      if (baseDark){ map.removeLayer(baseChiara); baseScura.addTo(map); baseScura.bringToBack();
+        baseBtn.innerHTML = '<i class="bi bi-moon-stars" aria-hidden="true"></i> Sfondo scuro'; }
+      else { map.removeLayer(baseScura); baseChiara.addTo(map); baseChiara.bringToBack();
+        baseBtn.innerHTML = '<i class="bi bi-sun" aria-hidden="true"></i> Sfondo chiaro'; }
+      baseBtn.setAttribute('aria-pressed', baseDark ? 'true' : 'false');
+    });
+
+    // auto-refresh dei frame ogni 5 minuti (nuovo campione disponibile)
+    setInterval(function(){ var wasPlaying = playing; buildLayers(); if (wasPlaying) setPlay(true); }, STEP);
   })();
   </script>
 </div>


### PR DESCRIPTION
Richiesta utente: rendere il radar simile alla piattaforma ufficiale DPC (parametri e bottoni).

- **Timeline animata** dell'ultima ora: 12 frame a 5 minuti via WMTS con parametro `TIME` (testato, 200 OK sui frame storici), **play/pausa + barra di scorrimento + 'HH:MM · N min fa'**, auto-refresh ogni 5'.
- **Base scura** (CARTO dark) con **toggle a sfondo chiaro** (massima visibilità dei dati, come la piattaforma DPC).
- **Legenda colorata** debole→molto forte, etichetta prodotto sulla mappa, stella Genzano di Roma, SRI/VMI.
- Sempre metodo ufficiale WMTS open-data CC-BY-SA, Leaflet self-hosted, nessun iframe di terzi.

Build pulito.