### PR TITLE
Condivisione/scarica cartine: cache-bust per condividere la versione fresca

### DIFF
--- a/themes/flavour-pcgenzano/layouts/partials/meteo-cartine-home.html
+++ b/themes/flavour-pcgenzano/layouts/partials/meteo-cartine-home.html
@@ -14,8 +14,8 @@
         <img src="{{ $svg }}{{ $vG }}" loading="lazy" alt="Cartina del Lazio con temperatura e cielo previsti per provincia e il riquadro completo di Genzano di Roma (temperatura attuale, percepita, massima e minima, umidità, vento, pressione, nuvolosità, UV, alba, tramonto e prossimi giorni).">
         <figcaption>Lazio e dettaglio completo di Genzano di Roma.</figcaption>
         <div class="cartina-azioni">
-          <a class="btn btn-sm btn-outline-primary" href="{{ $svg }}" download><i class="bi bi-download" aria-hidden="true"></i> Scarica</a>
-          <button type="button" class="btn btn-sm btn-outline-primary" data-condividi-cartina data-img="{{ $svg }}" data-title="Cartina meteo del Lazio — Protezione Civile Genzano di Roma"><i class="bi bi-share" aria-hidden="true"></i> <span class="cartina-azione-label">Condividi</span></button>
+          <a class="btn btn-sm btn-outline-primary" href="{{ $svg }}{{ $vG }}" download><i class="bi bi-download" aria-hidden="true"></i> Scarica</a>
+          <button type="button" class="btn btn-sm btn-outline-primary" data-condividi-cartina data-img="{{ $svg }}{{ $vG }}" data-title="Cartina meteo del Lazio — Protezione Civile Genzano di Roma"><i class="bi bi-share" aria-hidden="true"></i> <span class="cartina-azione-label">Condividi</span></button>
           <a class="btn btn-sm btn-primary" href="{{ "allerte-meteo/" | relURL }}"><i class="bi bi-cloud-sun" aria-hidden="true"></i> Approfondisci il meteo</a>
         </div>
       </figure>

--- a/themes/flavour-pcgenzano/layouts/shortcodes/meteo-anteprime.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/meteo-anteprime.html
@@ -20,8 +20,8 @@
            alt="Animazione della previsione del Lazio per le prossime 72 ore: la temperatura e il cielo previsti nelle cinque province e a Genzano di Roma cambiano fotogramma dopo fotogramma, a passo di sei ore.">
       <figcaption>Evoluzione della temperatura e del cielo previsti nel Lazio, frame ogni 6 ore. <strong>Elaborazione grafica del Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma</strong>, su dati Open-Meteo (modelli ECMWF).</figcaption>
       <div class="cartina-azioni">
-        <a class="btn btn-sm btn-outline-primary" href="{{ $svgA }}" download><i class="bi bi-download" aria-hidden="true"></i> Scarica</a>
-        <button type="button" class="btn btn-sm btn-outline-primary" data-condividi-cartina data-img="{{ $svgA }}" data-title="Animazione meteo del Lazio — Protezione Civile Genzano di Roma"><i class="bi bi-share" aria-hidden="true"></i> <span class="cartina-azione-label">Condividi</span></button>
+        <a class="btn btn-sm btn-outline-primary" href="{{ $svgA }}{{ $vA }}" download><i class="bi bi-download" aria-hidden="true"></i> Scarica</a>
+        <button type="button" class="btn btn-sm btn-outline-primary" data-condividi-cartina data-img="{{ $svgA }}{{ $vA }}" data-title="Animazione meteo del Lazio — Protezione Civile Genzano di Roma"><i class="bi bi-share" aria-hidden="true"></i> <span class="cartina-azione-label">Condividi</span></button>
       </div>
     </figure>
     <p class="meteo-confronto-desc">Leggera e nitida a ogni ingrandimento, centrata sul nostro territorio: temperatura e cielo previsti che cambiano fotogramma dopo fotogramma.</p>
@@ -34,8 +34,8 @@
            alt="Carta sinottica animata dell'Italia e del Mediterraneo centrale per le prossime 72 ore: temperatura a 850 hPa a colori, pressione al livello del mare con isobare nere, geopotenziale a 500 hPa con linee viola, vento a 500 hPa con barbe; Genzano di Roma è indicata da una stella.">
       <figcaption>Carta sinottica in stile professionale: campo termico, isobare, saccature in quota e corrente a getto. <strong>Elaborazione grafica del Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma</strong>, su dati Open-Meteo (modelli ECMWF).</figcaption>
       <div class="cartina-azioni">
-        <a class="btn btn-sm btn-outline-primary" href="{{ $webpB }}" download><i class="bi bi-download" aria-hidden="true"></i> Scarica la clip</a>
-        <button type="button" class="btn btn-sm btn-outline-primary" data-condividi-cartina data-img="{{ $webpB }}" data-title="Carta sinottica Italia — Protezione Civile Genzano di Roma"><i class="bi bi-share" aria-hidden="true"></i> <span class="cartina-azione-label">Condividi</span></button>
+        <a class="btn btn-sm btn-outline-primary" href="{{ $webpB }}{{ $vB }}" download><i class="bi bi-download" aria-hidden="true"></i> Scarica la clip</a>
+        <button type="button" class="btn btn-sm btn-outline-primary" data-condividi-cartina data-img="{{ $webpB }}{{ $vB }}" data-title="Carta sinottica Italia — Protezione Civile Genzano di Roma"><i class="bi bi-share" aria-hidden="true"></i> <span class="cartina-azione-label">Condividi</span></button>
       </div>
     </figure>
     <p class="meteo-confronto-desc">Vista d'insieme su Italia e Mediterraneo: precipitazioni e neve a colori, isobare, correnti in quota e minimi/massimi di pressione. Clip animata condivisibile.</p>


### PR DESCRIPTION
Segnalazione utente: condividendo/aprendo /images/meteo-lazio.svg si apriva una versione VECCHIA in cache (del 23 maggio, design pre-riquadro Genzano). La homepage la mostrava fresca perché usa ?v=.

Fix: i pulsanti Scarica e Condividi ora puntano all'URL con cache-bust `?v=<timestamp>` → forzano il fetch della versione corrente (con il riquadro completo di Genzano di Roma). Applicato a home (cartina Lazio) e /allerte-meteo/ (animazione + sinottica).