### PR TITLE
Audit #350: fix frontmatter draft (43 facile) + cross-ref CLAUDE.md + nome esteso

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,7 @@ Elenco completo in rule `09-regole-contenuti-qualita.md`. Vincoli più critici:
 
 Tabella completa workflow + note operative in rule `10-automazioni-github-actions.md`. Trigger rapidi:
 - `deploy.yml` a ogni push su `main`.
+- `aggiorna-manuale.yml` (lunedì 06:00 UTC): monitora le fonti AGID/Designers Italia/DPC e apre issue quando cambiano — manuale e `.claude/rules/` vanno aggiornati in coppia (rule 02 § "Sincronizzazione automatica con gli aggiornamenti AGID").
 - Modalità emergenza: `data/emergenza.json` → `"attiva": true`.
 - Allerta meteo manuale: `data/allerta.json` → `livello: verde|giallo|arancione|rosso`.
 - Niente articoli `draft: true`: solo pubblicato (data passata) o calendarizzato (data futura).

--- a/content/comunicazioni/2025-06-10-conservazione-alimenti-casa-spreco-facile.md
+++ b/content/comunicazioni/2025-06-10-conservazione-alimenti-casa-spreco-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Come conservare il cibo a casa"
 date: 2025-06-10
+draft: false
 description: "Regole semplici per conservare il cibo bene e sprecare meno."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2025-07-14-alimentazioni-speciali-campo-accoglienza-facile.md
+++ b/content/comunicazioni/2025-07-14-alimentazioni-speciali-campo-accoglienza-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Cibo speciale nel campo di accoglienza"
 date: 2025-07-14
+draft: false
 description: "Alcune persone non possono mangiare certi cibi. Ecco le regole da seguire in cucina."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2025-10-16-cucina-zero-spreco-avanzi-recupero-facile.md
+++ b/content/comunicazioni/2025-10-16-cucina-zero-spreco-avanzi-recupero-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Cucina senza sprechi: come usare tutto il cibo"
 date: 2025-10-16
+draft: false
 description: "Bucce, gambi, avanzi: non buttare il cibo. Ecco come usarlo tutto."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-04-27-app-where-are-u-112-localizzazione-emergenza-facile.md
+++ b/content/comunicazioni/2026-04-27-app-where-are-u-112-localizzazione-emergenza-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "App Where Are U: aiuta il 112 a trovarti"
 date: 2026-04-27T00:02:00+02:00
+draft: false
 description: "Where Are U è un'app gratuita. Quando chiami il 112, manda la tua posizione ai soccorritori."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-05-persone-fragili-aiutare-vicini-anziani-emergenza-facile.md
+++ b/content/comunicazioni/2026-05-05-persone-fragili-aiutare-vicini-anziani-emergenza-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Aiuta il tuo vicino fragile in caso di emergenza"
 date: 2026-05-05T00:01:00+02:00
+draft: false
 description: "Come aiutare anziani e persone fragili vicine a te in caso di emergenza."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-07-zone-allerta-lazio-come-leggere-bollettino-facile.md
+++ b/content/comunicazioni/2026-05-07-zone-allerta-lazio-come-leggere-bollettino-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Le zone di allerta del Lazio: come leggere il bollettino"
 date: 2026-05-07
+draft: false
 description: "Genzano di Roma è in Zona F. Questo articolo spiega cosa significa il bollettino di allerta."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-14-centro-operativo-comunale-coc-facile.md
+++ b/content/comunicazioni/2026-05-14-centro-operativo-comunale-coc-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Il COC: la sala dove il Comune coordina l'emergenza"
 date: 2026-05-14
+draft: false
 description: "Cos'è il COC e cosa fa il Comune durante un'emergenza. Spiegato in italiano semplice."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-16-rimborsi-volontari-lavoratori-autonomi-facile.md
+++ b/content/comunicazioni/2026-05-16-rimborsi-volontari-lavoratori-autonomi-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "I rimborsi per i volontari che lavorano in proprio"
 date: 2026-05-16T00:02:00+02:00
+draft: false
 description: "Se fai il volontario e lavori in proprio, puoi ricevere un rimborso. Ecco come fare."
 badge: "Aggiornamento"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-24-rischio-chimico-industriale-cittadini-facile.md
+++ b/content/comunicazioni/2026-05-24-rischio-chimico-industriale-cittadini-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Rischio chimico: cosa fare in caso di incidente"
 date: 2026-05-24T00:01:00+02:00
+draft: false
 description: "Cosa fare se c'è un incidente chimico vicino a te. Guida in italiano semplice."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-27-riconoscere-malori-estivi-colpo-calore-ictus-facile.md
