### PR TITLE
fix(meteo): trigger orario affidabile per la cartina Lazio

### DIFF
--- a/.github/workflows/check-allerta.yml
+++ b/.github/workflows/check-allerta.yml
@@ -117,3 +117,25 @@ jobs:
         run: |
           echo "Triggering notifica-telegram workflow..."
           gh workflow run notifica-telegram.yml --ref main
+
+      # Trigger ORARIO affidabile della cartina meteo Lazio.
+      # meteo-lazio.yml dipendeva dal solo cron nativo GitHub (8 * * * *), che
+      # ritarda e SCARTA i run schedulati nelle ore di carico: la cartina
+      # restava ferma anche 5-7 ore (incidente 25/05/2026, ferma alle 06:48).
+      # Questo workflow invece gira ogni 5 min puntuale via cron-job.org: nel
+      # run che cade nei primi 5 minuti dell'ora lanciamo meteo-lazio.yml ->
+      # esattamente 1 rigenerazione/ora sul trigger affidabile. Il cron interno
+      # di meteo-lazio.yml (:08) resta come ulteriore fail-safe. Stesso pattern
+      # "doppio trigger" delle allerte. Indipendente dal commit allerta: la
+      # cartina va aggiornata anche quando il livello DPC non cambia.
+      - name: "🌤️ Rigenera cartina meteo Lazio (una volta all'ora)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MIN=$(date -u +%-M)
+          if [ "$MIN" -lt 5 ]; then
+            echo "Minuto $MIN < 5: avvio meteo-lazio.yml (rigenerazione oraria)."
+            gh workflow run meteo-lazio.yml --ref main
+          else
+            echo "Minuto $MIN: salto (la cartina si rigenera solo nei primi 5 min dell'ora)."
+          fi

--- a/.github/workflows/meteo-lazio.yml
+++ b/.github/workflows/meteo-lazio.yml
@@ -13,11 +13,18 @@ name: "🌤️ Cartina meteo Lazio + riquadro Genzano"
 
 on:
   schedule:
-    # OGNI ORA, al minuto 08 (fuori dai quarti d'ora canonici — vedi memoria
-    # feedback_github_cron_explicit_better). Girando ogni ora copre tutte le 24
-    # ore (mezzanotte inclusa) sia in ora legale sia solare: il fuso non conta.
-    # Non è un pattern "*/N": "*" nel campo ore = tutte le ore esplicitamente.
+    # FAIL-SAFE minimale: cron nativo GitHub al minuto 08 (fuori dai quarti
+    # d'ora canonici — vedi memoria feedback_github_cron_explicit_better).
+    # NON è il trigger primario: il cron schedulato di GitHub ritarda e SCARTA
+    # i run nelle ore di carico, lasciando la cartina ferma anche 5-7 ore
+    # (incidente 25/05/2026, ferma alle 06:48). Il trigger PRIMARIO è ora la
+    # rigenerazione oraria avviata da check-allerta.yml (che gira ogni 5 min
+    # puntuale via cron-job.org e lancia questo workflow nei primi 5 min
+    # dell'ora). Questo cron interviene solo se quella catena si interrompe.
     - cron: "8 * * * *"
+  # Trigger PRIMARIO: workflow_dispatch avviato da check-allerta.yml una volta
+  # all'ora (vedi step "🌤️ Rigenera cartina meteo Lazio"). Anche cron-job.org
+  # potrebbe pingarlo direttamente, se in futuro si vuole disaccoppiarlo.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problema

La cartina meteo del Lazio era **ferma alle 06:48** (incidente 25/05/2026, ~7 ore di stallo).

Il campo `aggiornato` in `data/meteo_genzano.json` registra l'ora dell'ultima **esecuzione riuscita** dello script (`genera-meteo-lazio.py` → `now`), non un dato meteo. Quindi "ferma alle 06:48" = il workflow non gira con successo da quell'ora.

**Causa:** `meteo-lazio.yml` si affidava al **solo cron nativo GitHub** (`8 * * * *`), che ritarda e scarta i run schedulati nelle ore di carico. La cadenza reale dei commit lo conferma: gap di 1h31m–5h36m, a minuti sparsi (:48, :11, :09, :38…), mai vicino al :08 schedulato. Per contro `check-allerta.yml` (trigger cron-job.org ogni 5 min) ha continuato a girare regolarmente.

Escluso: non è il recente bump `actions/checkout@v4→v5` (modifica valida), né errori YAML/script.

## Soluzione

Aggancio la rigenerazione meteo al trigger affidabile di `check-allerta.yml`:
- `check-allerta.yml` gira ogni 5 min puntuale via cron-job.org → nel run che cade nei primi 5 minuti dell'ora lancia `meteo-lazio.yml` via `workflow_dispatch` → **1 rigenerazione/ora affidabile**.
- Il cron nativo `:08` di `meteo-lazio.yml` resta come **fail-safe**.
- Stesso pattern doppio-trigger già usato per le allerte (rule 10).

## File

- `.github/workflows/check-allerta.yml` — nuovo step "Rigenera cartina meteo Lazio" (gate sul minuto, indipendente dal commit allerta).
- `.github/workflows/meteo-lazio.yml` — commento di testata aggiornato: cron nativo declassato a fail-safe.

## Note

- Prende effetto solo su `main` (i workflow schedulati/dispatch girano dal default branch).
- Dopo il merge la cartina si auto-ripristina entro l'ora; per sbloccarla subito basta un "Run workflow" manuale su `meteo-lazio.yml`.

https://claude.ai/code/session_011CFvgqLQSS5C7BqLkQsTC3

---
_Generated by [Claude Code](https://claude.ai/code/session_011CFvgqLQSS5C7BqLkQsTC3)_