### PR TITLE
Home meteo: spazio sopra la card 'Approfondisci'

### DIFF
--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6561,7 +6561,7 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 
 /* ── Card-CTA "Approfondisci il meteo" (home) ── */
 .meteo-approfondisci-card { display: flex; align-items: center; gap: 1rem; width: 100%;
-  background: #003366; color: #fff; text-decoration: none; border-radius: 10px;
+  margin-top: 1.6rem; background: #003366; color: #fff; text-decoration: none; border-radius: 10px;
   padding: 1rem 1.2rem; box-shadow: 0 2px 10px rgba(0,51,102,.18);
   transition: background .15s, transform .15s, box-shadow .15s; }
 .meteo-approfondisci-card:hover, .meteo-approfondisci-card:focus-visible {


### PR DESCRIPTION
Richiesta utente: dare spazio tra i pulsanti Scarica/Condividi e la card-CTA 'Vuoi vedere di più?'. Aggiunto margin-top 1.6rem alla card.