+++ b/content/comunicazioni/2026-05-27-riconoscere-malori-estivi-colpo-calore-ictus-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Malori d'estate: cosa guardare e quando chiamare il 112"
 date: 2026-05-27
+draft: false
 description: "D'estate alcuni malori sono gravi. Impara a riconoscerli e chiama subito il 112."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-05-31-giornata-senza-tabacco-mozziconi-incendi-facile.md
+++ b/content/comunicazioni/2026-05-31-giornata-senza-tabacco-mozziconi-incendi-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Mozziconi di sigaretta e incendi: cosa sapere"
 date: 2026-05-31
+draft: false
 description: "Il 31 maggio è la Giornata senza tabacco. I mozziconi buttati per terra possono causare incendi."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-01-avvio-campagna-aib-lazio-2026-facile.md
+++ b/content/comunicazioni/2026-06-01-avvio-campagna-aib-lazio-2026-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Dal 1 giugno: attenzione agli incendi nei boschi"
 date: 2026-06-01
+draft: false
 description: "Dal 1 giugno è vietato accendere fuochi nei boschi. Se vedi fumo, chiama il 112."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-04-tutela-minori-emergenze-bambini-vittime-facile.md
+++ b/content/comunicazioni/2026-06-04-tutela-minori-emergenze-bambini-vittime-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Come proteggere i bambini in emergenza"
 date: 2026-06-04
+draft: false
 description: "Il 4 giugno è la Giornata dei bambini vittime. Ecco come tenerli al sicuro."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-11-it-alert-come-funziona-reagire-facile.md
+++ b/content/comunicazioni/2026-06-11-it-alert-come-funziona-reagire-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "IT-alert: cosa è e cosa fare"
 date: 2026-06-11
+draft: false
 description: "IT-alert avvisa il tuo telefono in caso di pericolo. Cosa fare quando suona."
 badge: "Comunicazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-06-22-rischio-idrogeologico-estivo-siccita-piogge-facile.md
+++ b/content/comunicazioni/2026-06-22-rischio-idrogeologico-estivo-siccita-piogge-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Estate e piogge forti: cosa può succedere e cosa fare"
 date: 2026-06-22
+draft: false
 description: "D'estate ci sono rischi di frane e allagamenti. Spieghiamo perché e cosa fare."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-07-03-viaggi-estivi-kit-emergenza-auto-facile.md
+++ b/content/comunicazioni/2026-07-03-viaggi-estivi-kit-emergenza-auto-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Kit di emergenza in auto per le vacanze"
 date: 2026-07-03
+draft: false
 description: "Cosa mettere in auto prima di partire. Come comportarsi in caso di panne o incidente."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-07-10-app-it-alert-test-nazionale-facile.md
+++ b/content/comunicazioni/2026-07-10-app-it-alert-test-nazionale-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "IT-alert: cosa fare quando arriva il messaggio"
 date: 2026-07-10T00:01:00+02:00
+draft: false
 description: "IT-alert manda messaggi di allarme al tuo telefono. Ecco cosa fare."
 badge: "Comunicazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-07-17-grandine-estiva-danni-protezione-facile.md
+++ b/content/comunicazioni/2026-07-17-grandine-estiva-danni-protezione-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "La grandine: cosa è e cosa fare"
 date: 2026-07-17
+draft: false
 description: "Cos'è la grandine, perché è pericolosa e cosa fare per proteggerti."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-07-18-siccita-gestione-risorsa-idrica-facile.md
+++ b/content/comunicazioni/2026-07-18-siccita-gestione-risorsa-idrica-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Siccità: cosa puoi fare tu per l'acqua"
 date: 2026-07-18
+draft: false
 description: "La siccità è quando piove poco. L'acqua scarseggia. Puoi aiutare con gesti semplici ogni giorno."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-07-23-disabilita-emergenza-piani-accessibili-facile.md
+++ b/content/comunicazioni/2026-07-23-disabilita-emergenza-piani-accessibili-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Disabilità e emergenza: cosa fare"
 date: 2026-07-23
+draft: false
 description: "Cosa fare in emergenza se hai una disabilità o conosci qualcuno con disabilità."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-08-01-agosto-mese-critico-pc-preparazione-facile.md
+++ b/content/comunicazioni/2026-08-01-agosto-mese-critico-pc-preparazione-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Agosto: il mese più difficile per la Protezione Civile"
 date: 2026-08-01
+draft: false
 description: "Agosto è il mese più difficile per la PC. Ecco cosa puoi fare tu."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-08-27-it-alert-test-settembre-cosa-sapere-facile.md
