### PR TITLE
Laboratorio meteo: dati fino a ieri + aggiornamento automatico esempi

### DIFF
--- a/.github/workflows/clima-castelli.yml
+++ b/.github/workflows/clima-castelli.yml
@@ -1,0 +1,67 @@
+name: "📈 Dataset clima Castelli (Laboratorio meteo)"
+
+# Rigenera mensilmente i dataset climatici pre-cotti del Laboratorio meteo
+# (/laboratorio-meteo/), da dati aperti ERA5 via Open-Meteo (CC BY 4.0, nessuna
+# chiave API). Output: static/open-data/clima-*.json + clima-manifest.json.
+# Lo script calcola l'ultimo anno solare completo in automatico, così i dataset
+# si estendono da soli al passare degli anni. Gli esempi mostrati nelle card del
+# Laboratorio restano aggiornati senza intervento manuale.
+#
+# deploy.yml NON è toccato (vincolo): il workflow committa i file e ri-triggera
+# deploy.yml esplicitamente (i push del GITHUB_TOKEN non auto-triggerano i push).
+
+on:
+  schedule:
+    # 1° del mese, minuto 41 (fuori dai quarti d'ora canonici — vedi memoria
+    # feedback_github_cron_explicit_better). I dati climatici cambiano lentamente.
+    - cron: "41 4 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: "clima-castelli"
+  cancel-in-progress: false
+
+jobs:
+  genera:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📥 Checkout"
+        uses: actions/checkout@v5
+
+      - name: "🐍 Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: "📊 Genera dataset clima"
+        run: |
+          set -euo pipefail
+          python3 scripts/genera-clima-castelli.py
+          for f in clima-manifest clima-anno-temperature-genzano clima-pioggia-annuale-genzano clima-luglio-temperature-genzano clima-giorni-molto-caldi-genzano; do
+            python3 -c "import json; json.load(open('static/open-data/$f.json'))" && echo "$f.json valido"
+          done
+
+      - name: "💾 Commit se cambiato + ri-trigger deploy"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet static/open-data/clima-*.json; then
+            echo "Nessun cambiamento nei dataset clima — niente commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add static/open-data/clima-*.json
+          git commit -m "chore(clima): dataset Laboratorio meteo aggiornati [skip-clima]"
+          for tentativo in 1 2 3; do
+            if git push 2>&1; then break; fi
+            echo "Push fallito (tentativo $tentativo), rebase..."
+            git pull --rebase origin main || { echo "Rebase fallito"; exit 1; }
+            if [ "$tentativo" = "3" ]; then echo "Push fallito dopo 3 tentativi"; exit 1; fi
+          done
+          gh workflow run deploy.yml

