### PR TITLE
Home: card terremoti semplice accanto a IT-alert

### DIFF
--- a/themes/flavour-pcgenzano/layouts/index.html
+++ b/themes/flavour-pcgenzano/layouts/index.html
@@ -223,7 +223,7 @@
 {{/* Notizie in evidenza */}}
 {{ partial "latest-news.html" . }}
 
-{{/* Meteo e terremoti in tempo reale — cartina Lazio + card sismica (sezione unica) */}}
+{{/* Meteo — cartina Lazio (la card sismica è accanto a IT-alert in social-channels) */}}
 {{ partial "meteo-cartine-home.html" . }}
 
 {{/* Giochi della Sicurezza — CTA formazione */}}

--- a/themes/flavour-pcgenzano/layouts/partials/meteo-cartine-home.html
+++ b/themes/flavour-pcgenzano/layouts/partials/meteo-cartine-home.html
@@ -1,14 +1,13 @@
-{{- /* Sezione homepage "Meteo e terremoti in tempo reale": la nostra cartina del
-       Lazio (con riquadro completo di Genzano di Roma, dentro l'SVG) + card sismica
-       con rimando diretto all'INGV. Tentativo 1 di riordino home: accorpa meteo e
-       sismica in un'unica sezione (prima erano due, con il guscio "Monitoraggio"). */ -}}
+{{- /* Sezione homepage "Meteo": la nostra cartina del Lazio (con riquadro completo
+       di Genzano di Roma, dentro l'SVG) + azioni Scarica/Condividi/Approfondisci.
+       La card sismica è ora una card semplice accanto a IT-alert (social-channels). */ -}}
 {{- $svg := "images/meteo-lazio.svg" | relURL -}}
 {{- $vG := "" -}}{{- with .Site.Data.meteo_genzano }}{{ with .aggiornato }}{{ $vG = printf "?v=%s" (. | replaceRE `[^0-9]` "") }}{{ end }}{{ end -}}
 
 <section class="meteo-home" aria-labelledby="meteo-home-titolo">
   <div class="container">
-    <h2 id="meteo-home-titolo" class="meteo-home-titolo"><i class="bi bi-cloud-sun-fill" aria-hidden="true"></i> Meteo e terremoti in tempo reale</h2>
-    <p class="meteo-home-intro">La nostra cartina del Lazio con il dettaglio completo di Genzano di Roma e gli ultimi terremoti rilevati dall'INGV. Dati <strong>indicativi</strong>: per le allerte valgono i bollettini del <a href="https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti" target="_blank" rel="noopener noreferrer">Centro Funzionale Regionale del Lazio</a>.</p>
+    <h2 id="meteo-home-titolo" class="meteo-home-titolo"><i class="bi bi-cloud-sun-fill" aria-hidden="true"></i> Meteo a Genzano di Roma e nel Lazio</h2>
+    <p class="meteo-home-intro">Temperatura e cielo previsti oggi, con il dettaglio completo di Genzano di Roma. Aggiornata automaticamente su dati aperti Open-Meteo (modelli ECMWF). Un dato <strong>indicativo</strong>: per le allerte valgono i bollettini del <a href="https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti" target="_blank" rel="noopener noreferrer">Centro Funzionale Regionale del Lazio</a>.</p>
 
     <div class="meteo-home-grid">
       <figure class="meteo-home-card">
@@ -23,23 +22,6 @@
     </div>
 
     <p class="meteo-home-link"><a href="{{ "allerte-meteo/" | relURL }}">Sulla pagina Allerte meteo trovi anche la carta sinottica dell'Italia, l'animazione e il radar pioggia in tempo reale <i class="bi bi-arrow-right" aria-hidden="true"></i></a></p>
-
-    {{/* Card sismica — rimando diretto all'INGV (niente embed pesante) */}}
-    <div class="meteo-home-grid">
-      <div class="terremoto-card">
-        <div class="terremoto-card-icon" aria-hidden="true"><i class="bi bi-activity"></i></div>
-        <div class="terremoto-card-body">
-          <h3 class="terremoto-card-title">Hai sentito un terremoto?</h3>
-          <p class="terremoto-card-text">Controlla le <strong>ultime scosse</strong> rilevate in tempo reale dall'<strong>INGV</strong> (Istituto Nazionale di Geofisica e Vulcanologia) e scopri cosa fare in caso di terremoto.</p>
-          <div class="terremoto-card-actions">
-            <a class="btn btn-primary" href="https://terremoti.ingv.it/" target="_blank" rel="noopener noreferrer" aria-label="Vedi le ultime scosse di terremoto sul sito INGV (si apre in una nuova scheda)"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Ultime scosse (INGV)</a>
-            <a class="btn btn-outline-primary" href="{{ "rischi-prevenzione/rischio-sismico/" | relURL }}"><i class="bi bi-shield-check" aria-hidden="true"></i> Cosa fare in caso di terremoto</a>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <p class="small text-muted text-center mt-3 mb-0">Fonti ufficiali: <a href="https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti" target="_blank" rel="noopener noreferrer">Bollettino Regione Lazio</a> · <a href="https://www.ingv.it/" target="_blank" rel="noopener noreferrer">INGV</a> · <a href="https://www.protezionecivile.gov.it/" target="_blank" rel="noopener noreferrer">Dipartimento Protezione Civile</a></p>
   </div>
 </section>
 <script src="{{ "js/condividi-cartina.js" | relURL }}" defer></script>

