### PR TITLE
Giochi+schede: oggetto del cuore piccolo ammesso nel kit + footer schede armonizzato

### DIFF
--- a/content/catalogo-giochi/vesti-tina.md
+++ b/content/catalogo-giochi/vesti-tina.md
@@ -38,7 +38,7 @@ sitemap:
 
 1. Acqua e biscotti: SÌ.
 2. Torcia, casco, giacchetto: SÌ.
-3. Caramelle, videogioco, peluche: NO.
+3. Caramelle, videogioco, console: NO.
 4. Pochi oggetti, ma utili.
 
 ## Apri il gioco interattivo

--- a/content/catalogo-giochi/zaino-emergenza.md
+++ b/content/catalogo-giochi/zaino-emergenza.md
@@ -37,9 +37,10 @@ sitemap:
 ## Come si gioca
 
 1. Mettono dentro: acqua, cibo a lunga conservazione, torcia, radio, medicine, documenti, fischietto.
-2. NON metti dentro: videogiochi, peluche, oggetti pesanti.
-3. Lo zaino deve poterlo portare anche un bambino.
-4. Va lasciato vicino alla porta di casa, pronto.
+2. NON metti dentro: videogiochi, oggetti pesanti, troppi giochi.
+3. Un solo oggetto del cuore piccolo (un peluche, una foto) aiuta a stare calmi.
+4. Lo zaino deve poterlo portare anche un bambino.
+5. Va lasciato vicino alla porta di casa, pronto.
 
 ## Apri il gioco interattivo
 

--- a/static/formazione/schede-stampabili/assets/scheda-print.css
+++ b/static/formazione/schede-stampabili/assets/scheda-print.css
@@ -212,10 +212,13 @@ body {
   background: #fff;
 }
 