--- a/scripts/genera-clima-castelli.py
+++ b/scripts/genera-clima-castelli.py
@@ -10,6 +10,7 @@ le aggrega in dataset didattici e scrive:
 Output JSON: { titolo, sottotitolo?, tipo: 'line'|'bar', unita, x[], serie[] }
 Eseguibile in locale (rete) o in CI. Stdlib pura, nessuna dipendenza.
 """
+import datetime
 import json
 import sys
 import urllib.parse
@@ -23,7 +24,11 @@ ARCHIVE = "https://archive-api.open-meteo.com/v1/archive"
 
 # Genzano di Roma (centro abitato)
 LAT, LON = 41.7085, 12.6916
-ANNO_DA, ANNO_A = 2005, 2025  # anni interi disponibili nell'archivio ERA5
+# Ultimo anno solare completo (l'archivio ERA5 è affidabile fino all'anno scorso),
+# e finestra di 20 anni indietro. Calcolato dinamicamente: a un refresh periodico
+# i dataset si estendono da soli all'ultimo anno disponibile.
+ANNO_A = datetime.date.today().year - 1
+ANNO_DA = ANNO_A - 20
 
 FONTE = "Rianalisi ERA5 via Open-Meteo (CC BY 4.0), allineata al Copernicus Climate Data Store."
 
@@ -52,8 +57,8 @@ def aggrega(d):
     per_anno_prec = defaultdict(list)
     per_anno_caldo = defaultdict(int)   # giorni con tmax >= 35
     per_anno_lug_tmax = defaultdict(list)
-    mese_2025_max = defaultdict(list)
-    mese_2025_min = defaultdict(list)
+    mese_ult_max = defaultdict(list)   # mesi dell'ultimo anno completo (ANNO_A)
+    mese_ult_min = defaultdict(list)
 
     for i, t in enumerate(d["time"]):
         anno, mese = int(t[:4]), int(t[5:7])
@@ -68,11 +73,11 @@ def aggrega(d):
                 per_anno_lug_tmax[anno].append(tmax)
         if prec is not None:
             per_anno_prec[anno].append(prec)
-        if anno == 2025:
+        if anno == ANNO_A:
             if tmax is not None:
-                mese_2025_max[mese].append(tmax)
+                mese_ult_max[mese].append(tmax)
             if tmin is not None:
-                mese_2025_min[mese].append(tmin)
+                mese_ult_min[mese].append(tmin)
 
     anni = list(range(ANNO_DA, ANNO_A + 1))
     return {
@@ -81,8 +86,8 @@ def aggrega(d):
         "prec_annua": [round(sum(per_anno_prec[a]), 0) if per_anno_prec[a] else None for a in anni],
         "giorni_caldo": [per_anno_caldo[a] for a in anni],
         "mesi": list(range(1, 13)),
-        "mese_max": [media(mese_2025_max[m]) for m in range(1, 13)],
-        "mese_min": [media(mese_2025_min[m]) for m in range(1, 13)],
+        "mese_max": [media(mese_ult_max[m]) for m in range(1, 13)],
+        "mese_min": [media(mese_ult_min[m]) for m in range(1, 13)],
     }
 
 
@@ -127,7 +132,7 @@ def main():
     })
 
     scrivi("anno-temperature-genzano", {
-        "titolo": "Un anno di temperature a Genzano — 2025",
+        "titolo": f"Un anno di temperature a Genzano — {ANNO_A}",
         "sottotitolo": "Media mensile delle massime e delle minime",
         "tipo": "line", "unita": "°C", "x": MESI,
         "serie": [
@@ -144,7 +149,7 @@ def main():
         {"titolo": "Le giornate molto calde", "file": "clima-giorni-molto-caldi-genzano.json",
          "descr": "Quanti giorni all'anno superano i 35 °C a Genzano."},
         {"titolo": "Un anno di temperature", "file": "clima-anno-temperature-genzano.json",
-         "descr": "Massime e minime mese per mese a Genzano nel 2025."},
+         "descr": f"Massime e minime mese per mese a Genzano nel {ANNO_A}."},
     ]
     (OUTDIR / "clima-manifest.json").write_text(
         json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/static/js/laboratorio-meteo.js
+++ b/static/js/laboratorio-meteo.js
@@ -4,7 +4,8 @@
 (function () {
   'use strict';
 
-  var ARCHIVE = 'https://archive-api.open-meteo.com/v1/archive';
+  var ARCHIVE = 'https://archive-api.open-meteo.com/v1/archive';   // ERA5: storico, latenza ~5 gg
+  var FORECAST = 'https://api.open-meteo.com/v1/forecast';         // copre il recente passato fino a ieri
   var OPENDATA = (window.LAB_OPENDATA || '/open-data/');
 
   // Luoghi dei Castelli Romani (coordinate indicative del centro abitato).
@@ -69,7 +70,11 @@
   // ---- Fetch live ----------------------------------------------------------
   function caricaLive(luogo, varKey, da, a) {
     var v = VARIABILI[varKey];
-    var url = ARCHIVE + '?latitude=' + luogo.lat + '&longitude=' + luogo.lon +
+    // Per periodi recenti (inizio entro ~90 gg) uso l'endpoint forecast, che ha i dati
+    // fino a ieri; per le serie storiche lunghe uso l'archivio ERA5 (latenza ~5 gg).
+    var limite = ggFa(90);
+    var endpoint = (new Date(da) >= limite) ? FORECAST : ARCHIVE;
+    var url = endpoint + '?latitude=' + luogo.lat + '&longitude=' + luogo.lon +
       '&start_date=' + da + '&end_date=' + a +
       '&daily=' + v.daily.join(',') + '&timezone=Europe%2FRome';
 
@@ -315,12 +320,12 @@
     LUOGHI.forEach(function (l) {
       var o = document.createElement('option'); o.value = l.id; o.textContent = l.nome; sel.appendChild(o);
     });
-    // periodo default: ultimi 30 giorni con margine di 6 gg (latenza archivio ERA5)
-    var fine = ggFa(6), inizio = ggFa(36);
+    // periodo default: ultimi 30 giorni fino a ieri (l'endpoint forecast copre fino a ieri)
+    var fine = ggFa(1), inizio = ggFa(31);
     $('lab-a').value = iso(fine);
     $('lab-da').value = iso(inizio);
-    $('lab-a').max = iso(ggFa(5));
-    $('lab-da').max = iso(ggFa(5));
+    $('lab-a').max = iso(ggFa(1));
+    $('lab-da').max = iso(ggFa(1));
 
     $('lab-form').addEventListener('submit', function (e) {
       e.preventDefault();
@@ -333,12 +338,12 @@
 
     Array.prototype.forEach.call(document.querySelectorAll('.lab-chip'), function (chip) {
       chip.addEventListener('click', function () {
-        var fineD = ggFa(6);
+        var fineD = ggFa(1);
         if (chip.dataset.giorni) {
           $('lab-a').value = iso(fineD);
-          $('lab-da').value = iso(ggFa(6 + parseInt(chip.dataset.giorni, 10)));
+          $('lab-da').value = iso(ggFa(1 + parseInt(chip.dataset.giorni, 10)));
         } else if (chip.dataset.annoScorso) {
-          var f = ggFa(6); f.setFullYear(f.getFullYear() - 1);
+          var f = ggFa(1); f.setFullYear(f.getFullYear() - 1);
           var i = new Date(f); i.setMonth(i.getMonth() - 1);
           $('lab-a').value = iso(f); $('lab-da').value = iso(i);
         }


### PR DESCRIPTION
Due miglioramenti dopo il feedback: (1) il costruttore live arriva fino a IERI usando l'endpoint forecast di Open-Meteo per i periodi recenti (l'archivio ERA5 resta per le serie lunghe); default e data massima portati a ieri. (2) Gli esempi pronti ora si aggiornano da soli: lo script calcola dinamicamente l'ultimo anno completo + nuovo workflow mensile clima-castelli.yml che rigenera i dataset e ri-triggera il deploy. Verifica Playwright: ultima riga 30 mag 2026 con valori reali. Build pulita, YAML workflow valido.