### PR TITLE
Workflow: comprimi podcast m4a a 64 kbps mono (<50 MB, no LFS)

### DIFF
--- a/.github/workflows/comprimi-podcast.yml
+++ b/.github/workflows/comprimi-podcast.yml
@@ -1,0 +1,69 @@
+name: "🎙️ Comprimi podcast (m4a → 64 kbps mono)"
+
+# Manutenzione one-shot: ricodifica i podcast .m4a (parlato) a 64 kbps mono per
+# scendere sotto i 50 MB (soglia oltre cui GitHub avvisa "file too large") e
+# alleggerire il repo, senza Git LFS. Qualità voce invariata all'ascolto.
+# Sostituisce un file solo se la nuova versione è più piccola e valida.
+# Esecuzione manuale (workflow_dispatch); committa e ri-triggera deploy.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: "comprimi-podcast"
+  cancel-in-progress: false
+
+jobs:
+  comprimi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📥 Checkout"
+        uses: actions/checkout@v4
+
+      - name: "🔧 ffmpeg"
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg
+
+      - name: "🎚️ Ricodifica podcast a 64 kbps mono"
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for f in static/podcast/episodi/*.m4a; do
+            tmp="${f%.m4a}.tmp.m4a"
+            ffmpeg -y -loglevel error -i "$f" -c:a aac -b:a 64k -ac 1 -movflags +faststart "$tmp"
+            orig=$(stat -c%s "$f"); new=$(stat -c%s "$tmp")
+            # verifica durata preservata (entro 2 secondi) per non rovinare l'audio
+            d1=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$f" | cut -d. -f1)
+            d2=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$tmp" | cut -d. -f1)
+            diff=$(( d1 > d2 ? d1 - d2 : d2 - d1 ))
+            if [ "$new" -gt 1000 ] && [ "$new" -lt "$orig" ] && [ "$diff" -le 2 ]; then
+              mv "$tmp" "$f"
+              echo "OK  $(basename "$f"): $(( orig/1024/1024 )) MB -> $(( new/1024/1024 )) MB"
+            else
+              rm -f "$tmp"
+              echo "SKIP $(basename "$f") (nessun guadagno o durata difforme)"
+            fi
+          done
+
+      - name: "💾 Commit + ri-trigger deploy"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- static/podcast/episodi/; then
+            echo "Nessun podcast modificato."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add static/podcast/episodi/*.m4a
+          git commit -m "chore(podcast): ricodifica a 64 kbps mono (<50 MB, repo più leggero) [skip-podcast]"
+          for t in 1 2 3; do
+            if git push 2>&1; then break; fi
+            git pull --rebase origin main || { echo "Rebase fallito"; exit 1; }
+            [ "$t" = "3" ] && { echo "Push fallito"; exit 1; }
+          done
+          gh workflow run deploy.yml


### PR DESCRIPTION
Risolve l'avviso GitHub 'file too large >50 MB' sui 5 podcast, scelta utente (ri-compressione invece di Git LFS, che non è compatibile col free-tier + deploy orari).

- Workflow manuale `comprimi-podcast.yml`: ricodifica .m4a a 64 kbps mono (parlato, qualità invariata), sostituisce solo se più piccolo e durata preservata, committa e ri-triggera deploy.
- Niente Git LFS, niente rischio pipeline/quota.