+++ b/content/comunicazioni/2026-08-27-it-alert-test-settembre-cosa-sapere-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "IT-Alert: cosa è e cosa fare"
 date: 2026-08-27
+draft: false
 description: "IT-Alert è il sistema di allarme sul cellulare. Cosa fare quando suona."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-09-04-fulmini-protezione-civile-autoprotezione-facile.md
+++ b/content/comunicazioni/2026-09-04-fulmini-protezione-civile-autoprotezione-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Fulmini: cosa fare per stare al sicuro"
 date: 2026-09-04
+draft: false
 description: "Cosa fare prima, durante e dopo un temporale con fulmini. Regole semplici per proteggerti."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-09-08-allerta-gialla-cosa-significa-facile.md
+++ b/content/comunicazioni/2026-09-08-allerta-gialla-cosa-significa-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Allerta gialla: cosa è e cosa fare"
 date: 2026-09-08
+draft: false
 description: "Allerta gialla: non è un'emergenza, ma devi fare attenzione. Leggi cosa fare."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-09-14-app-protezione-civile-fonti-ufficiali-facile.md
+++ b/content/comunicazioni/2026-09-14-app-protezione-civile-fonti-ufficiali-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Le app giuste da avere nel telefono"
 date: 2026-09-14
+draft: false
 description: "Quali app e siti seguire per sapere cosa succede in caso di rischio o emergenza."
 badge: "Informazione"
 priorita: "normale"

--- a/content/comunicazioni/2026-10-14-primo-soccorso-base-famiglie-facile.md
+++ b/content/comunicazioni/2026-10-14-primo-soccorso-base-famiglie-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Primo soccorso in famiglia: cosa fare"
 date: 2026-10-14
+draft: false
 description: "Cosa fare in casa quando qualcuno si fa male. Frasi semplici per tutti."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-10-30-halloween-sicurezza-bambini-facile.md
+++ b/content/comunicazioni/2026-10-30-halloween-sicurezza-bambini-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Halloween: come stare al sicuro con i bambini"
 date: 2026-10-30T00:01:00+02:00
+draft: false
 description: "Consigli semplici per la notte di Halloween con i bambini."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-03-pneumatici-invernali-catene-novembre-facile.md
+++ b/content/comunicazioni/2026-11-03-pneumatici-invernali-catene-novembre-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Pneumatici invernali e catene: le regole di novembre"
 date: 2026-11-03
+draft: false
 description: "Dal 15 novembre devi avere pneumatici invernali o catene in auto. Ecco cosa fare."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-05-ondate-freddo-prevenzione-anziani-facile.md
+++ b/content/comunicazioni/2026-11-05-ondate-freddo-prevenzione-anziani-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Freddo intenso: come proteggersi e aiutare gli anziani"
 date: 2026-11-05
+draft: false
 description: "Il grande freddo è pericoloso. Leggi cosa fare per stare al sicuro e aiutare chi è solo."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-06-piano-emergenza-condominio-facile.md
+++ b/content/comunicazioni/2026-11-06-piano-emergenza-condominio-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Il piano di emergenza del condominio"
 date: 2026-11-06
+draft: false
 description: "Come fare un piano di emergenza per il palazzo. Cosa fare in caso di incendio, gas, alluvione."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-12-nebbia-rischio-viabilita-facile.md
+++ b/content/comunicazioni/2026-11-12-nebbia-rischio-viabilita-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Nebbia: come guidare in sicurezza"
 date: 2026-11-12
+draft: false
 description: "La nebbia è pericolosa in auto. Ecco cosa fare per guidare sicuro."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-14-sicurezza-impianti-elettrici-casa-facile.md
+++ b/content/comunicazioni/2026-11-14-sicurezza-impianti-elettrici-casa-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "La sicurezza elettrica a casa"
 date: 2026-11-14
+draft: false
 description: "Come usare l'elettricità a casa in modo sicuro. Cosa controllare e cosa fare in caso di problema."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-16-cadute-anziani-prevenzione-casa-facile.md
+++ b/content/comunicazioni/2026-11-16-cadute-anziani-prevenzione-casa-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Come evitare le cadute in casa: guida per gli anziani"
 date: 2026-11-16
+draft: false
 description: "Consigli semplici per rendere la casa più sicura e non cadere."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-19-animali-domestici-emergenze-facile.md
+++ b/content/comunicazioni/2026-11-19-animali-domestici-emergenze-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Animali domestici in emergenza: cosa fare"
 date: 2026-11-19
+draft: false
 description: "In emergenza porta via il tuo animale. Questa pagina spiega cosa fare."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-21-giornata-nazionale-alberi-facile.md