-/* Footer istituzionale */
+/* Footer istituzionale — spaziatura armonizzata con le schede Kit Calamità
+   (kit-calamita-shared/print.css): più aria sopra il footer e sotto, così
+   la riga blu non resta incollata al testo né alla banda affiliazioni. */
 .scheda-footer {
   margin-top: auto;
-  padding-top: 0.8rem;
+  padding-top: 9mm;        /* stacco dal corpo della scheda */
+  padding-bottom: 4mm;     /* aria sopra la banda affiliazioni */
   border-top: 2px solid var(--scheda-blu);
   display: flex;
   justify-content: space-between;
@@ -225,6 +228,10 @@ body {
 .scheda-footer .scheda-site {
   font-weight: 600;
   color: var(--scheda-blu);
+}
+/* In stampa il footer è già spinto in fondo: un filo di aria coerente col Kit */
+@media print {
+  .scheda-footer { padding-top: 8mm; padding-bottom: 3mm; }
 }
 
 /* ── Banda affiliazioni: Quality Label ESC (cod. E10435833 obbligatorio per

--- a/static/formazione/schede-stampabili/esperimenti-protezione-civile/index.html
+++ b/static/formazione/schede-stampabili/esperimenti-protezione-civile/index.html
@@ -28,6 +28,13 @@
       background: #fff8e6; border-left: 4px solid var(--scheda-oro);
       border-radius: 0 6px 6px 0; font-size: 0.9rem; line-height: 1.45; color: #664d03;
     }
+    /* Footer: più aria su queste schede dense (un esperimento per foglio).
+       Override locale, il CSS condiviso resta intatto per le altre schede. */
+    .scheda-footer {
+      margin-top: 2rem;       /* stacco garantito dal contenuto, anche a foglio pieno */
+      padding-top: 1.1rem;    /* aria tra la riga blu e il testo del footer */
+      padding-bottom: 0.5rem; /* stacco dalla banda affiliazioni sottostante */
+    }
     /* Stampa: forza un esperimento per foglio A4 */
     @media print {
       .scheda-toolbar, .esp-intro, .no-print { display: none !important; }

--- a/static/formazione/schede-stampabili/esperimenti-protezione-civile/index.html
+++ b/static/formazione/schede-stampabili/esperimenti-protezione-civile/index.html
@@ -28,13 +28,6 @@
       background: #fff8e6; border-left: 4px solid var(--scheda-oro);
       border-radius: 0 6px 6px 0; font-size: 0.9rem; line-height: 1.45; color: #664d03;
     }
-    /* Footer: più aria su queste schede dense (un esperimento per foglio).
-       Override locale, il CSS condiviso resta intatto per le altre schede. */
-    .scheda-footer {
-      margin-top: 2rem;       /* stacco garantito dal contenuto, anche a foglio pieno */
-      padding-top: 1.1rem;    /* aria tra la riga blu e il testo del footer */
-      padding-bottom: 0.5rem; /* stacco dalla banda affiliazioni sottostante */
-    }
     /* Stampa: forza un esperimento per foglio A4 */
     @media print {
       .scheda-toolbar, .esp-intro, .no-print { display: none !important; }

--- a/static/giochi/assets/js/coach.js
+++ b/static/giochi/assets/js/coach.js
@@ -147,8 +147,8 @@
       come: [
         'Acqua e biscotti: SÌ.',
         'Torcia, casco, giacchetto: SÌ.',
-        'Caramelle, videogioco, peluche: NO.',
-        'Pochi oggetti, ma utili.'
+        'Caramelle, videogioco, console: NO.',
+        'Pochi oggetti, ma utili. Un peluche piccolo aiuta a stare calmi.'
       ],
       teoria: [
         { titolo: 'Lo zaino per l\'emergenza', url: '/rischi-prevenzione/kit-emergenza/' }
@@ -349,7 +349,8 @@
       regola: 'Lo zaino di emergenza ha cose utili, non comode. Pochi oggetti, ben scelti.',
       come: [
         'Mettono dentro: acqua, cibo a lunga conservazione, torcia, radio, medicine, documenti, fischietto.',
-        'NON metti dentro: videogiochi, peluche, oggetti pesanti.',
+        'NON metti dentro: videogiochi, oggetti pesanti, troppi giochi.',
+        'Un solo oggetto del cuore piccolo (un peluche, una foto) aiuta a stare calmi.',
         'Lo zaino deve poterlo portare anche un bambino.',
         'Va lasciato vicino alla porta di casa, pronto.'
       ],

--- a/static/giochi/infanzia/vesti-tina/index.html
+++ b/static/giochi/infanzia/vesti-tina/index.html
@@ -199,13 +199,13 @@
     var ROUNDS_LIVELLO_1 = [
       { giusto: {id:'casco', nome:'casco'}, sbagliati: [{id:'caramelle',nome:'caramelle'},{id:'tv',nome:'televisore'}], tip: 'Il casco protegge la testa!' },
       { giusto: {id:'torcia', nome:'torcia'}, sbagliati: [{id:'videogioco',nome:'videogioco'},{id:'pallone',nome:'pallone'}], tip: 'La torcia fa luce se va via la corrente!' },
-      { giusto: {id:'acqua', nome:"bottiglia d'acqua"}, sbagliati: [{id:'peluche',nome:'peluche'},{id:'caramelle',nome:'caramelle'}], tip: "L'acqua è sempre importante!" },
+      { giusto: {id:'acqua', nome:"bottiglia d'acqua"}, sbagliati: [{id:'tv',nome:'televisore'},{id:'caramelle',nome:'caramelle'}], tip: "L'acqua è sempre importante!" },
       { giusto: {id:'giacchetto', nome:'giacchetto giallo'}, sbagliati: [{id:'cuscino',nome:'cuscino'},{id:'tv',nome:'televisore'}], tip: 'Il giacchetto giallo ti rende ben visibile!' },
       { giusto: {id:'coperta', nome:'coperta'}, sbagliati: [{id:'pallone',nome:'pallone'},{id:'videogioco',nome:'videogioco'}], tip: 'La coperta scalda se fa freddo!' }
     ];
     var ROUNDS_LIVELLO_2 = [
       { giusto: {id:'fischietto', nome:'fischietto'}, sbagliati: [{id:'pattini',nome:'pattini'},{id:'console',nome:'console'}], tip: 'Il fischietto si sente da lontano se hai bisogno di aiuto!' },
-      { giusto: {id:'mascherina', nome:'mascherina'}, sbagliati: [{id:'gelato',nome:'gelato'},{id:'peluche',nome:'peluche'}], tip: 'La mascherina ti protegge dal fumo e dalla polvere!' },
+      { giusto: {id:'mascherina', nome:'mascherina'}, sbagliati: [{id:'gelato',nome:'gelato'},{id:'pattini',nome:'pattini'}], tip: 'La mascherina ti protegge dal fumo e dalla polvere!' },
       { giusto: {id:'caricatore', nome:'caricatore del telefono'}, sbagliati: [{id:'console',nome:'console'},{id:'pattini',nome:'pattini'}], tip: 'Il caricatore serve per chiamare aiuto col telefono!' },
       { giusto: {id:'documenti', nome:'documenti'}, sbagliati: [{id:'gelato',nome:'gelato'},{id:'pallone',nome:'pallone'}], tip: 'I documenti dicono chi sei: i grandi devono averli sempre!' },
       { giusto: {id:'biscotti', nome:'biscotti che durano tanto'}, sbagliati: [{id:'gelato',nome:'gelato'},{id:'caramelle',nome:'caramelle'}], tip: 'I biscotti che durano sono cibo che resta buono a lungo!' }
@@ -286,7 +286,7 @@
         if (window.AudioSintetico) window.AudioSintetico.tonoNeutro();
         setTimeout(function(){ btn.classList.remove('sbagliato'); }, 500);
         if (window.GameCoach && window.GameCoach.hint) {
-          window.GameCoach.hint('In emergenza servono: acqua, cibo, torcia, casco, giacchetto, coperta. NON servono: caramelle, peluche, videogiochi, TV.', '/rischi-prevenzione/kit-emergenza/');
+          window.GameCoach.hint('In emergenza servono: acqua, cibo, torcia, casco, giacchetto, coperta. NON servono: caramelle, videogiochi, TV. Un peluche piccolo aiuta a stare calmi.', '/rischi-prevenzione/kit-emergenza/');
         }
       }
     }

--- a/static/giochi/primaria/zaino-emergenza/js/script.js
+++ b/static/giochi/primaria/zaino-emergenza/js/script.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
         { name: 'Libri di scuola', icon: '\uD83D\uDCDA', correct: false, tip: 'Troppo pesanti: la scuola aspetta!' },
         { name: 'Vasetto di fiori', icon: '\uD83C\uDF37', correct: false, tip: 'Fragile e occupa spazio inutilmente.' },
         { name: 'Bicicletta', icon: '\uD83D\uDEB2', correct: false, tip: 'Non entra nello zaino — se serve va portata a parte.' },
-        { name: 'Animaletto di peluche', icon: '\uD83D\uDC30', correct: false, tip: 'Uno piccolo può rassicurare i bambini piccoli, ma qui valuta se c’è spazio.' },
+        { name: 'Animaletto di peluche', icon: '\uD83D\uDC30', correct: true, tip: 'Un solo oggetto del cuore piccolo aiuta a stare calmi: scegline uno.' },
         { name: 'Smalto per unghie', icon: '\uD83D\uDC85', correct: false, tip: 'Non è una priorità in emergenza.' },
     ];
 


### PR DESCRIPTION
## Cosa cambia

### 1) Risolta la contraddizione "peluche" tra giochi e kit
Uniformata la linea fondata (Kit Calamità bambini → NCTSN PFA / IFRC / WHO): **un solo oggetto del cuore piccolo (peluche, foto) è ammesso nel kit** perché aiuta a stare calmi; restano esclusi videogiochi, oggetti pesanti, troppi giochi e il peluche gigante (spazio/peso).

- `giochi/primaria/zaino-emergenza/js/script.js`: "Animaletto di peluche" ora corretto (il "Peluche gigante" resta sbagliato).
- `giochi/infanzia/vesti-tina/index.html`: peluche tolto dagli oggetti sbagliati dei round + hint contestuale positivo.
- `giochi/assets/js/coach.js`: tolto il peluche dai "NO" dei due giochi + bullet sull'oggetto di conforto.
- `content/catalogo-giochi/zaino-emergenza.md` · `vesti-tina.md`: testo allineato.
- Lasciati intatti `acchiappa-pericolo` (peluche = oggetto sicuro, già corretto) ed `esperimenti.md` (già sulla linea giusta).

### 2) Footer schede stampabili armonizzato col Kit Calamità
Footer del CSS condiviso `schede-stampabili/assets/scheda-print.css` portato allo stesso respiro del Kit Calamità (`padding-top: 9mm` + `padding-bottom: 4mm` + override stampa 8/3mm): vale per tutte le schede. Rimosso il ritocco una-tantum sulla scheda esperimenti.

## Verifiche
- `node -c` OK su `script.js` e `coach.js`.
- Nessuna contraddizione "peluche = sbagliato" residua (eccetto il gigante, voluto).
- Modifiche `.md` solo testuali (liste), nessun frontmatter/shortcode toccato.

https://claude.ai/code/session_01GUjxzi6zzzVmcBa5xe8Fbb

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUjxzi6zzzVmcBa5xe8Fbb)_