### PR TITLE
AGID frasi lunghe (finale) + fix euristica audit sez.10

### DIFF
--- a/.github/workflows/audit-sito.yml
+++ b/.github/workflows/audit-sito.yml
@@ -337,11 +337,27 @@ jobs:
           LONG_SENT=""
           for art in "$CONTENT_GLOB"/comunicazioni/*.md; do
             [ -f "$art" ] || continue
-            # Rimuovi frontmatter e converti blocchi in righe "frase"
-            BODY=$(awk '/^---$/{c++; next} c>=2' "$art" \
-              | tr '\n' ' ' \
-              | sed 's/\([\.\!\?]\)/\1\n/g')
-            COUNT=$(echo "$BODY" | awk '{ if (NF > 40) c++ } END { print c+0 }')
+            # Conta SOLO le frasi di PROSA: salta righe di lista, titoli,
+            # citazioni, tabelle, shortcode, immagini e HTML. Senza questo filtro
+            # un elenco puntato senza punto finale verrebbe concatenato e contato
+            # come un'unica "frase" da decine di parole (falso positivo).
+            COUNT=$(awk '
+              /^---$/ { c++; next }
+              c < 2 { next }
+              {
+                # salta i blocchi shortcode multilinea ({{< ... >}}): alt/caption
+                # non sono prosa e altrimenti verrebbero contati come frasi lunghe
+                if (insc) { if ($0 ~ />}}/) insc=0; next }
+                if ($0 ~ /[{][{][<%]/) { if ($0 !~ />}}/) insc=1; next }
+                line=$0; sub(/^[ \t]+/,"",line)
+                if (line=="") next
+                if (line ~ /^([-*>|]|[0-9]+[.)][ \t]|#+[ \t]|!\[|<)/) next
+                gsub(/[.!?]+[ \t]/,"&\n",line)
+                m=split(line, arr, "\n")
+                for(i=1;i<=m;i++){ if (split(arr[i],w," ") > 40) cnt++ }
+              }
+              END { print cnt+0 }
+            ' "$art")
             if [ "$COUNT" -ge 3 ]; then
               LONG_SENT="$LONG_SENT\n- \`$art\`: $COUNT frasi con >40 parole"
             fi

--- a/content/comunicazioni/2024-11-26-manuale-caritas-banco-alimentare-presentazione.md
+++ b/content/comunicazioni/2024-11-26-manuale-caritas-banco-alimentare-presentazione.md
@@ -56,7 +56,7 @@ Il recupero e la distribuzione di alimenti a fini di solidarietà rientra nel "c
 
 Il manuale introduce alcuni **strumenti operativi specifici per il mondo del volontariato**:
 
-1. **Distinzione tra OC di I livello e OC di II livello** — le prime (come i Banchi Alimentari) distribuiscono grandi quantitativi alle seconde, che operano direttamente con gli indigenti attraverso pacchi viveri, empori solidali, unità di strada, mense, comunità di accoglienza.
+1. **Distinzione tra OC di I livello e OC di II livello.** Le prime (come i Banchi Alimentari) distribuiscono grandi quantitativi alle seconde. Le seconde operano direttamente con gli indigenti, attraverso pacchi viveri, empori solidali, unità di strada, mense e comunità di accoglienza.
 2. **Sistema semplificato HACCP** — applicazione dei principi HACCP adattata alla dimensione e al grado di complessità delle OC. Il manuale fornisce un approccio schematico basato sulle fasi di processo, alternativo all'albero delle decisioni classico.
 3. **Livelli di attenzione a "semaforo"** — le tre macrocategorie di alimenti (alto/medio/basso livello di attenzione) sono contrassegnate da icone colorate (mano rossa/arancione/verde) per guidare gli operatori nella gestione in base al rischio.
 4. **Schede operative e registri pronti all'uso** — il manuale include in appendice le schede per la tracciabilità, il controllo delle temperature, il piano di sanificazione, l'elenco fornitori, le non conformità.

--- a/content/comunicazioni/2026-04-05-storia-gruppo-comunale-volontari-genzano-quarant-anni.md
+++ b/content/comunicazioni/2026-04-05-storia-gruppo-comunale-volontari-genzano-quarant-anni.md
@@ -62,7 +62,7 @@ Il Land Rover arriva senza dispositivi di segnalazione ottico-acustica. Il Grupp
 
 ## La missione Arcobaleno del 1999
 
-La fine degli anni Novanta porta per la prima volta il Gruppo a operare **fuori dai confini italiani**. Durante la guerra del Kosovo, il Dipartimento della Protezione Civile coordina la **missione Arcobaleno (1999)**, la più grande operazione internazionale di accoglienza gestita dall'Italia nel dopoguerra: circa 45.000 profughi albanesi e kosovari accolti nel nostro Paese, decine di campi di accoglienza allestiti, una mobilitazione senza precedenti del volontariato.
+La fine degli anni Novanta porta per la prima volta il Gruppo a operare **fuori dai confini italiani**. Durante la guerra del Kosovo, il Dipartimento della Protezione Civile coordina la **missione Arcobaleno (1999)**, la più grande operazione internazionale di accoglienza gestita dall'Italia nel dopoguerra. Vennero accolti nel nostro Paese circa 45.000 profughi albanesi e kosovari, con decine di campi di accoglienza allestiti e una mobilitazione del volontariato senza precedenti.
 
 Il Gruppo di Genzano partecipa alla missione, consolidando l'esperienza sui campi di accoglienza internazionali che tornerà utile negli anni successivi per le emergenze sismiche nazionali e, molto più tardi, per l'**emergenza Ucraina del 2022**.
 
@@ -152,7 +152,7 @@ Il mezzo rappresenta l'evoluzione del pickup da territorio: manovrabile, versati
 
 ## Quarant'anni di volontariato, di continuità
 
-Ripercorrere questa storia significa notare una costante: **il Gruppo non ha mai aspettato il mezzo perfetto**. Ha preso quello che c'era — un'ambulanza dismessa, un'autobotte militare da riconvertire, un Range Rover donato, un VM90 da smontare pezzo per pezzo — e l'ha reso utile al territorio. La cabina in lamiera autocostruita dell'ACP70 e il cassone rifatto del VM90 con i proventi di una donazione non sono aneddoti nostalgici: sono la dimostrazione che la protezione civile, prima di essere un organigramma, è un modo di rimboccarsi le maniche.
+Ripercorrere questa storia significa notare una costante: **il Gruppo non ha mai aspettato il mezzo perfetto**. Ha preso quello che c'era — un'ambulanza dismessa, un'autobotte militare da riconvertire, un Range Rover donato, un VM90 da smontare pezzo per pezzo — e l'ha reso utile al territorio. La cabina in lamiera autocostruita dell'ACP70 e il cassone rifatto del VM90 con i proventi di una donazione non sono aneddoti nostalgici. Dimostrano che la protezione civile, prima di essere un organigramma, è un modo di rimboccarsi le maniche.
 
 Dagli anni Ottanta ad oggi, il Gruppo ha attraversato:
 

--- a/content/comunicazioni/2026-04-09-allagamenti-alluvioni-alberi-pericolanti-interventi-tecnici.md
+++ b/content/comunicazioni/2026-04-09-allagamenti-alluvioni-alberi-pericolanti-interventi-tecnici.md
@@ -115,7 +115,7 @@ Per gli interventi in quota (ramo sospeso, albero che minaccia una linea elettri
 
 **Quando il ramo è in alto**
 
-Se il ramo pericolante è ad altezza superiore ai 4-5 metri, o se la caduta deve essere controllata per non danneggiare auto o edifici sottostanti, entra in scena la **PA1 – piattaforma aerea** del Gruppo, un Nissan Cabstar classificato come mezzo d'opera. Il cestello consente di raggiungere in sicurezza punti elevati.
+A volte il ramo pericolante è ad altezza superiore ai 4-5 metri, oppure la caduta va controllata per non danneggiare auto o edifici sottostanti. In questi casi entra in scena la **PA1 – piattaforma aerea** del Gruppo, un Nissan Cabstar classificato come mezzo d'opera. Il cestello consente di raggiungere in sicurezza punti elevati.
 
 L'uso della piattaforma aerea richiede **patentino specifico PLE** (Piattaforma di Lavoro Elevabile), ai sensi del D.Lgs. 81/2008 e dell'Accordo Stato-Regioni del 22 febbraio 2012. Chi non ha il patentino non manovra il mezzo, punto.
 

--- a/content/comunicazioni/2026-04-13-frequenze-radio-emergenza-radioamatori-protezione-civile-1.md
+++ b/content/comunicazioni/2026-04-13-frequenze-radio-emergenza-radioamatori-protezione-civile-1.md
@@ -26,7 +26,7 @@ La Rete Zamberletti opera su due frequenze HF in banda laterale inferiore (LSB),
 
 Queste frequenze sono distinte dalle frequenze generali di emergenza della IARU Regione 1 (3.760 kHz e 7.060 kHz), che sono centri di attività raccomandati per qualsiasi comunicazione di emergenza radioamatoriale a livello internazionale. La Rete Zamberletti utilizza frequenze proprie e dedicate, coordinate dall'ARI a livello nazionale.
 
-A livello locale, le sottoreti tra Prefetture e Comuni del territorio operano in **banda VHF e UHF**, utilizzando frequenze definite da ciascuna Sezione ARI capoluogo di provincia in base all'orografia del territorio e alla disponibilità di ponti ripetitori. Per l'area metropolitana di Roma Capitale, l'ARI Roma ha individuato come frequenze di riferimento la **145,275 MHz FM** in VHF (principale) e la **433,425 MHz FM** in UHF (alternativa), sulle quali si svolgono prove di collegamento locali due volte al mese, in coordinamento con le esercitazioni della Rete Zamberletti.
+A livello locale, le sottoreti tra Prefetture e Comuni del territorio operano in **banda VHF e UHF**, utilizzando frequenze definite da ciascuna Sezione ARI capoluogo di provincia in base all'orografia del territorio e alla disponibilità di ponti ripetitori. Per l'area metropolitana di Roma Capitale, l'ARI Roma ha individuato come frequenze di riferimento la **145,275 MHz FM** in VHF (principale) e la **433,425 MHz FM** in UHF (alternativa). Su queste frequenze si svolgono prove di collegamento locali due volte al mese, in coordinamento con le esercitazioni della Rete Zamberletti.
 
 In caso di calamità, il traffico di emergenza ha priorità assoluta su ogni altra trasmissione radioamatoriale: è un principio sancito dalla ITU, l'Unione Internazionale delle Telecomunicazioni.
 
@@ -68,7 +68,7 @@ Ad aprile 2026, la Rete Zamberletti è prossima al traguardo della **500ª prova
 
 ## Perché le onde corte funzionano quando tutto il resto si ferma
 
-La ragione per cui le comunicazioni HF dei radioamatori restano operative anche nelle emergenze più gravi è di natura fisica. Le onde corte, nella gamma tra 3 e 30 MHz, si propagano sfruttando la **riflessione ionosferica**: il segnale viene irradiato verso l'alto, incontra gli strati ionizzati dell'atmosfera e viene riflesso nuovamente verso terra, coprendo distanze che possono superare i mille chilometri con un singolo salto.
+La ragione per cui le comunicazioni HF dei radioamatori restano operative anche nelle emergenze più gravi è di natura fisica. Le onde corte, nella gamma tra 3 e 30 MHz, si propagano sfruttando la **riflessione ionosferica**. Il segnale viene irradiato verso l'alto, incontra gli strati ionizzati dell'atmosfera e viene riflesso verso terra. Così può coprire distanze che superano i mille chilometri con un singolo salto.
 
 Questo tipo di propagazione, detta **NVIS** (Near Vertical Incidence Skywave) quando l'angolo di irradiazione è quasi verticale, è particolarmente efficace sulla banda degli 80 metri per i collegamenti nazionali. Non richiede ripetitori, non richiede centrali telefoniche, non richiede energia elettrica dalla rete: basta un ricetrasmettitore, un'antenna filare e una batteria.
 
@@ -80,7 +80,7 @@ Le due bande si completano: l'HF collega Roma con le Prefetture su scala naziona
 
 ## Il ruolo dei radioamatori oggi
 
-I radioamatori non sostituiscono i sistemi di telecomunicazione professionali delle istituzioni. Li integrano, li affiancano e, nei momenti più critici, li suppliscono. Quando nel 2009 il terremoto dell'Aquila interruppe le comunicazioni, quando nel 2016 il sisma di Amatrice isolò interi borghi, quando nel 2023 l'alluvione in Emilia-Romagna compromise le reti cellulari, i radioamatori furono tra i primi a ristabilire un filo di comunicazione tra il territorio colpito e le strutture di coordinamento.
+I radioamatori non sostituiscono i sistemi di telecomunicazione professionali delle istituzioni. Li integrano, li affiancano e, nei momenti più critici, li suppliscono. Nel 2009 il terremoto dell'Aquila interruppe le comunicazioni. Nel 2016 il sisma di Amatrice isolò interi borghi. Nel 2023 l'alluvione in Emilia-Romagna compromise le reti cellulari. In tutti questi casi i radioamatori furono tra i primi a ristabilire un filo di comunicazione tra il territorio colpito e le strutture di coordinamento.
 
 L'ARI gestisce in autonomia le stazioni radio installate nelle Prefetture. I radioamatori volontari, inquadrati nell'organizzazione ARI-RE (Radiocomunicazioni di Emergenza), sono formati per operare in condizioni di stress, con procedure standardizzate, modulistica dedicata e una disciplina operativa che trasforma il diletto radioamatoriale in un servizio pubblico di altissimo valore.
 

--- a/content/comunicazioni/2026-04-16-catena-comunicazioni-protezione-civile-dpc-cor-com-coc.md
+++ b/content/comunicazioni/2026-04-16-catena-comunicazioni-protezione-civile-dpc-cor-com-coc.md
@@ -193,9 +193,9 @@ In ogni scenario, il Gruppo non agisce mai in modo isolato: è sempre un **tasse
 
 ## Un sistema che si regge sull'esercizio
 
-La catena descritta in questo articolo è teoria organizzativa. La sua efficacia reale dipende da una sola cosa: **quanto è esercitata**. Le **esercitazioni periodiche** — comunali, intercomunali, regionali, nazionali — servono esattamente a questo: a verificare che i flussi informativi funzionino, che i referenti si conoscano, che le sigle (COC, COM, COR, DI.COMA.C.) non siano solo parole ma **persone con un telefono, una procedura e un orario di reperibilità**.
+La catena descritta in questo articolo è teoria organizzativa. La sua efficacia reale dipende da una sola cosa: **quanto è esercitata**. Le **esercitazioni periodiche** — comunali, intercomunali, regionali, nazionali — servono esattamente a questo. Verificano che i flussi informativi funzionino e che i referenti si conoscano. E che le sigle (COC, COM, COR, DI.COMA.C.) non siano solo parole, ma **persone con un telefono, una procedura e un orario di reperibilità**.
 
-Ogni volontario di protezione civile, nel proprio piccolo, contribuisce a questa catena. Quando sale sul pickup con la radio in mano e chiama la Sala Operativa, non sta parlando con "la radio": sta parlando con la **Funzione 8 del COC**, che a sua volta comunica con la **Funzione 8 del COM**, che a sua volta riporta al COR. E così il sistema tiene.
+Ogni volontario di protezione civile, nel proprio piccolo, contribuisce a questa catena. Quando sale sul pickup con la radio in mano e chiama la Sala Operativa, non sta parlando con "la radio". Sta parlando con la **Funzione 8 del COC**, che a sua volta comunica con la **Funzione 8 del COM**, che riporta al COR. E così il sistema tiene.
 
 ---
 

--- a/content/comunicazioni/2026-04-17-gestione-sala-radio-chiamata-emergenza-scheda-intervento.md
+++ b/content/comunicazioni/2026-04-17-gestione-sala-radio-chiamata-emergenza-scheda-intervento.md
@@ -146,7 +146,7 @@ Indica che la **comunicazione è terminata** definitivamente. È diversa da "pas
 
 **Sigle e numeri: sempre con alfabeto fonetico**
 
-Quando la squadra detta una sigla (una targa di auto incidentata, un codice di magazzino) o un numero, l'operatore deve **far scandire le lettere con l'alfabeto fonetico ICAO-NATO** (Alfa Bravo Charlie Delta...) o, in alternativa pratica, con termini semplici (città, nomi comuni). I numeri si leggono **cifra per cifra**:
+Quando la squadra detta una sigla (una targa di auto incidentata, un codice di magazzino) o un numero, l'operatore deve **far scandire le lettere con l'alfabeto fonetico ICAO-NATO** (Alfa Bravo Charlie Delta...). In alternativa pratica si usano termini semplici, come nomi di città o parole comuni. I numeri si leggono **cifra per cifra**:
 
 - **354** va comunicato come *"tre-cinque-quattro"*, non come *"trecentocinquantaquattro"*
 
@@ -170,7 +170,7 @@ La trasmissione avviene premendo il pulsante **PTT** posto lateralmente all'appa
 
 **Il "Roger Beep"**
 
-Alcuni apparati emettono un breve suono elettronico al termine della trasmissione, il **Roger Beep**. Serve a comunicare al chiamato che la portante è stata rilasciata e può parlare. In alcuni apparati è presente **anche in apertura di trasmissione**: in quel caso è buona norma **attendere un paio di secondi dopo aver premuto il PTT prima di iniziare a parlare**, per evitare che il suono copra le prime parole del messaggio.
+Alcuni apparati emettono un breve suono elettronico al termine della trasmissione, il **Roger Beep**. Serve a comunicare al chiamato che la portante è stata rilasciata e può parlare. In alcuni apparati è presente **anche in apertura di trasmissione**. In quel caso è buona norma **attendere un paio di secondi dopo aver premuto il PTT prima di iniziare a parlare**: così il suono non copre le prime parole del messaggio.
 
 **La "coda"**
 

--- a/content/comunicazioni/2026-05-22-infiorata-genzano-2026.md
+++ b/content/comunicazioni/2026-05-22-infiorata-genzano-2026.md
@@ -14,7 +14,7 @@ draft: false
 tts: true
 ---
 
-L'**Infiorata di Genzano di Roma** è la festa più conosciuta della nostra città: il tappeto di fiori che si stende lungo via Italo Belardi — l'antica Via Livia — in occasione del Corpus Domini è una tradizione che si rinnova ogni anno dal **1778**. Nel 2026 si celebra la **248ª edizione**.
+L'**Infiorata di Genzano di Roma** è la festa più conosciuta della nostra città. Il tappeto di fiori si stende lungo via Italo Belardi — l'antica Via Livia — in occasione del Corpus Domini. È una tradizione che si rinnova ogni anno dal **1778**. Nel 2026 si celebra la **248ª edizione**.
 
 L'evento attira decine di migliaia di visitatori da tutta Italia e dall'estero, concentrati su un'unica via cittadina nell'arco di tre giorni. Per questo motivo l'Infiorata è una **manifestazione di rilievo per la Protezione Civile** comunale: ogni anno il Gruppo collabora con il Comune e con le altre componenti del sistema di soccorso per garantire un afflusso sicuro.
 
@@ -98,7 +98,7 @@ In caso di **malore, incidente** o qualsiasi emergenza chiama il **112** — il 
 
 Per **piccoli malori, traumi lievi e prima assistenza sanitaria** sono attivi lungo il percorso **pattuglie a piedi di personale sanitario** e **ambulanze stazionate in piazza** ai piedi dell'Infiorata. Sono i riferimenti più rapidi per chi è già sul posto e ha bisogno di una valutazione immediata.
 
-In caso di **persona smarrita** — in particolare bambini che si separano dai genitori nella folla — funziona durante la manifestazione un **ufficio annunci dedicato** dotato di **altoparlanti diffusi su tutti i percorsi della festa**: l'annunciatore segnala la persona scomparsa e l'indicazione del punto dove ritrovarla. Se ti separi da qualcuno della tua famiglia, **avvicinati al volontario o all'operatore in divisa più vicino**: ti indicherà come arrivare all'ufficio annunci.
+In caso di **persona smarrita** — in particolare bambini che si separano dai genitori nella folla — durante la manifestazione funziona un **ufficio annunci dedicato**, con **altoparlanti diffusi su tutti i percorsi della festa**. L'annunciatore segnala la persona scomparsa e indica il punto dove ritrovarla. Se ti separi da qualcuno della tua famiglia, **avvicinati al volontario o all'operatore in divisa più vicino**: ti indicherà come arrivare all'ufficio annunci.
 
 Per **segnalazioni di Protezione Civile non urgenti** fuori dall'evento puoi chiamare la Sala Operativa Regionale Lazio al **803&nbsp;555**.
 
@@ -112,9 +112,9 @@ L'Infiorata è una manifestazione gestita con **pianificazione operativa pluri-e
 - **Ufficio annunci con altoparlanti** — segnala persone smarrite e ricongiunge i nuclei familiari.
 - **Comune di Genzano di Roma** — coordinamento generale e regia della manifestazione.
 
-Il **Gruppo Comunale Volontari di Protezione Civile** opera **a supporto della Polizia Locale e delle Forze dell'Ordine**, sulla base del **Piano Comunale di Protezione Civile** discusso preventivamente e del **tavolo operativo** che si tiene prima dell'evento con tutti gli enti e le istituzioni preposte alla gestione della sicurezza della manifestazione. I compiti specifici sono definiti di anno in anno dalla pianificazione operativa.
+Il **Gruppo Comunale Volontari di Protezione Civile** opera **a supporto della Polizia Locale e delle Forze dell'Ordine**. La cornice è il **Piano Comunale di Protezione Civile**, discusso preventivamente, e il **tavolo operativo** che si tiene prima dell'evento con tutti gli enti e le istituzioni preposte alla sicurezza della manifestazione. I compiti specifici sono definiti di anno in anno dalla pianificazione operativa.
 
-Il supporto del Gruppo **non include la regolazione del traffico né servizi di polizia stradale**: sono compiti di competenza esclusiva degli organi di polizia stradale (Forze dell'Ordine e Polizia Locale), come stabilito dagli **articoli 11 e 12 del Codice della Strada** (D.Lgs. 285/1992) e come ribadito dalla [Circolare del 6 agosto 2018 del Dipartimento della Protezione Civile](https://www.protezionecivile.gov.it/it/normativa/circolare-del-6-agosto-2018-manifestazioni-pubbliche-precisazioni-sullattivazione-e-limpiego-del-volontariato-di-protezione-civile/) sulle *"manifestazioni pubbliche: precisazioni sull'attivazione e l'impiego del volontariato di protezione civile"*. La stessa circolare consente al volontariato solo *"limitati compiti di informazione alla popolazione, anche in relazione a percorsi e tracciati straordinari o limitazioni di accesso"*, quando deliberati dalle autorità competenti. Anche **l'uso delle palette dirigitraffico è vietato** al volontariato di Protezione Civile.
+Il supporto del Gruppo **non include la regolazione del traffico né servizi di polizia stradale**. Sono compiti di competenza esclusiva degli organi di polizia stradale (Forze dell'Ordine e Polizia Locale), come stabilito dagli **articoli 11 e 12 del Codice della Strada** (D.Lgs. 285/1992). Lo ribadisce anche la [Circolare del 6 agosto 2018 del Dipartimento della Protezione Civile](https://www.protezionecivile.gov.it/it/normativa/circolare-del-6-agosto-2018-manifestazioni-pubbliche-precisazioni-sullattivazione-e-limpiego-del-volontariato-di-protezione-civile/) sulle *"manifestazioni pubbliche: precisazioni sull'attivazione e l'impiego del volontariato di protezione civile"*. La stessa circolare consente al volontariato solo *"limitati compiti di informazione alla popolazione, anche in relazione a percorsi e tracciati straordinari o limitazioni di accesso"*, quando deliberati dalle autorità competenti. Anche **l'uso delle palette dirigitraffico è vietato** al volontariato di Protezione Civile.
 
 Il Gruppo **non è attivabile direttamente dai cittadini**: in caso di emergenza il riferimento per il cittadino resta sempre il **112**.
 

--- a/content/comunicazioni/2026-10-29-tempesta-vaia-2018-vento-foreste-cambiamento-climatico.md
+++ b/content/comunicazioni/2026-10-29-tempesta-vaia-2018-vento-foreste-cambiamento-climatico.md
@@ -23,7 +23,7 @@ Sono passati **otto anni**. Fra il **27 e il 30 ottobre 2018**, una **tempesta a
 
 Il risultato fu **biblico**. La tempesta venne battezzata **Vaia** dal Servizio Meteorologico tedesco. Quando si esaurì, sui versanti del Trentino, dell'Alto Adige, del Friuli-Venezia Giulia, del Veneto e di parte della Lombardia c'erano **14 milioni di alberi abbattuti**. Distesi a terra come stuzzicadenti, su un'area complessiva di **42.500 ettari di foresta** distrutti o gravemente danneggiati. Le fotografie aeree mostravano centinaia di chilometri quadrati di bosco rovesciato in un'unica direzione, allineato come dopo l'esplosione di un'arma nucleare.
 
-Vaia è la **più grande catastrofe forestale** della storia europea recente. È un evento che ha imposto al sistema italiano della protezione civile una nuova categoria di rischio — il **rischio "vento estremo"** sui boschi montani — e ha aperto un capitolo lungo della **gestione delle foreste in crisi**, che si protrarrà per decenni.
+Vaia è la **più grande catastrofe forestale** della storia europea recente. Ha imposto al sistema italiano della protezione civile una nuova categoria di rischio: il **rischio "vento estremo"** sui boschi montani. E ha aperto un capitolo lungo della **gestione delle foreste in crisi**, destinato a protrarsi per decenni.
 
 {{< foto src="/images/2026-10-29-vaia-bosco-abbattuto-dolomiti.webp"
          alt="Foto a colori del 2019: vista panoramica di un versante alpino dopo la tempesta Vaia. Migliaia di abeti rossi sono stesi al suolo, allineati nella stessa direzione, schiantati dalla violenza del vento. Sopra, la striscia di bosco intatto rimasta in piedi. Le piante a terra sono ancora con le radici in superficie, alcune giovani conifere superstiti emergono dal cumulo."
@@ -40,7 +40,7 @@ Vaia non fu, propriamente, **una sola tempesta**: fu una **sequenza di sistemi p
 
 I danni si concentrarono soprattutto sui **versanti rivolti a sud-est** e in particolare sulle **piantagioni di abete rosso (Picea abies)** monoculturali — gli abeti rossi delle Dolomiti, alti, slanciati, con radici poco profonde, sono particolarmente vulnerabili al vento da scirocco.
 
-Le **vittime** umane di Vaia furono **almeno 13** in Italia (più altre nei Paesi limitrofi), per cause connesse: cadute di alberi, smottamenti, incidenti stradali, blackout elettrici prolungati. Oltre il numero immediato, i **danni a lungo termine** hanno alterato la morfologia di intere valli: i **boschi che proteggevano** da frane e valanghe sono caduti, i **ruscelli intasati** di legname hanno cambiato regime, le **infrastrutture viarie e di rifornimento** sono rimaste compromesse per mesi.
+Le **vittime** umane di Vaia furono **almeno 13** in Italia (più altre nei Paesi limitrofi), per cause connesse: cadute di alberi, smottamenti, incidenti stradali, blackout elettrici prolungati. Oltre al bilancio immediato, i **danni a lungo termine** hanno alterato la morfologia di intere valli. I **boschi che proteggevano** da frane e valanghe sono caduti, i **ruscelli intasati** di legname hanno cambiato regime e le **infrastrutture viarie e di rifornimento** sono rimaste compromesse per mesi.
 
 ## La crisi dopo la crisi: il bostrico
 
@@ -82,7 +82,7 @@ In passato Genzano e i Comuni vicini hanno registrato eventi di vento con caduta
 
 Le **vittime di Vaia** sono ricordate ogni anno con cerimonie sobrie nei Comuni alpini più colpiti. Le foreste schiantate stanno lentamente ricominciando a vivere: nuove generazioni di abeti, ma anche **specie miste più resistenti al cambiamento climatico** (faggi, larici, querce, aceri). Sarà un bosco diverso da quello di prima, e sarà più adatto al clima che verrà.
 
-Vaia ha anche generato un fenomeno positivo: il legname schiantato — milioni di tonnellate di abete rosso di altissima qualità — è stato in parte trasformato in **strumenti musicali** (l'abete della **Foresta dei Violini** della Val di Fiemme è il legno preferito dai liutai mondiali, fra cui i Stradivari). Centinaia di **violini e violoncelli "Vaia"** sono oggi nelle mani di musicisti in tutto il mondo. Ogni nota suonata su quegli strumenti porta dentro il ricordo di una tempesta e di una resilienza italiana.
+Vaia ha anche generato un fenomeno positivo. Il legname schiantato — milioni di tonnellate di abete rosso di altissima qualità — è stato in parte trasformato in **strumenti musicali**. L'abete della **Foresta dei Violini** della Val di Fiemme è il legno preferito dai liutai mondiali, fra cui gli Stradivari. Centinaia di **violini e violoncelli "Vaia"** sono oggi nelle mani di musicisti in tutto il mondo. Ogni nota suonata su quegli strumenti porta dentro il ricordo di una tempesta e di una resilienza italiana.
 
 ## Per approfondire (fonti istituzionali)
 


### PR DESCRIPTION
Completa il lavoro sulle frasi lunghe (issue #350 sez.10).

**Causa radice individuata:** la sez.10 dell'audit univa tutto il corpo e contava gli **elenchi senza punto finale** come un'unica 'frase' da decine/centinaia di parole → falsi positivi (es. una lista di mezzi contata come frase da 194 parole). 

**Fix euristica** (`audit-sito.yml`): conta solo la PROSA, saltando liste puntate/numerate, titoli, tabelle, citazioni e blocchi shortcode `{{< >}}` (alt/caption).

**Veri periodi run-on spezzati** (>40 parole) in 8 articoli: sala-radio, allagamenti, catena-comunicazioni, storia-gruppo, manuale-caritas, frequenze-radio, infiorata, vaia (oltre ai 2 già fatti in #375).

Verifica: **0 articoli** con ≥3 frasi di prosa >40 parole.