+++ b/content/comunicazioni/2026-11-21-giornata-nazionale-alberi-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Giornata degli alberi: perché gli alberi ci proteggono"
 date: 2026-11-21
+draft: false
 description: "Il 21 novembre è la Giornata degli alberi. Gli alberi proteggono il territorio dai pericoli."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-22-truffe-online-black-friday-facile.md
+++ b/content/comunicazioni/2026-11-22-truffe-online-black-friday-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Black Friday: come evitare le truffe online"
 date: 2026-11-22
+draft: false
 description: "Come riconoscere le truffe online durante il Black Friday e cosa fare se vieni truffato."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-24-sicurezza-cucina-festivita-facile.md
+++ b/content/comunicazioni/2026-11-24-sicurezza-cucina-festivita-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Cucina sicura durante le feste"
 date: 2026-11-24
+draft: false
 description: "Consigli semplici per cucinare in sicurezza a Natale e Capodanno."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-11-28-sicurezza-animali-stalla-fattorie-facile.md
+++ b/content/comunicazioni/2026-11-28-sicurezza-animali-stalla-fattorie-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Animali in fattoria: cosa fare in emergenza"
 date: 2026-11-28
+draft: false
 description: "Come proteggere gli animali della fattoria in caso di incendio, alluvione o terremoto."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-12-02-neve-e-ghiaccio-preparazione-facile.md
+++ b/content/comunicazioni/2026-12-02-neve-e-ghiaccio-preparazione-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Neve e ghiaccio: cosa fare"
 date: 2026-12-02
+draft: false
 description: "Neve e ghiaccio a Genzano di Roma: come prepararsi e cosa fare."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-12-09-rientro-post-ponte-sicurezza-stradale-facile.md
+++ b/content/comunicazioni/2026-12-09-rientro-post-ponte-sicurezza-stradale-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Rientro dal ponte: guida sicura e stanchezza"
 date: 2026-12-09
+draft: false
 description: "Consigli pratici per tornare a casa in sicurezza dopo il ponte dell'Immacolata."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-12-16-pacchi-natalizi-logistica-corriere-facile.md
+++ b/content/comunicazioni/2026-12-16-pacchi-natalizi-logistica-corriere-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Ricevere i pacchi di Natale: cosa fare"
 date: 2026-12-16
+draft: false
 description: "Prima di Natale arrivano molti pacchi. Ecco come riceverli, evitare truffe e smaltire gli imballaggi."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-12-18-influenza-picco-stagionale-facile.md
+++ b/content/comunicazioni/2026-12-18-influenza-picco-stagionale-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "L'influenza in inverno: cosa fare"
 date: 2026-12-18
+draft: false
 description: "A dicembre e gennaio arriva l'influenza. Ecco come prevenirla e come stare meglio."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/comunicazioni/2026-12-30-capodanno-petardi-sicurezza-facile.md
+++ b/content/comunicazioni/2026-12-30-capodanno-petardi-sicurezza-facile.md
@@ -1,6 +1,7 @@
 ---
 title: "Capodanno: petardi e sicurezza"
 date: 2026-12-30
+draft: false
 description: "Cosa fare con i petardi a Capodanno. Regole semplici per stare al sicuro."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/facile-da-leggere/_index.md
+++ b/content/facile-da-leggere/_index.md
@@ -354,7 +354,7 @@ dataUltimaRevisione: "2026-05-06"
 
 <p>Sono luoghi aperti e larghi.</p>
 <p>Vai lì se la tua casa non è sicura.</p>
-<p><a href="/cartografia/" style="display: inline-block; background: #003366; color: #fff; padding: 0.8rem 1.2rem; border-radius: 8px; text-decoration: none; margin-top: 0.5rem;">Vedi le aree di attesa di Genzano</a></p>
+<p><a href="/cartografia/" style="display: inline-block; background: #003366; color: #fff; padding: 0.8rem 1.2rem; border-radius: 8px; text-decoration: none; margin-top: 0.5rem;">Vedi le aree di attesa di Genzano di Roma</a></p>
 </div>
 
 <div class="facile-blocco">


### PR DESCRIPTION
Risolve i punti dell'audit settimanale #350:
- **Sez. 27 (❌)**: aggiunto `draft: false` ai 43 file `<slug>-facile.md` che ne erano privi (frontmatter completo).
- **Sez. 28 (❌)**: CLAUDE.md (Automazioni) ora cita `aggiorna-manuale.yml`.
- **Sez. 4 (⚠️)**: link 'aree di attesa di Genzano' → 'Genzano di Roma'.

Resta aperta la **sez. 10** (frasi >40 parole in vari articoli): backlog editoriale, da valutare a parte.

Closes parzialmente #350.