### PR TITLE
Home: card sismica 'Hai sentito un terremoto?' con link diretto INGV

### DIFF
--- a/themes/flavour-pcgenzano/layouts/index.html
+++ b/themes/flavour-pcgenzano/layouts/index.html
@@ -249,21 +249,20 @@
       </div>
     </div>
 
-    {{/* Widget INGV — riga propria, full-width su mobile per max usabilità */}}
-    <div class="row mb-4">
-      <div class="col-12">
-        {{ partial "external-widget.html" (dict
-          "src"              "https://terremoti.ingv.it/"
-          "title"            "Mappa interattiva dei terremoti recenti in Italia — INGV"
-          "placeholderTitle" "Terremoti recenti — INGV"
-          "placeholderDesc"  "Lista e mappa degli eventi sismici in Italia forniti da <strong>INGV</strong> (Istituto Nazionale di Geofisica e Vulcanologia)."
-          "icon"             "bi-activity"
-          "btnLabel"         "Carica la mappa INGV"
-          "altUrl"           "https://terremoti.ingv.it/"
-          "altLabel"         "terremoti.ingv.it"
-          "fallbackText"     "Elenco terremoti recenti su terremoti.ingv.it (Istituto Nazionale di Geofisica e Vulcanologia)"
-          "widgetId"         "home-sismico-ingv"
-        ) }}
+    {{/* Card sismica — rimando diretto all'INGV (niente embed pesante) */}}
+    <div class="row mb-4 justify-content-center">
+      <div class="col-12 col-lg-10">
+        <div class="terremoto-card">
+          <div class="terremoto-card-icon" aria-hidden="true"><i class="bi bi-activity"></i></div>
+          <div class="terremoto-card-body">
+            <h3 class="terremoto-card-title">Hai sentito un terremoto?</h3>
+            <p class="terremoto-card-text">Controlla le <strong>ultime scosse</strong> rilevate in tempo reale dall'<strong>INGV</strong> (Istituto Nazionale di Geofisica e Vulcanologia) e scopri cosa fare in caso di terremoto.</p>
+            <div class="terremoto-card-actions">
+              <a class="btn btn-primary" href="https://terremoti.ingv.it/" target="_blank" rel="noopener noreferrer" aria-label="Vedi le ultime scosse di terremoto sul sito INGV (si apre in una nuova scheda)"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Ultime scosse (INGV)</a>
+              <a class="btn btn-outline-primary" href="{{ "rischi-prevenzione/rischio-sismico/" | relURL }}"><i class="bi bi-shield-check" aria-hidden="true"></i> Cosa fare in caso di terremoto</a>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <p class="small text-muted text-center mt-3 mb-0">

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6558,3 +6558,18 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 .meteo-home-link { text-align: center; margin-top: 1.3rem; font-weight: 600; }
 .cartina-azioni { display: flex; gap: .5rem; justify-content: center; margin-top: .6rem; flex-wrap: wrap; }
 .cartina-azioni .btn i { margin-right: .25rem; }
+
+/* ============================================================
+   TERREMOTO CARD HOME v1.0 — card sismica con rimando INGV
+   ============================================================ */
+.terremoto-card { display: flex; align-items: center; gap: 1.1rem; background: #e7f0fa;
+  border: 1px solid #cfe0f0; border-left: 5px solid #003366; border-radius: 10px;
+  padding: 1.1rem 1.3rem; }
+.terremoto-card-icon { flex: 0 0 auto; width: 56px; height: 56px; border-radius: 50%;
+  background: #003366; color: #fff; display: inline-flex; align-items: center;
+  justify-content: center; font-size: 1.7rem; }
+.terremoto-card-title { color: #003366; margin: 0 0 .25rem; font-size: 1.2rem; }
+.terremoto-card-text { margin: 0 0 .7rem; color: #1a1a1a; font-size: .96rem; }
+.terremoto-card-actions { display: flex; flex-wrap: wrap; gap: .5rem; }
+@media (max-width: 575px) { .terremoto-card { flex-direction: column; text-align: center; }
+  .terremoto-card-actions { justify-content: center; } }


### PR DESCRIPTION
Richiesta utente: card terremoto in homepage tipo 'Hai sentito un terremoto? vuoi vedere le ultime scosse?' con link diretto all'INGV.

- Card leggera con: **Ultime scosse (INGV)** → https://terremoti.ingv.it/ (nuova scheda) + **Cosa fare in caso di terremoto** → /rischi-prevenzione/rischio-sismico/ (linkografia interna).
- **Rimosso** l'embed iframe terremoti INGV dalla home (più leggero, privacy-first). Resta il widget Windy (rimozione separata, da confermare).

Build pulito.