### PR TITLE
chore: aggiorna GitHub Actions a versioni Node.js 24-compatibili (deadline 2 giu 2026)

### DIFF
--- a/.github/workflows/aggiorna-indice-ricerca.yml
+++ b/.github/workflows/aggiorna-indice-ricerca.yml
@@ -36,13 +36,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "⚙️ Setup Hugo"
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@v3.2.1
         with:
           hugo-version: '0.143.1'
           extended: true

--- a/.github/workflows/aggiorna-manuale.yml
+++ b/.github/workflows/aggiorna-manuale.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "Setup Python"
         uses: actions/setup-python@v5

--- a/.github/workflows/aggiorna-stato-sistema.yml
+++ b/.github/workflows/aggiorna-stato-sistema.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "🔎 Leggi lo stato dei workflow critici"
         env:

--- a/.github/workflows/aggiorna-video-correlati.yml
+++ b/.github/workflows/aggiorna-video-correlati.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -70,7 +70,7 @@ jobs:
         run: python3 scripts/genera-video-correlati.py
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@v3.2.1
         with:
           hugo-version: 'latest'
           extended: true

--- a/.github/workflows/audit-glossario-coverage.yml
+++ b/.github/workflows/audit-glossario-coverage.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run coverage check
         id: check

--- a/.github/workflows/audit-sito.yml
+++ b/.github/workflows/audit-sito.yml
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "🔧 Setup Hugo"
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@v3.2.1
         with:
           hugo-version: "0.143.1"
           extended: true

--- a/.github/workflows/audit-versione-facile-coverage.yml
+++ b/.github/workflows/audit-versione-facile-coverage.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run coverage check
         id: check

--- a/.github/workflows/backup-documenti-aruba.yml
+++ b/.github/workflows/backup-documenti-aruba.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "🐍 Setup Python"
         uses: actions/setup-python@v5

--- a/.github/workflows/check-allerta.yml
+++ b/.github/workflows/check-allerta.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "🛠️ Setup pdftotext (per fallback PDF Regione Lazio)"
         run: which pdftotext || sudo apt-get install -y --no-install-recommends poppler-utils

--- a/.github/workflows/check-links-sito.yml
+++ b/.github/workflows/check-links-sito.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "🔧 Setup Hugo"
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@v3.2.1
         with:
           hugo-version: '0.143.1'
           extended: true

--- a/.github/workflows/check-video-dpc-eventi.yml
+++ b/.github/workflows/check-video-dpc-eventi.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/check-video-lis.yml
+++ b/.github/workflows/check-video-lis.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/comprimi-podcast.yml
+++ b/.github/workflows/comprimi-podcast.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "🔧 ffmpeg"
         run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg

--- a/.github/workflows/controllo-documenti.yml
+++ b/.github/workflows/controllo-documenti.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/controllo-fonti-cruscotto.yml
+++ b/.github/workflows/controllo-fonti-cruscotto.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Ping delle fonti del cruscotto
         id: ping

--- a/.github/workflows/controllo-freschezza.yml
+++ b/.github/workflows/controllo-freschezza.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Rileva articoli da riverificare
         id: scan

--- a/.github/workflows/controllo-refusi.yml
+++ b/.github/workflows/controllo-refusi.yml
@@ -19,7 +19,7 @@ jobs:
   refusi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: "⚙️ Setup Hugo"
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@v3.2.1
         with:
           hugo-version: '0.143.1'
           extended: true
@@ -65,7 +65,7 @@ jobs:
         run: python3 scripts/aggiungi-pagine-statiche-al-cerca.py
 
       - name: "📤 Deploy FTP su Aruba"
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@v4.4.0
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}
@@ -98,4 +98,4 @@ jobs:
     steps:
       - name: "🌐 Deploy GitHub Pages"
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/genera-pacchetti-kit.yml
+++ b/.github/workflows/genera-pacchetti-kit.yml
@@ -41,7 +41,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip-pacchetti]')"
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/genera-qr-articoli.yml
+++ b/.github/workflows/genera-qr-articoli.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/genera-social-bozze.yml
+++ b/.github/workflows/genera-social-bozze.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 

--- a/.github/workflows/gestione-scadenze.yml
+++ b/.github/workflows/gestione-scadenze.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Sweep articoli con scadenza superata
         id: sweep

--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -22,7 +22,7 @@ jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
       - name: Attendi il deploy (le URL devono essere raggiungibili)

--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Aspetta che GitHub Pages si aggiorni
       - name: "⏳ Attendi propagazione deploy"

--- a/.github/workflows/meteo-cartine-extra.yml
+++ b/.github/workflows/meteo-cartine-extra.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "🐍 Python"
         uses: actions/setup-python@v5

