### PR TITLE
noindex pagine taxonomy /badges/ (thin content auto-generato)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/_default/baseof.html
+++ b/themes/flavour-pcgenzano/layouts/_default/baseof.html
@@ -14,8 +14,16 @@
   {{- $pagePath := strings.TrimPrefix $basePath .RelPermalink -}}
   {{- $canonicalURL := printf "%s%s" (strings.TrimRight "/" $prodBase) (printf "/%s" $pagePath) -}}
   {{- $isProduction := eq (strings.TrimRight "/" .Site.BaseURL) (strings.TrimRight "/" $prodBase) -}}
+  {{- /* Pagine taxonomy auto-generate (es. /badges/ + /badges/<termine>/ dalla
+       tassonomia `badge` in hugo.toml): contenuto sottile, orfano (nessun link
+       interno) e duplicato dei filtri di /comunicazioni/. Le teniamo per il
+       filtro lato archivio ma le escludiamo dall'indice (noindex, follow).
+       Vale anche per qualsiasi pagina con `noindex: true` nel frontmatter. */ -}}
+  {{- $isTaxonomy := or (eq .Kind "taxonomy") (eq .Kind "term") -}}
   {{- if not $isProduction }}
   <meta name="robots" content="noindex, nofollow">
+  {{- else if or $isTaxonomy .Params.noindex }}
+  <meta name="robots" content="noindex, follow">
   {{- end }}
   {{- .Scratch.Set "canonicalURL" $canonicalURL }}
   {{ partial "meta-social.html" . }}

--- a/themes/flavour-pcgenzano/layouts/_default/sitemap.xml
+++ b/themes/flavour-pcgenzano/layouts/_default/sitemap.xml
@@ -4,7 +4,9 @@
   {{- $prodBase := .Site.Params.productionBaseURL | default .Site.BaseURL -}}
   {{- $basePath := (urls.Parse .Site.BaseURL).Path | default "/" -}}
   {{- range .Data.Pages -}}
-  {{- if not .Params.noindex }}
+  {{/* Escludi le pagine taxonomy auto-generate (/badges/ + /badges/<termine>/):
+       thin content non indicizzato — coerente con il noindex in baseof.html. */}}
+  {{- if and (not .Params.noindex) (ne .Kind "taxonomy") (ne .Kind "term") }}
   {{- $pagePath := strings.TrimPrefix $basePath .RelPermalink -}}
   <url>
     <loc>{{ printf "%s/%s" (strings.TrimRight "/" $prodBase) $pagePath | safeHTML }}</loc>


### PR DESCRIPTION
## Problema
La tassonomia `badge = "badges"` in `hugo.toml` genera la pagina `/badges/` (e teoricamente `/badges/<termine>/`): contenuto **sottile e vuoto**, orfano (nessun link interno la raggiunge) e duplicato dei filtri già presenti in `/comunicazioni/`. Era indicizzabile per la convenzione "tutto index di default" e Google ne ha indicizzata una versione vuota.

La pagina risulta vuota perché gli articoli usano il campo `badge:` (singolare), mentre Hugo popola la tassonomia solo dalla chiave plurale `badges:` → zero termini.

## Soluzione (mantieni la tassonomia, escludila dall'indice)
- `baseof.html`: `<meta name="robots" content="noindex, follow">` sulle pagine `Kind` taxonomy/term in produzione, e su qualsiasi pagina con `noindex: true` nel frontmatter (gancio riutilizzabile).
- `sitemap.xml`: escluse le pagine taxonomy/term dall'urlset.

## Verifica
Build Hugo 0.154.5 pulita su entrambi i baseURL (Aruba + GitHub Pages):
- `/badges/` → `noindex, follow`, fuori dalla sitemap;
- home, articoli e sezioni restano indicizzabili (nessun `meta robots`);
- preview GitHub Pages mantiene il `noindex,nofollow` globale invariato.

Google deindicizzerà `/badges/` al prossimo crawl.

https://claude.ai/code/session_01FNu28HEcngCYuFuSav2R1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNu28HEcngCYuFuSav2R1S)_