### PR TITLE
Home meteo: card-CTA colorata per 'Allerte meteo' (al posto del link piatto)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/partials/meteo-cartine-home.html
+++ b/themes/flavour-pcgenzano/layouts/partials/meteo-cartine-home.html
@@ -21,7 +21,16 @@
       </figure>
     </div>
 
-    <p class="meteo-home-link"><a href="{{ "allerte-meteo/" | relURL }}">Sulla pagina Allerte meteo trovi anche la carta sinottica dell'Italia, l'animazione e il radar pioggia in tempo reale <i class="bi bi-arrow-right" aria-hidden="true"></i></a></p>
+    <div class="meteo-home-grid">
+      <a class="meteo-approfondisci-card" href="{{ "allerte-meteo/" | relURL }}">
+        <span class="meteo-approfondisci-icona" aria-hidden="true"><i class="bi bi-cloud-lightning-rain-fill"></i></span>
+        <span class="meteo-approfondisci-testo">
+          <span class="meteo-approfondisci-titolo">Vuoi vedere di più?</span>
+          Sulla pagina <strong>Allerte meteo</strong> trovi la carta sinottica dell'Italia, l'animazione e il radar pioggia in tempo reale.
+        </span>
+        <span class="meteo-approfondisci-freccia" aria-hidden="true"><i class="bi bi-arrow-right"></i></span>
+      </a>
+    </div>
   </div>
 </section>
 <script src="{{ "js/condividi-cartina.js" | relURL }}" defer></script>

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6558,3 +6558,19 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 .meteo-home-link { text-align: center; margin-top: 1.3rem; font-weight: 600; }
 .cartina-azioni { display: flex; gap: .5rem; justify-content: center; margin-top: .6rem; flex-wrap: wrap; }
 .cartina-azioni .btn i { margin-right: .25rem; }
+
+/* ── Card-CTA "Approfondisci il meteo" (home) ── */
+.meteo-approfondisci-card { display: flex; align-items: center; gap: 1rem; width: 100%;
+  background: #003366; color: #fff; text-decoration: none; border-radius: 10px;
+  padding: 1rem 1.2rem; box-shadow: 0 2px 10px rgba(0,51,102,.18);
+  transition: background .15s, transform .15s, box-shadow .15s; }
+.meteo-approfondisci-card:hover, .meteo-approfondisci-card:focus-visible {
+  background: #0a4a85; color: #fff; transform: translateY(-2px); box-shadow: 0 4px 16px rgba(0,51,102,.28); }
+.meteo-approfondisci-card:focus-visible { outline: 3px solid #ffbe2e; outline-offset: 2px; }
+.meteo-approfondisci-icona { flex: 0 0 auto; font-size: 1.8rem; color: #ffbe2e; line-height: 1; }
+.meteo-approfondisci-testo { flex: 1 1 auto; font-size: .95rem; line-height: 1.35; }
+.meteo-approfondisci-titolo { display: block; font-weight: 700; font-size: 1.05rem; margin-bottom: .1rem; }
+.meteo-approfondisci-freccia { flex: 0 0 auto; font-size: 1.5rem; color: #ffbe2e; transition: transform .15s; }
+.meteo-approfondisci-card:hover .meteo-approfondisci-freccia { transform: translateX(4px); }
+@media (prefers-reduced-motion: reduce) { .meteo-approfondisci-card, .meteo-approfondisci-freccia { transition: none; }
+  .meteo-approfondisci-card:hover { transform: none; } }


### PR DESCRIPTION
Richiesta utente: rendere graficamente migliore il link 'Sulla pagina Allerte meteo trovi...' — dentro un bottone o una card colorata.

- Ora è una **card-CTA cliccabile** blu istituzionale (#003366) con icona meteo, titolo 'Vuoi vedere di più?', testo e freccia oro (#ffbe2e); hover lift + freccia che scorre; focus visibile; rispetta prefers-reduced-motion.

Build pulito.