### PR TITLE
Home meteo: intro più snella (via la frase ridondante sul CFR Lazio)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/partials/meteo-cartine-home.html
+++ b/themes/flavour-pcgenzano/layouts/partials/meteo-cartine-home.html
@@ -7,7 +7,7 @@
 <section class="meteo-home" aria-labelledby="meteo-home-titolo">
   <div class="container">
     <h2 id="meteo-home-titolo" class="meteo-home-titolo"><i class="bi bi-cloud-sun-fill" aria-hidden="true"></i> Meteo a Genzano di Roma e nel Lazio</h2>
-    <p class="meteo-home-intro">Temperatura e cielo previsti oggi, con il dettaglio completo di Genzano di Roma. Aggiornata automaticamente su dati aperti Open-Meteo (modelli ECMWF). Un dato <strong>indicativo</strong>: per le allerte valgono i bollettini del <a href="https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti" target="_blank" rel="noopener noreferrer">Centro Funzionale Regionale del Lazio</a>.</p>
+    <p class="meteo-home-intro">Temperatura e cielo previsti oggi, con il dettaglio completo di Genzano di Roma. Aggiornata automaticamente su dati aperti Open-Meteo (modelli ECMWF).</p>
 
     <div class="meteo-home-grid">
       <figure class="meteo-home-card">


### PR DESCRIPTION
Richiesta utente: nell'intro della sezione meteo la frase 'Un dato indicativo: per le allerte valgono i bollettini del Centro Funzionale Regionale del Lazio' è ridondante (già presente nelle didascalie). Rimossa dall'intro.