### PR TITLE
Cruscotto multidisciplinare /cruscotto/ (Terremoti INGV nativo + switch radar/meteo/allerta)

### DIFF
--- a/content/cruscotto/_index.md
+++ b/content/cruscotto/_index.md
@@ -1,0 +1,79 @@
+---
+title: "Cruscotto del territorio"
+description: "Cruscotto multidisciplinare: terremoti in tempo reale (INGV), radar pioggia, meteo del Lazio e stato di allerta, in un'unica pagina."
+layout: "single"
+tts: false
+toc: false
+aliases:
+  - /dashboard/
+---
+
+Un'unica pagina per consultare i dati di rischio del territorio, da **fonti ufficiali e aperte**. Scegli il tema con i pulsanti qui sotto. Sono dati **indicativi**: per le allerte valgono i bollettini del [Centro Funzionale Regionale del Lazio](https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti), in emergenza chiama il **112**.
+
+<div class="cruscotto-switch" role="tablist" aria-label="Temi del cruscotto">
+  <button type="button" class="cruscotto-tab" id="tab-terremoti" data-panel="terremoti" role="tab" aria-selected="true" aria-controls="panel-terremoti" tabindex="0"><i class="bi bi-activity" aria-hidden="true"></i> Terremoti</button>
+  <button type="button" class="cruscotto-tab" id="tab-radar" data-panel="radar" role="tab" aria-selected="false" aria-controls="panel-radar" tabindex="-1"><i class="bi bi-cloud-rain-heavy" aria-hidden="true"></i> Radar pioggia</button>
+  <button type="button" class="cruscotto-tab" id="tab-meteo" data-panel="meteo" role="tab" aria-selected="false" aria-controls="panel-meteo" tabindex="-1"><i class="bi bi-cloud-sun" aria-hidden="true"></i> Meteo</button>
+  <button type="button" class="cruscotto-tab" id="tab-allerta" data-panel="allerta" role="tab" aria-selected="false" aria-controls="panel-allerta" tabindex="-1"><i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Allerta</button>
+</div>
+
+<div class="cruscotto-panel" id="panel-terremoti" data-panel="terremoti" role="tabpanel" aria-labelledby="tab-terremoti" tabindex="0">
+
+{{< dashboard-terremoti >}}
+
+</div>
+
+<div class="cruscotto-panel" id="panel-radar" data-panel="radar" role="tabpanel" aria-labelledby="tab-radar" tabindex="0" hidden>
+
+{{< radar-dpc >}}
+
+</div>
+
+<div class="cruscotto-panel" id="panel-meteo" data-panel="meteo" role="tabpanel" aria-labelledby="tab-meteo" tabindex="0" hidden>
+
+{{< meteo-lazio >}}
+
+</div>
+
+<div class="cruscotto-panel" id="panel-allerta" data-panel="allerta" role="tabpanel" aria-labelledby="tab-allerta" tabindex="0" hidden>
+
+{{< allerta-stato-attuale >}}
+
+</div>
+
+<script>
+(function(){
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.cruscotto-switch .cruscotto-tab'));
+  var panels = document.querySelectorAll('.cruscotto-panel');
+  function show(name, focus){
+    tabs.forEach(function(t){
+      var on = t.dataset.panel === name;
+      t.setAttribute('aria-selected', on ? 'true' : 'false');
+      t.tabIndex = on ? 0 : -1;
+      if (on && focus) t.focus();
+    });
+    panels.forEach(function(p){ p.hidden = (p.dataset.panel !== name); });
+    // le mappe Leaflet nascoste hanno dimensione 0: un resize le ridisegna
+    window.dispatchEvent(new Event('resize'));
+    if (name === 'terremoti') window.dispatchEvent(new Event('cruscotto:terremoti'));
+  }
+  tabs.forEach(function(t, i){
+    t.addEventListener('click', function(){ show(t.dataset.panel); });
+    t.addEventListener('keydown', function(e){
+      var n = null;
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') n = (i + 1) % tabs.length;
+      else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') n = (i - 1 + tabs.length) % tabs.length;
+      else if (e.key === 'Home') n = 0;
+      else if (e.key === 'End') n = tabs.length - 1;
+      if (n !== null) { e.preventDefault(); show(tabs[n].dataset.panel, true); }
+    });
+  });
+})();
+</script>
+
+## Le fonti del cruscotto
+
+- **Terremoti** — [INGV](https://terremoti.ingv.it/) (Istituto Nazionale di Geofisica e Vulcanologia), servizio FDSN open data, ultimi 7 giorni in Italia.
+- **Radar pioggia** — [Radar-DPC](https://mappe.protezionecivile.gov.it/it/mappe-e-dashboard-rischi/piattaforma-radar/) (Dipartimento della Protezione Civile), servizi WMTS open data.
+- **Meteo** — [Open-Meteo](https://open-meteo.com/) (modelli ECMWF), nostra elaborazione per il Lazio e Genzano di Roma.
+- **Allerta** — [Centro Funzionale Regionale del Lazio](https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti).

--- a/hugo.toml
+++ b/hugo.toml
@@ -138,6 +138,12 @@ enableGitInfo = true
   parent = "per-il-cittadino"
   weight = 7
 
+[[menus.main]]
+  name = "Cruscotto del territorio"
+  url = "/cruscotto/"
+  parent = "per-il-cittadino"
+  weight = 8
+
 # --- Dropdown: Per le scuole (7 voci didattiche) ---
 # (rinominato da "Educazione e Inclusione" a maggio 2026 — splittato per
 # alleggerire e separare le 3 vocazioni mescolate: didattica scolastica,

--- a/static/app-shared/site-chrome.js
+++ b/static/app-shared/site-chrome.js
@@ -89,6 +89,7 @@
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/numeri-utili/" role="menuitem"><span>Numeri Utili</span></a></li>' +
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/piano-familiare/" role="menuitem"><span>Piano Familiare</span></a></li>' +
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/formazione/kit-calamita/" role="menuitem"><span>Kit pronti per situazioni vulnerabili</span></a></li>' +
+                    '<li role="none"><a class="list-item" href="' + SITE_URL + '/cruscotto/" role="menuitem"><span>Cruscotto del territorio</span></a></li>' +
                   '</ul></div></div>' +
                 '</li>' +
                 /* Dropdown: Per le scuole (6 voci didattiche, splittato da "Educazione e Inclusione" maggio 2026) */

--- a/themes/flavour-pcgenzano/layouts/partials/social-channels.html
+++ b/themes/flavour-pcgenzano/layouts/partials/social-channels.html
@@ -77,15 +77,14 @@
           </div>
           <div class="it-alert-body">
             <p>
-              Controlla le <strong>ultime scosse</strong> rilevate in tempo reale
-              dall'<strong>INGV</strong> e <a href="{{ "rischi-prevenzione/rischio-sismico/" | relURL }}">cosa fare in caso di terremoto</a>.
+              Controlla le <strong>ultime scosse</strong> in tempo reale (dati INGV)
+              sul nostro cruscotto e scopri <a href="{{ "rischi-prevenzione/rischio-sismico/" | relURL }}">cosa fare in caso di terremoto</a>.
             </p>
-            <a href="https://terremoti.ingv.it/"
-               target="_blank" rel="noopener noreferrer"
+            <a href="{{ "cruscotto/" | relURL }}"
                class="btn btn-sm btn-outline-primary"
-               aria-label="Vedi le ultime scosse di terremoto su INGV — si apre in una nuova finestra">
+               aria-label="Apri il cruscotto con le ultime scosse di terremoto">
               <i class="bi bi-geo-alt me-1" aria-hidden="true"></i>
-              Ultime scosse (INGV)
+              Ultime scosse
             </a>
           </div>
         </div>

--- a/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
@@ -1,0 +1,122 @@
+{{/* Shortcode dashboard-terremoti — cruscotto sismico nativo (dati ufficiali INGV).
+     Fonte: INGV FDSN event web service (https://webservices.ingv.it/fdsnws/event/1/query),
+     GeoJSON, CORS aperto (Access-Control-Allow-Origin: *) -> fetch diretto dal browser,
+     niente widget/iframe di terzi. Leaflet self-hosted. Mappa + indicatori + liste.
+     Replica nativa della dashboard ArcGIS "Terremoti in Italia negli ultimi 7 giorni". */}}
+{{ $leafletCSS := "vendor/leaflet/leaflet.css" | relURL }}
+{{ $leafletJS  := "vendor/leaflet/leaflet.js"  | relURL }}
+
+<link rel="stylesheet" href="{{ $leafletCSS }}" crossorigin="">
+<div class="dash-sisma" aria-labelledby="dash-sisma-tit">
+  <h2 id="dash-sisma-tit" class="visually-hidden">Cruscotto terremoti in Italia</h2>
+
+  <div class="dash-sisma-toolbar" role="group" aria-label="Filtri terremoti">
+    <span class="dash-sisma-grp" role="group" aria-label="Finestra temporale">
+      <button type="button" class="dash-pill" data-win="1" aria-pressed="false">24 ore</button>
+      <button type="button" class="dash-pill" data-win="7" aria-pressed="true">7 giorni</button>
+    </span>
+    <span class="dash-sisma-grp" role="group" aria-label="Magnitudo minima">
+      <button type="button" class="dash-pill" data-mag="1.5" aria-pressed="true">tutti</button>
+      <button type="button" class="dash-pill" data-mag="2" aria-pressed="false">M≥2</button>
+      <button type="button" class="dash-pill" data-mag="3" aria-pressed="false">M≥3</button>
+      <button type="button" class="dash-pill" data-mag="4" aria-pressed="false">M≥4</button>
+    </span>
+    <span class="dash-sisma-stato" id="dash-sisma-stato" aria-live="polite"></span>
+  </div>
+
+  <div class="dash-sisma-kpi" id="dash-sisma-kpi" aria-live="polite">
+    <div class="dash-kpi"><span class="dash-kpi-num" id="kpi-num">—</span><span class="dash-kpi-lab">Eventi nel periodo</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="kpi-max">—</span><span class="dash-kpi-lab">Magnitudo massima</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="kpi-m3">—</span><span class="dash-kpi-lab">Eventi M≥3</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="kpi-ult">—</span><span class="dash-kpi-lab">Ultimo evento</span></div>
+  </div>
+
+  <div class="dash-sisma-grid">
+    <div id="dash-sisma-mappa" role="application" aria-label="Mappa dei terremoti in Italia nel periodo selezionato, con Genzano di Roma evidenziata."></div>
+    <div class="dash-sisma-liste">
+      <h3>Ultimi eventi</h3>
+      <ol class="dash-sisma-list" id="lista-ultimi"></ol>
+      <h3>Più forti</h3>
+      <ol class="dash-sisma-list" id="lista-forti"></ol>
+    </div>
+  </div>
+
+  <div class="dash-sisma-legenda" aria-hidden="true">
+    <span><i style="background:#9aa7b4"></i> M&lt;2</span>
+    <span><i style="background:#f7e359"></i> 2–3</span>
+    <span><i style="background:#f5a623"></i> 3–4</span>
+    <span><i style="background:#e8412b"></i> 4–5</span>
+    <span><i style="background:#7f1d1d"></i> ≥5</span>
+  </div>
+
+  <noscript><div class="alert alert-warning mt-2" role="note">Per il cruscotto serve JavaScript. Dati ufficiali su <a href="https://terremoti.ingv.it/" target="_blank" rel="noopener noreferrer">terremoti.ingv.it</a>.</div></noscript>
+  <p class="small text-muted mt-2 mb-0">Dati: <a href="https://terremoti.ingv.it/" target="_blank" rel="noopener noreferrer">INGV — Istituto Nazionale di Geofisica e Vulcanologia</a> (FDSN, open data). Aggiornamento automatico. In emergenza chiama il <a href="tel:112">112</a>.</p>
+
+  <script src="{{ $leafletJS }}" crossorigin=""></script>
+  <script>
+  (function(){
+    if (typeof L === 'undefined') return;
+    var FDSN = 'https://webservices.ingv.it/fdsnws/event/1/query';
+    var GENZANO = [41.7085, 12.6916];
+    var win = 7, minmag = 1.5, eventi = [], markers = null, map = null;
+    var stato = document.getElementById('dash-sisma-stato');
+
+    function colore(m){ return m>=5?'#7f1d1d':m>=4?'#e8412b':m>=3?'#f5a623':m>=2?'#f7e359':'#9aa7b4'; }
+    function raggio(m){ return Math.max(4, (m+1)*2.4); }
+    function pad(n){ return ('0'+n).slice(-2); }
+    function oraIt(iso){ var d=new Date(iso); return pad(d.getDate())+'/'+pad(d.getMonth()+1)+' '+pad(d.getHours())+':'+pad(d.getMinutes()); }
+    function minFa(iso){ var m=Math.round((Date.now()-new Date(iso).getTime())/60000); if(m<60)return m+' min fa'; var h=Math.round(m/60); return h<48?h+' ore fa':Math.round(h/24)+' gg fa'; }
+    function dist(la,lo){ var R=6371,t=Math.PI/180,dla=(la-GENZANO[0])*t,dlo=(lo-GENZANO[1])*t,a=Math.sin(dla/2)**2+Math.cos(GENZANO[0]*t)*Math.cos(la*t)*Math.sin(dlo/2)**2; return Math.round(R*2*Math.atan2(Math.sqrt(a),Math.sqrt(1-a))); }
+
+    map = L.map('dash-sisma-mappa', { center: [42.2,12.6], zoom: 5, scrollWheelZoom:false });
+    map.on('focus', function(){ map.scrollWheelZoom.enable(); });
+    map.on('blur',  function(){ map.scrollWheelZoom.disable(); });
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+      subdomains:'abcd', maxZoom:12, attribution:'© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> © <a href="https://carto.com/attributions">CARTO</a>' }).addTo(map);
+    L.marker(GENZANO, { icon: L.divIcon({className:'dash-stella', html:'<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#003366" stroke="#fff" stroke-width="1.4"/></svg>', iconSize:[22,22], iconAnchor:[11,11]}) }).bindPopup('<strong>Genzano di Roma</strong>').addTo(map);
+    markers = L.layerGroup().addTo(map);
+
+    function render(){
+      markers.clearLayers();
+      var el = document.getElementById('lista-ultimi'), ef = document.getElementById('lista-forti');
+      el.innerHTML=''; ef.innerHTML='';
+      if(!eventi.length){ stato.textContent='Nessun evento nel periodo selezionato.'; document.getElementById('kpi-num').textContent='0'; document.getElementById('kpi-max').textContent='—'; document.getElementById('kpi-m3').textContent='0'; document.getElementById('kpi-ult').textContent='—'; return; }
+      var maxM=0, m3=0;
+      eventi.forEach(function(e){
+        if(e.mag>maxM)maxM=e.mag; if(e.mag>=3)m3++;
+        L.circleMarker([e.lat,e.lon],{radius:raggio(e.mag),color:'#333',weight:0.6,fillColor:colore(e.mag),fillOpacity:0.8})
+          .bindPopup('<strong>M '+e.mag.toFixed(1)+'</strong><br>'+e.place+'<br>'+oraIt(e.time)+' · prof. '+e.depth+' km<br>'+dist(e.lat,e.lon)+' km da Genzano di Roma')
+          .addTo(markers);
+      });
+      document.getElementById('kpi-num').textContent=eventi.length;
+      document.getElementById('kpi-max').textContent='M '+maxM.toFixed(1);
+      document.getElementById('kpi-m3').textContent=m3;
+      var ult=eventi.slice().sort(function(a,b){return new Date(b.time)-new Date(a.time);});
+      document.getElementById('kpi-ult').textContent=minFa(ult[0].time);
+      function riga(e){ return '<li><span class="dash-mag" style="border-left-color:'+colore(e.mag)+'">M '+e.mag.toFixed(1)+'</span> <span class="dash-luogo">'+e.place+'</span> <span class="dash-meta">'+oraIt(e.time)+' · '+dist(e.lat,e.lon)+' km da Genzano di Roma</span></li>'; }
+      el.innerHTML=ult.slice(0,8).map(riga).join('');
+      ef.innerHTML=eventi.slice().sort(function(a,b){return b.mag-a.mag;}).slice(0,8).map(riga).join('');
+    }
+
+    function carica(){
+      stato.textContent='Aggiornamento…';
+      var from=new Date(Date.now()-win*86400000).toISOString().slice(0,19);
+      var url=FDSN+'?starttime='+from+'&minmagnitude='+minmag+'&minlatitude=35&maxlatitude=48&minlongitude=5&maxlongitude=20&format=geojson&orderby=time&limit=1500';
+      fetch(url).then(function(r){return r.json();}).then(function(j){
+        eventi=(j.features||[]).map(function(f){var p=f.properties,g=f.geometry.coordinates;return {time:p.time,mag:p.mag,place:p.place||'',depth:Math.round(g[2]),lat:g[1],lon:g[0]};}).filter(function(e){return typeof e.mag==='number';});
+        render();
+        stato.textContent='Aggiornato alle '+pad(new Date().getHours())+':'+pad(new Date().getMinutes());
+      }).catch(function(){ stato.textContent='Dati momentaneamente non disponibili — vedi terremoti.ingv.it'; });
+    }
+
+    document.querySelectorAll('.dash-pill[data-win]').forEach(function(b){ b.addEventListener('click',function(){ document.querySelectorAll('.dash-pill[data-win]').forEach(function(x){x.setAttribute('aria-pressed','false');}); b.setAttribute('aria-pressed','true'); win=parseInt(b.dataset.win,10); carica(); }); });
+    document.querySelectorAll('.dash-pill[data-mag]').forEach(function(b){ b.addEventListener('click',function(){ document.querySelectorAll('.dash-pill[data-mag]').forEach(function(x){x.setAttribute('aria-pressed','false');}); b.setAttribute('aria-pressed','true'); minmag=parseFloat(b.dataset.mag); carica(); }); });
+
+    // init quando la scheda diventa visibile (lazy) o subito se già visibile
+    var box=document.getElementById('dash-sisma-mappa');
+    function go(){ map.invalidateSize(); carica(); setInterval(carica, 300000); }
+    if (box.offsetParent !== null) { go(); }
+    else { window.addEventListener('cruscotto:terremoti', go, {once:true}); }
+  })();
+  </script>
+</div>

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6574,3 +6574,36 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 .meteo-approfondisci-card:hover .meteo-approfondisci-freccia { transform: translateX(4px); }
 @media (prefers-reduced-motion: reduce) { .meteo-approfondisci-card, .meteo-approfondisci-freccia { transition: none; }
   .meteo-approfondisci-card:hover { transform: none; } }
+
+/* ============================================================
+   CRUSCOTTO MULTIDISCIPLINARE v1.0 — /cruscotto/
+   Switch a schede (ARIA tabs) + cruscotto sismico INGV. WCAG 2.2 AA.
+   ============================================================ */
+.cruscotto-switch { display: flex; flex-wrap: wrap; gap: .5rem; margin: 1.2rem 0; border-bottom: 2px solid #e2e7eb; padding-bottom: .6rem; }
+.cruscotto-tab { display: inline-flex; align-items: center; gap: .4rem; border: 2px solid #003366; background: #fff; color: #003366; padding: .5rem 1rem; border-radius: 999px; font-size: .95rem; font-weight: 600; cursor: pointer; transition: background .15s, color .15s; }
+.cruscotto-tab[aria-selected="true"] { background: #003366; color: #fff; }
+.cruscotto-tab:focus-visible { outline: 3px solid #ffbe2e; outline-offset: 2px; }
+.cruscotto-panel[hidden] { display: none; }
+
+/* cruscotto sismico */
+.dash-sisma-toolbar { display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; margin-bottom: .8rem; }
+.dash-sisma-grp { display: inline-flex; gap: .35rem; }
+.dash-pill { border: 2px solid #003366; background: #fff; color: #003366; padding: .35rem .8rem; border-radius: 999px; font-size: .9rem; cursor: pointer; }
+.dash-pill[aria-pressed="true"] { background: #003366; color: #fff; }
+.dash-pill:focus-visible { outline: 3px solid #ffbe2e; outline-offset: 2px; }
+.dash-sisma-stato { font-size: .88rem; color: #495057; margin-left: auto; }
+.dash-sisma-kpi { display: grid; grid-template-columns: repeat(4, 1fr); gap: .8rem; margin-bottom: 1rem; }
+.dash-kpi { background: #e7f0fa; border-left: 4px solid #003366; border-radius: 8px; padding: .7rem .9rem; text-align: center; }
+.dash-kpi-num { display: block; font-size: 1.5rem; font-weight: 800; color: #003366; line-height: 1.1; }
+.dash-kpi-lab { display: block; font-size: .78rem; color: #495057; margin-top: .2rem; }
+.dash-sisma-grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: 1rem; align-items: start; }
+#dash-sisma-mappa { height: 520px; border-radius: 8px; border: 2px solid #003366; background: #eaeaea; }
+.dash-sisma-liste h3 { font-size: 1rem; color: #003366; margin: .2rem 0 .4rem; }
+.dash-sisma-list { list-style: none; margin: 0 0 1rem; padding: 0; }
+.dash-sisma-list li { display: flex; align-items: baseline; gap: .5rem; padding: .35rem 0; border-bottom: 1px solid #eef1f4; font-size: .9rem; }
+.dash-mag { flex: 0 0 auto; background: #fff; color: #1a1a1a; border: 1px solid #d4dde6; border-left: 5px solid #9aa7b4; border-radius: 5px; padding: .1rem .4rem; font-weight: 800; font-variant-numeric: tabular-nums; }
+.dash-luogo { flex: 1 1 auto; color: #1a1a1a; }
+.dash-meta { flex: 0 0 auto; color: #6c757d; font-size: .8rem; }
+.dash-sisma-legenda { display: flex; flex-wrap: wrap; gap: .8rem; margin-top: .6rem; font-size: .8rem; color: #495057; }
+.dash-sisma-legenda i { display: inline-block; width: .85rem; height: .85rem; border-radius: 50%; vertical-align: middle; margin-right: .25rem; border: 1px solid rgba(0,0,0,.2); }
+@media (max-width: 768px) { .dash-sisma-grid { grid-template-columns: 1fr; } .dash-sisma-kpi { grid-template-columns: repeat(2, 1fr); } #dash-sisma-mappa { height: 420px; } }


### PR DESCRIPTION
Richiesta utente: dashboard tipo ArcGIS ('Terremoti in Italia ultimi 7 giorni') ma **nativa**, e **multidisciplinare con switch** ad altre fonti online.

- **Scheda Terremoti** nativa: dati ufficiali **INGV FDSN** (open data, CORS aperto → fetch dal browser, niente iframe). Mappa Leaflet self-hosted + KPI (numero, magnitudo max, M≥3, ultimo) + liste Ultimi/Più forti + filtri (24h/7gg, magnitudo) + distanza da Genzano di Roma + auto-refresh.
- **Switch a schede** (ARIA tablist, tastiera frecce/Home/End): Terremoti · Radar pioggia · Meteo · Allerta (riusa i componenti esistenti).
- Menu 'Cruscotto del territorio' (hugo.toml + site-chrome.js sincronizzati), card home collegata.
- **AGID + WCAG 2.2 AA**: focus visibile, contrasti, badge magnitudo non solo-colore.

Estensibile: aggiungere una fonte = una scheda nuova. Build pulito.