### PR TITLE
Home: rimuovo Windy (resta in /allerte-meteo/)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/index.html
+++ b/themes/flavour-pcgenzano/layouts/index.html
@@ -231,24 +231,6 @@
   <div class="container">
     <h2 id="monitoraggio-title" class="section-title text-center">Monitoraggio in tempo reale</h2>
     <p class="text-muted text-center mb-4">Strumenti di consultazione da fonti scientifiche ufficiali. <strong>Non sostituiscono</strong> i bollettini di allerta della Regione Lazio.</p>
-    {{/* Widget meteo — riga propria, full-width su mobile per max usabilità */}}
-    <div class="row mb-4">
-      <div class="col-12">
-        {{ partial "external-widget.html" (dict
-          "src"              "https://embed.windy.com/embed2.html?lat=41.6919&lon=12.6928&detailLat=41.6919&detailLon=12.6928&width=100%25&height=780&zoom=12&level=surface&overlay=radar&product=ecmwf&menu=&message=&marker=true&calendar=now&pressure=&type=map&location=coordinates&detail=&metricWind=default&metricTemp=default&radarRange=-1"
-          "title"            "Mappa meteo interattiva Windy centrata su Genzano di Roma"
-          "placeholderTitle" "Mappa meteo — Windy"
-          "placeholderDesc"  "Radar, precipitazioni, vento e temperatura centrati su Genzano. Carica i contenuti forniti da <strong>Windy.com</strong> (cookie tecnici di terze parti possibili)."
-          "icon"             "bi-cloud-rain-heavy"
-          "btnLabel"         "Carica la mappa meteo"
-          "altUrl"           "https://www.windy.com/?41.691,12.692,12"
-          "altLabel"         "Windy.com centrato su Genzano di Roma"
-          "fallbackText"     "Mappa meteo online su windy.com — Genzano di Roma (41.6919 N, 12.6928 E)"
-          "widgetId"         "home-meteo-windy"
-        ) }}
-      </div>
-    </div>
-
     {{/* Card sismica — rimando diretto all'INGV (niente embed pesante) */}}
     <div class="row mb-4 justify-content-center">
       <div class="col-12 col-lg-10">


### PR DESCRIPTION
Richiesta utente: togliere Windy dalla home, lasciarlo in /allerte-meteo/ con le altre mappe esterne (dove è già presente).

- Rimosso il widget Windy dalla homepage. In home il meteo è ora la **nostra cartina del Lazio** (riquadro Genzano di Roma completo) + la **card sismica** con rimando INGV.
- Windy invariato su /allerte-meteo/.

Build pulito.