--- a/themes/flavour-pcgenzano/layouts/partials/social-channels.html
+++ b/themes/flavour-pcgenzano/layouts/partials/social-channels.html
@@ -14,7 +14,7 @@
     <div class="row g-3 align-items-stretch">
 
       {{/* ── BOX 1: SEGUICI SUI NOSTRI CANALI (blu istituzionale) ── */}}
-      <div class="col-lg-7">
+      <div class="col-lg-4">
         <div class="strumenti-articolo" role="region" aria-labelledby="canali-heading">
           <div class="strumenti-articolo-header" id="canali-heading">
             <i class="bi bi-share-fill me-2" aria-hidden="true"></i>
@@ -45,7 +45,7 @@
       </div>
 
       {{/* ── BOX 2: IT-ALERT (ambra, variante avviso) ── */}}
-      <div class="col-lg-5">
+      <div class="col-lg-4">
         <div class="strumenti-articolo variant-avviso" role="region" aria-labelledby="italert-heading">
           <div class="strumenti-articolo-header" id="italert-heading">
             <i class="bi bi-phone-vibrate-fill me-2" aria-hidden="true"></i>
@@ -63,6 +63,29 @@
                aria-label="Scopri come funziona IT-alert — si apre in una nuova finestra">
               <i class="bi bi-info-circle me-1" aria-hidden="true"></i>
               Scopri come funziona
+            </a>
+          </div>
+        </div>
+      </div>
+
+      {{/* ── BOX 3: TERREMOTI (rimando diretto INGV, stile sobrio come IT-alert) ── */}}
+      <div class="col-lg-4">
+        <div class="strumenti-articolo" role="region" aria-labelledby="terremoti-heading">
+          <div class="strumenti-articolo-header" id="terremoti-heading">
+            <i class="bi bi-activity me-2" aria-hidden="true"></i>
+            Hai sentito un terremoto?
+          </div>
+          <div class="it-alert-body">
+            <p>
+              Controlla le <strong>ultime scosse</strong> rilevate in tempo reale
+              dall'<strong>INGV</strong> e <a href="{{ "rischi-prevenzione/rischio-sismico/" | relURL }}">cosa fare in caso di terremoto</a>.
+            </p>
+            <a href="https://terremoti.ingv.it/"
+               target="_blank" rel="noopener noreferrer"
+               class="btn btn-sm btn-outline-primary"
+               aria-label="Vedi le ultime scosse di terremoto su INGV — si apre in una nuova finestra">
+              <i class="bi bi-geo-alt me-1" aria-hidden="true"></i>
+              Ultime scosse (INGV)
             </a>
           </div>
         </div>

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6558,18 +6558,3 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 .meteo-home-link { text-align: center; margin-top: 1.3rem; font-weight: 600; }
 .cartina-azioni { display: flex; gap: .5rem; justify-content: center; margin-top: .6rem; flex-wrap: wrap; }
 .cartina-azioni .btn i { margin-right: .25rem; }
-
-/* ============================================================
-   TERREMOTO CARD HOME v1.0 — card sismica con rimando INGV
-   ============================================================ */
-.terremoto-card { display: flex; align-items: center; gap: 1.1rem; background: #e7f0fa;
-  border: 1px solid #cfe0f0; border-left: 5px solid #003366; border-radius: 10px;
-  padding: 1.1rem 1.3rem; }
-.terremoto-card-icon { flex: 0 0 auto; width: 56px; height: 56px; border-radius: 50%;
-  background: #003366; color: #fff; display: inline-flex; align-items: center;
-  justify-content: center; font-size: 1.7rem; }
-.terremoto-card-title { color: #003366; margin: 0 0 .25rem; font-size: 1.2rem; }
-.terremoto-card-text { margin: 0 0 .7rem; color: #1a1a1a; font-size: .96rem; }
-.terremoto-card-actions { display: flex; flex-wrap: wrap; gap: .5rem; }
-@media (max-width: 575px) { .terremoto-card { flex-direction: column; text-align: center; }
-  .terremoto-card-actions { justify-content: center; } }


### PR DESCRIPTION
Richiesta utente: la sezione terremoti era troppo grande/invasiva; volevano una card semplice come IT-alert, possibilmente accanto.

- Card sismica ora è un **box .strumenti-articolo sobrio** (stesso stile di IT-alert): testo + 'Ultime scosse (INGV)' + link interno 'cosa fare in caso di terremoto'.
- Affiancata a IT-alert nella sezione Comunità (3 box: Canali · IT-alert · Terremoti).
- Sezione meteo torna **solo meteo** (titolo/intro aggiornati).
- Rimosso il riquadrone precedente + CSS morto.

Build pulito.