### PR TITLE
Cruscotto v2 native: sismicità Castelli Romani + Aria/pollini + Mare

### DIFF
--- a/content/cruscotto/_index.md
+++ b/content/cruscotto/_index.md
@@ -15,6 +15,8 @@ Un'unica pagina per consultare i dati di rischio del territorio, da **fonti uffi
   <button type="button" class="cruscotto-tab" id="tab-radar" data-panel="radar" role="tab" aria-selected="false" aria-controls="panel-radar" tabindex="-1"><i class="bi bi-cloud-rain-heavy" aria-hidden="true"></i> Radar pioggia</button>
   <button type="button" class="cruscotto-tab" id="tab-meteo" data-panel="meteo" role="tab" aria-selected="false" aria-controls="panel-meteo" tabindex="-1"><i class="bi bi-cloud-sun" aria-hidden="true"></i> Meteo</button>
   <button type="button" class="cruscotto-tab" id="tab-allerta" data-panel="allerta" role="tab" aria-selected="false" aria-controls="panel-allerta" tabindex="-1"><i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Allerta</button>
+  <button type="button" class="cruscotto-tab" id="tab-aria" data-panel="aria" role="tab" aria-selected="false" aria-controls="panel-aria" tabindex="-1"><i class="bi bi-wind" aria-hidden="true"></i> Aria e pollini</button>
+  <button type="button" class="cruscotto-tab" id="tab-mare" data-panel="mare" role="tab" aria-selected="false" aria-controls="panel-mare" tabindex="-1"><i class="bi bi-water" aria-hidden="true"></i> Mare</button>
 </div>
 
 <div class="cruscotto-panel" id="panel-terremoti" data-panel="terremoti" role="tabpanel" aria-labelledby="tab-terremoti" tabindex="0">
@@ -38,6 +40,18 @@ Un'unica pagina per consultare i dati di rischio del territorio, da **fonti uffi
 <div class="cruscotto-panel" id="panel-allerta" data-panel="allerta" role="tabpanel" aria-labelledby="tab-allerta" tabindex="0" hidden>
 
 {{< allerta-stato-attuale >}}
+
+</div>
+
+<div class="cruscotto-panel" id="panel-aria" data-panel="aria" role="tabpanel" aria-labelledby="tab-aria" tabindex="0" hidden>
+
+{{< dashboard-aria >}}
+
+</div>
+
+<div class="cruscotto-panel" id="panel-mare" data-panel="mare" role="tabpanel" aria-labelledby="tab-mare" tabindex="0" hidden>
+
+{{< dashboard-mare >}}
 
 </div>
 
