### PR TITLE
docs: sposta brief AI esterne loghi da pagina pubblica al manuale

### DIFF
--- a/content/area-download/_index.md
+++ b/content/area-download/_index.md
@@ -168,15 +168,6 @@ I 4 loghi ufficiali per le grafiche del Gruppo (cover articoli, slide social, sc
 | 3 | **Coordinamento FE.PI.VOL.** | <https://www.protezionecivilegenzano.it/images/logo-fepivol.png> | PNG · 400×400 |
 | 4 | **SNPC Volontariato** | <https://www.protezionecivilegenzano.it/images/logo-snpc-volontariato.png> | PNG · 400×482 |
 
-<div class="card border-primary bg-primary bg-opacity-10 mb-3">
-<div class="card-body p-3 small">
-<i class="bi bi-robot me-1" aria-hidden="true"></i>
-<strong>Per le AI esterne</strong> (ChatGPT, Gemini, Midjourney, Canva, Adobe Express, DALL-E, ecc.): gli URL sopra sono <strong>pubblici e diretti</strong>, scaricabili dalle AI con capacità web/image-fetch. Quando dai un brief a un'AI esterna per generare una grafica del Gruppo, includi <strong>ESATTAMENTE QUESTI 4 LOGHI</strong> e specifica:
-<br><br>
-<em>«La grafica deve riportare ESATTAMENTE 4 loghi: (1) PC Genzano in alto come firma; (2) Quality Label ESC + codice E10435833 accanto (mai disgiunti, Reg. UE 2021/888); (3) Coordinamento FE.PI.VOL.; (4) SNPC Volontariato — questi 3 nel footer come blocco affiliazioni. Mai doppioni. Mai 5° logo (Comune, PC Lazio, VVF, INGV, ecc.). Mai logo ESC senza codice E10435833.»</em>
-</div>
-</div>
-
 ### Varianti storiche e composizioni del logo PC Genzano
 
 | Logo / stemma | Descrizione | Formato |

--- a/manuale/parte-03-immagini-per-gli-articoli.md
+++ b/manuale/parte-03-immagini-per-gli-articoli.md
@@ -742,7 +742,22 @@ Ogni grafica istituzionale del Gruppo (cover, slide social, scheda A4, locandina
 
 **Vietato:** mai mescolare PC Genzano tra le affiliazioni (doppione), mai inserire un 5° logo (PC Lazio, Comune, VVF, INGV, ecc. — vivono nei contenuti testuali o nel chrome del sito, non nella grafica del Gruppo), mai logo Quality Label ESC senza codice E10435833 (Reg. UE 2021/888).
 
-Vale anche per grafiche generate con AI esterne (ChatGPT, Gemini, Canva, ecc.): includere sempre la regola nel prompt + fornire i 4 file ufficiali del repo. Specifiche complete in `.claude/rules/02-content-design-pa.md § "Composizione standard"`.
+Vale anche per grafiche generate con AI esterne (ChatGPT, Gemini, Midjourney, Canva, Adobe Express, DALL-E, Stable Diffusion, ecc.): includere sempre la regola nel prompt + fornire i 4 file ufficiali del repo. Specifiche complete in `.claude/rules/02-content-design-pa.md § "Composizione standard"`.
+
+**Brief pronto da incollare alle AI esterne** (uso interno: NON va pubblicato sul sito; gli URL sono pubblici e diretti, scaricabili dalle AI con capacità web/image-fetch):
+
+> «La grafica deve riportare ESATTAMENTE 4 loghi: (1) PC Genzano in alto come firma; (2) Quality Label ESC + codice E10435833 accanto (mai disgiunti, Reg. UE 2021/888); (3) Coordinamento FE.PI.VOL.; (4) SNPC Volontariato — questi 3 nel footer come blocco affiliazioni. Mai doppioni. Mai 5° logo (Comune, PC Lazio, VVF, INGV, ecc.). Mai logo ESC senza codice E10435833.»
+
+URL pubblici dei 4 file da allegare al prompt:
+
+| # | Logo | URL diretto |
+|---|---|---|
+| 1 | PC Genzano (firma, WebP) | `https://www.protezionecivilegenzano.it/images/logo-pc-genzano.webp` |
+| 1 | PC Genzano hi-res (stampa) | `https://www.protezionecivilegenzano.it/images/logo-pc-genzano-hires.png` |
+| 2 | Quality Label ESC + codice E10435833 (web) | `https://www.protezionecivilegenzano.it/images/quality-label-esc.png` |
+| 2 | Quality Label ESC hi-res (stampa) | `https://www.protezionecivilegenzano.it/images/logo-esc-quality-label-it.png` |
+| 3 | Coordinamento FE.PI.VOL. | `https://www.protezionecivilegenzano.it/images/logo-fepivol.png` |
+| 4 | SNPC Volontariato | `https://www.protezionecivilegenzano.it/images/logo-snpc-volontariato.png` |
 
 **Dove sono già esposti** (non ri-implementare):
 - Footer site-wide (`themes/flavour-pcgenzano/layouts/partials/footer.html` + `static/app-shared/site-chrome.js`)


### PR DESCRIPTION
## Sintesi

Il callout "Per le AI esterne (ChatGPT, Gemini, Midjourney, Canva, ecc.)" era stato inserito nella pagina pubblica `/area-download/`, ma è documentazione operativa interna: il cittadino non ne ha bisogno e affolla la pagina dei materiali scaricabili.

Questa modifica:

- **Rimuove** il blocco callout dalla pagina pubblica `content/area-download/_index.md` (-9 righe).
- **Sposta** il brief completo — con il testo prompt-ready da incollare alle AI esterne + la tabella degli URL ai 4 file ufficiali dei loghi (PC Genzano, Quality Label ESC + codice E10435833, FE.PI.VOL., SNPC Volontariato) — nel manuale operativo interno `manuale/parte-03-immagini-per-gli-articoli.md` § "Regola dei 3 loghi affiliazione + 1 firma" (+17 righe).

Il risultato: la pagina pubblica resta pulita per il cittadino, e i maintainer/redattori trovano il brief AI esterne nel posto giusto (manuale operativo), insieme alle altre regole sulle composizioni grafiche istituzionali.

## File toccati

- `content/area-download/_index.md` (-9 righe)
- `manuale/parte-03-immagini-per-gli-articoli.md` (+17 righe)

## Test plan

- [x] Build Hugo pulita (nessuna sintassi Markdown rotta dallo spostamento).
- [x] La pagina `/area-download/` non mostra più il callout AI esterne.
- [x] Il manuale parte-03 ha la sezione completa con prompt + URL dei 4 loghi.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoqTvPnZEqLz14oqhVtey1)_