--- a/.github/workflows/meteo-lazio.yml
+++ b/.github/workflows/meteo-lazio.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "🐍 Python"
         uses: actions/setup-python@v5

--- a/.github/workflows/normativa-watcher.yml
+++ b/.github/workflows/normativa-watcher.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload risultato come artifact (debug)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: normativa-watcher-results
           path: novita.json

--- a/.github/workflows/notifica-telegram-articolo.yml
+++ b/.github/workflows/notifica-telegram-articolo.yml
@@ -44,7 +44,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip-telegram]')"
     steps:
       - name: "📥 Checkout (con storia per il diff)"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 

--- a/.github/workflows/notifica-telegram.yml
+++ b/.github/workflows/notifica-telegram.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout (con cronologia per il diff)"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 

--- a/.github/workflows/pubblica-programmata.yml
+++ b/.github/workflows/pubblica-programmata.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "🚀 Rilancia workflow deploy"
         env:

--- a/.github/workflows/scarica-foto-automatica.yml
+++ b/.github/workflows/scarica-foto-automatica.yml
@@ -50,7 +50,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip-foto-wiki]')"
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke-test-post-deploy.yml
+++ b/.github/workflows/smoke-test-post-deploy.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "⏳ Attendi propagazione FTP Aruba"
         # Il deploy.yml termina dopo l'upload FTP, ma Aruba può servire

--- a/.github/workflows/update-bootstrap-italia.yml
+++ b/.github/workflows/update-bootstrap-italia.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Passo 1: Scarica il codice
       - name: "📥 Checkout del repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: "⚙️ Setup Hugo"
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@v3.2.1
         with:
           hugo-version: '0.143.1'
           extended: true
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "🔬 Valida YAML di .github/workflows/"
         run: |
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Motivazione

GitHub forza Node.js 24 come runtime di default sui runner dal **2 giugno 2026** (deadline: 8 giorni).
Le 5 azioni elencate sotto generavano warning "Node.js 20 deprecato" e sarebbero state broken dopo la scadenza.

## Aggiornate ✅

| Action | Da | A | Data release | Stabilità | Note |
|---|---|---|---|---|---|
| `actions/checkout` | `@v4` | `@v5` | 17 nov 2025 (v5.0.1) | ✅ 6 mesi | 36 workflow — Node.js 24 da v5.0.0. Parametri `fetch-depth`, `token` invariati |
| `actions/upload-artifact` | `@v4` | `@v5` | 24 ott 2025 (v5.0.0) | ✅ 7 mesi | 1 workflow (normativa-watcher.yml) — parametri `name`, `path`, `retention-days` invariati |
| `peaceiris/actions-hugo` | `@v3` | `@v3.2.1` | 10 mag 2026 | ⚠️ 15 giorni | 6 workflow — "upgrade runtime Node 20→24" in v3.1.0. Pin esplicito vs floating `@v3` per garantire node24. Sotto la soglia 1-mese ma deadline urgente |
| `SamKirkland/FTP-Deploy-Action` | `@v4.3.5` | `@v4.4.0` | 23 apr 2026 | ✅ 32 giorni | 1 workflow (deploy.yml) — release notes: "Update to node 24". Tutti i `with:` invariati (server, username, password, local-dir, server-dir, dangerous-clean-slate, timeout, log-level, exclude) |
| `actions/deploy-pages` | `@v4` | `@v5` | 25 mar 2026 | ✅ 61 giorni | 1 workflow (deploy.yml) — nessun `with:` in uso, nessun breaking change documentato |

## Skipped ⚠️

Nessuna action skippata per breaking change. Nota: `actions/upload-pages-artifact@v3` (in deploy.yml riga 88) **non era nella lista dei 5 warning** ma la sua latest è v5.0.0 (apr 2026). Se genera warning dopo questa PR, richiede un aggiornamento separato.

## Verifica pre-commit

- Grep residui: 0 occorrenze delle 5 versioni vecchie in tutti i `.github/workflows/*.yml`
- Validazione YAML: `python3 -c "import yaml; yaml.safe_load(...)"` su 34 file — 0 errori
- Breaking changes `with:` verificati su changelog ufficiali GitHub

## Test plan

- [ ] CI verde su questo branch (tutti i job del `deploy.yml`)
- [ ] `deploy.yml` gira completo: build Hugo ✅ + Aruba FTP ✅ + GitHub Pages ✅
- [ ] Dopo merge su main: `curl -sI https://www.protezionecivilegenzano.it/` → 200

📅 Deadline: 2 giugno 2026 — merge entro il 1° giugno raccomandato.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PApj8o3NSkaDGXCiDGQFRu)_