@@ -77,3 +91,7 @@ Un'unica pagina per consultare i dati di rischio del territorio, da **fonti uffi
 - **Radar pioggia** — [Radar-DPC](https://mappe.protezionecivile.gov.it/it/mappe-e-dashboard-rischi/piattaforma-radar/) (Dipartimento della Protezione Civile), servizi WMTS open data.
 - **Meteo** — [Open-Meteo](https://open-meteo.com/) (modelli ECMWF), nostra elaborazione per il Lazio e Genzano di Roma.
 - **Allerta** — [Centro Funzionale Regionale del Lazio](https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti).
+- **Aria e pollini** — [Open-Meteo Air Quality](https://open-meteo.com/) (dati europei [Copernicus CAMS](https://atmosphere.copernicus.eu/)): indice AQI europeo, PM10, PM2.5, ozono, pollini.
+- **Mare** — [Open-Meteo Marine](https://open-meteo.com/): altezza e periodo onde sulla costa laziale.
+
+> La scheda **Terremoti** ha lo switch **Italia / Castelli Romani**: la vista locale mostra la sismicità del distretto vulcanico dei Colli Albani, su cui sorge Genzano di Roma.

--- a/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-aria.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-aria.html
@@ -1,0 +1,64 @@
+{{/* Shortcode dashboard-aria — qualità dell'aria e pollini a Genzano di Roma.
+     Fonte: Open-Meteo Air Quality API (dati CAMS, licenza CC-BY, CORS aperto) -> fetch
+     diretto dal browser, niente widget di terzi. Indicatori, nessuna mappa.
+     AQI europeo (scala EEA), PM10, PM2.5, ozono, NO2 + pollini (graminacee, olivo,
+     ambrosia, betulla). Il valore numerico è sempre mostrato (non solo colore). */}}
+<div class="dash-aria" aria-labelledby="dash-aria-tit">
+  <h2 id="dash-aria-tit" class="visually-hidden">Qualità dell'aria e pollini a Genzano di Roma</h2>
+
+  <div class="dash-aria-hero" id="aria-hero">
+    <span class="dash-aria-aqi" id="aria-aqi">—</span>
+    <span class="dash-aria-aqilab" id="aria-aqilab">Qualità dell'aria · in aggiornamento…</span>
+  </div>
+
+  <h3 class="dash-aria-h3">Inquinanti</h3>
+  <div class="dash-sisma-kpi">
+    <div class="dash-kpi"><span class="dash-kpi-num" id="aria-pm10">—</span><span class="dash-kpi-lab">PM10 (µg/m³)</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="aria-pm25">—</span><span class="dash-kpi-lab">PM2.5 (µg/m³)</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="aria-o3">—</span><span class="dash-kpi-lab">Ozono (µg/m³)</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="aria-no2">—</span><span class="dash-kpi-lab">Biossido d'azoto (µg/m³)</span></div>
+  </div>
+
+  <h3 class="dash-aria-h3">Pollini <span class="dash-aria-nota">(grani/m³ — valore indicativo)</span></h3>
+  <div class="dash-sisma-kpi" id="aria-pollini">
+    <div class="dash-kpi"><span class="dash-kpi-num" id="pol-grass">—</span><span class="dash-kpi-lab">Graminacee</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="pol-olive">—</span><span class="dash-kpi-lab">Olivo</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="pol-ragweed">—</span><span class="dash-kpi-lab">Ambrosia</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="pol-birch">—</span><span class="dash-kpi-lab">Betulla</span></div>
+  </div>
+
+  <p class="small text-muted mt-2 mb-0" id="aria-stato"></p>
+  <p class="small text-muted mt-1 mb-0">Dati: <a href="https://open-meteo.com/" target="_blank" rel="noopener noreferrer">Open-Meteo</a> / servizio europeo <a href="https://atmosphere.copernicus.eu/" target="_blank" rel="noopener noreferrer">Copernicus CAMS</a>. Dato indicativo per Genzano di Roma; per soglie sanitarie ufficiali vedi <a href="https://www.arpalazio.it/" target="_blank" rel="noopener noreferrer">ARPA Lazio</a>.</p>
+
+  <script>
+  (function(){
+    var API='https://air-quality-api.open-meteo.com/v1/air-quality?latitude=41.7085&longitude=12.6916&timezone=Europe%2FRome&current=european_aqi,pm10,pm2_5,ozone,nitrogen_dioxide,grass_pollen,olive_pollen,ragweed_pollen,birch_pollen';
+    function aqiInfo(v){
+      if(v==null)return['#9aa7b4','non disponibile'];
+      if(v<=20)return['#2ecc71','Buona'];
+      if(v<=40)return['#a8e05f','Discreta'];
+      if(v<=60)return['#f7e359','Moderata'];
+      if(v<=80)return['#f5a623','Scarsa'];
+      if(v<=100)return['#e8412b','Scadente'];
+      return['#7f1d1d','Pessima'];
+    }
+    function set(id,v,suf){ var e=document.getElementById(id); if(e) e.textContent=(v==null?'n.d.':Math.round(v)+(suf||'')); }
+    function carica(){
+      fetch(API).then(function(r){return r.json();}).then(function(j){
+        var c=j.current||{};
+        var info=aqiInfo(c.european_aqi);
+        var hero=document.getElementById('aria-hero');
+        document.getElementById('aria-aqi').textContent=(c.european_aqi==null?'n.d.':Math.round(c.european_aqi));
+        document.getElementById('aria-aqilab').textContent='Qualità dell’aria: '+info[1]+' (indice europeo AQI)';
+        hero.style.borderColor=info[0];
+        document.getElementById('aria-aqi').style.color=info[0];
+        set('aria-pm10',c.pm10); set('aria-pm25',c.pm2_5); set('aria-o3',c.ozone); set('aria-no2',c.nitrogen_dioxide);
+        set('pol-grass',c.grass_pollen); set('pol-olive',c.olive_pollen); set('pol-ragweed',c.ragweed_pollen); set('pol-birch',c.birch_pollen);
+        var t=c.time?new Date(c.time):new Date();
+        document.getElementById('aria-stato').textContent='Aggiornato alle '+('0'+t.getHours()).slice(-2)+':'+('0'+t.getMinutes()).slice(-2);
+      }).catch(function(){ document.getElementById('aria-stato').textContent='Dati momentaneamente non disponibili.'; });
+    }
+    carica(); setInterval(carica, 1800000); // ogni 30 minuti
+  })();
+  </script>
+</div>

--- a/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-mare.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-mare.html
@@ -1,0 +1,36 @@
+{{/* Shortcode dashboard-mare — stato del mare / mareggiate sulla costa laziale.
+     Fonte: Open-Meteo Marine API (CORS aperto) -> fetch dal browser, niente terzi.
+     Punto di riferimento: largo di Anzio-Nettuno (la costa più vicina a Genzano,
+     che è interna). Solo indicatori, nessuna mappa. */}}
+<div class="dash-mare" aria-labelledby="dash-mare-tit">
+  <h2 id="dash-mare-tit" class="visually-hidden">Stato del mare sulla costa laziale</h2>
+  <p class="dash-aria-nota mb-2">Riferimento: largo di <strong>Anzio-Nettuno</strong>, la costa più vicina a Genzano di Roma (paese interno). Utile per gite ed eventi sul litorale.</p>
+  <div class="dash-sisma-kpi">
+    <div class="dash-kpi"><span class="dash-kpi-num" id="mare-h">—</span><span class="dash-kpi-lab">Altezza onde (m)</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="mare-stato">—</span><span class="dash-kpi-lab">Stato del mare</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="mare-t">—</span><span class="dash-kpi-lab">Periodo onde (s)</span></div>
+    <div class="dash-kpi"><span class="dash-kpi-num" id="mare-dir">—</span><span class="dash-kpi-lab">Direzione onde</span></div>
+  </div>
+  <p class="small text-muted mt-2 mb-0" id="mare-stato-agg"></p>
+  <p class="small text-muted mt-1 mb-0">Dati: <a href="https://open-meteo.com/" target="_blank" rel="noopener noreferrer">Open-Meteo Marine</a> (modelli onde). Dato indicativo; per la balneazione e gli avvisi costieri vedi le fonti ufficiali (Guardia Costiera, 1530).</p>
+  <script>
+  (function(){
+    var API='https://marine-api.open-meteo.com/v1/marine?latitude=41.43&longitude=12.62&timezone=Europe%2FRome&current=wave_height,wave_period,wave_direction';
+    function cardinale(d){ if(d==null)return'n.d.'; var v=['N','NE','E','SE','S','SO','O','NO']; return v[Math.round(d/45)%8]; }
+    function scala(h){ // scala Douglas semplificata
+      if(h==null)return'n.d.'; if(h<0.1)return'Calmo'; if(h<0.5)return'Quasi calmo'; if(h<1.25)return'Poco mosso'; if(h<2.5)return'Mosso'; if(h<4)return'Molto mosso'; if(h<6)return'Agitato'; return'Molto agitato'; }
+    function carica(){
+      fetch(API).then(function(r){return r.json();}).then(function(j){
+        var c=j.current||{};
+        document.getElementById('mare-h').textContent=(c.wave_height==null?'n.d.':c.wave_height.toFixed(1));
+        document.getElementById('mare-stato').textContent=scala(c.wave_height);
+        document.getElementById('mare-t').textContent=(c.wave_period==null?'n.d.':Math.round(c.wave_period));
+        document.getElementById('mare-dir').textContent=cardinale(c.wave_direction);
+        var t=c.time?new Date(c.time):new Date();
+        document.getElementById('mare-stato-agg').textContent='Aggiornato alle '+('0'+t.getHours()).slice(-2)+':'+('0'+t.getMinutes()).slice(-2);
+      }).catch(function(){ document.getElementById('mare-stato-agg').textContent='Dati momentaneamente non disponibili.'; });
+    }
+    carica(); setInterval(carica, 1800000);
+  })();
+  </script>
+</div>

--- a/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
@@ -21,6 +21,10 @@
       <button type="button" class="dash-pill" data-mag="3" aria-pressed="false">M≥3</button>
       <button type="button" class="dash-pill" data-mag="4" aria-pressed="false">M≥4</button>
     </span>
+    <span class="dash-sisma-grp" role="group" aria-label="Zona">
+      <button type="button" class="dash-pill" data-zona="italia" aria-pressed="true">Italia</button>
+      <button type="button" class="dash-pill" data-zona="castelli" aria-pressed="false">Castelli Romani</button>
+    </span>
     <span class="dash-sisma-stato" id="dash-sisma-stato" aria-live="polite"></span>
   </div>
 
@@ -58,7 +62,11 @@
     if (typeof L === 'undefined') return;
     var FDSN = 'https://webservices.ingv.it/fdsnws/event/1/query';
     var GENZANO = [41.7085, 12.6916];
-    var win = 7, minmag = 1.5, eventi = [], markers = null, map = null;
+    var win = 7, minmag = 1.5, zona = 'italia', eventi = [], markers = null, map = null;
+    var BBOX = {
+      italia:   '&minlatitude=35&maxlatitude=48&minlongitude=5&maxlongitude=20',
+      castelli: '&minlatitude=41.55&maxlatitude=41.95&minlongitude=12.35&maxlongitude=12.95'
+    };
     var stato = document.getElementById('dash-sisma-stato');
 
     function colore(m){ return m>=5?'#7f1d1d':m>=4?'#e8412b':m>=3?'#f5a623':m>=2?'#f7e359':'#9aa7b4'; }
@@ -101,7 +109,7 @@
     function carica(){
       stato.textContent='Aggiornamento…';
       var from=new Date(Date.now()-win*86400000).toISOString().slice(0,19);
-      var url=FDSN+'?starttime='+from+'&minmagnitude='+minmag+'&minlatitude=35&maxlatitude=48&minlongitude=5&maxlongitude=20&format=geojson&orderby=time&limit=1500';
+      var url=FDSN+'?starttime='+from+'&minmagnitude='+minmag+BBOX[zona]+'&format=geojson&orderby=time&limit=1500';
       fetch(url).then(function(r){return r.json();}).then(function(j){
         eventi=(j.features||[]).map(function(f){var p=f.properties,g=f.geometry.coordinates;return {time:p.time,mag:p.mag,place:p.place||'',depth:Math.round(g[2]),lat:g[1],lon:g[0]};}).filter(function(e){return typeof e.mag==='number';});
         render();
@@ -111,6 +119,7 @@
 
     document.querySelectorAll('.dash-pill[data-win]').forEach(function(b){ b.addEventListener('click',function(){ document.querySelectorAll('.dash-pill[data-win]').forEach(function(x){x.setAttribute('aria-pressed','false');}); b.setAttribute('aria-pressed','true'); win=parseInt(b.dataset.win,10); carica(); }); });
     document.querySelectorAll('.dash-pill[data-mag]').forEach(function(b){ b.addEventListener('click',function(){ document.querySelectorAll('.dash-pill[data-mag]').forEach(function(x){x.setAttribute('aria-pressed','false');}); b.setAttribute('aria-pressed','true'); minmag=parseFloat(b.dataset.mag); carica(); }); });
+    document.querySelectorAll('.dash-pill[data-zona]').forEach(function(b){ b.addEventListener('click',function(){ document.querySelectorAll('.dash-pill[data-zona]').forEach(function(x){x.setAttribute('aria-pressed','false');}); b.setAttribute('aria-pressed','true'); zona=b.dataset.zona; map.setView(zona==='castelli'?[41.71,12.69]:[42.2,12.6], zona==='castelli'?10:5); carica(); }); });
 
     // init quando la scheda diventa visibile (lazy) o subito se già visibile
     var box=document.getElementById('dash-sisma-mappa');

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6607,3 +6607,11 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 .dash-sisma-legenda { display: flex; flex-wrap: wrap; gap: .8rem; margin-top: .6rem; font-size: .8rem; color: #495057; }
 .dash-sisma-legenda i { display: inline-block; width: .85rem; height: .85rem; border-radius: 50%; vertical-align: middle; margin-right: .25rem; border: 1px solid rgba(0,0,0,.2); }
 @media (max-width: 768px) { .dash-sisma-grid { grid-template-columns: 1fr; } .dash-sisma-kpi { grid-template-columns: repeat(2, 1fr); } #dash-sisma-mappa { height: 420px; } }
+
+/* Cruscotto — scheda Aria/pollini e Mare (indicatori) */
+.dash-aria-hero { display: flex; align-items: center; gap: 1rem; background: #fff; border: 1px solid #d4dde6;
+  border-left: 8px solid #9aa7b4; border-radius: 10px; padding: 1rem 1.2rem; margin-bottom: 1.1rem; }
+.dash-aria-aqi { font-size: 2.6rem; font-weight: 800; line-height: 1; color: #003366; min-width: 2.5ch; text-align: center; font-variant-numeric: tabular-nums; }
+.dash-aria-aqilab { font-size: 1.05rem; color: #1a1a1a; font-weight: 600; }
+.dash-aria-h3 { font-size: 1rem; color: #003366; margin: 1rem 0 .5rem; }
+.dash-aria-nota { font-size: .82rem; color: #6c757d; font-weight: 400; }


### PR DESCRIPTION
Aggiunge al cruscotto le fonti native (CORS, live dal browser) — prima ondata della richiesta 'tutti'.

- **Terremoti → switch Italia / Castelli Romani**: sismicità locale del distretto vulcanico dei Colli Albani (taglio iper-locale, unico).
- **Aria e pollini** (Open-Meteo Air Quality / Copernicus CAMS): AQI europeo, PM10/PM2.5/ozono/NO2, pollini.
- **Mare** (Open-Meteo Marine): onde costa laziale.

WCAG: valore numerico sempre mostrato (non solo colore), AQI con etichetta testuale.

Prossima ondata (workflow lato server): **incendi** (EFFIS/FIRMS, serve secret FIRMS_MAP_KEY) e **vulcani** (RSS INGV).