### PR TITLE
Laboratorio meteo: grafici più leggibili (etichette + tooltip + fix allineamento anni) + richiamo nel cruscotto

### DIFF
--- a/content/cruscotto/_index.md
+++ b/content/cruscotto/_index.md
@@ -10,6 +10,8 @@ aliases:
 
 Un'unica pagina per consultare i dati di rischio del territorio, da **fonti ufficiali e aperte**. Scegli il tema con i pulsanti qui sotto. Sono dati **indicativi**: per le allerte valgono i bollettini del [Centro Funzionale Regionale del Lazio](https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti), in emergenza chiama il **112**.
 
+<div class="cruscotto-callout" role="note"><i class="bi bi-graph-up-arrow" aria-hidden="true"></i> <span>Vuoi <strong>esplorare i dati nel tempo</strong>? Nel <a href="/laboratorio-meteo/">Laboratorio meteo</a> costruisci grafici di temperatura, pioggia e vento dei Castelli Romani, con tabella dei dati e download.</span></div>
+
 <div class="cruscotto-switch" role="tablist" aria-label="Temi del cruscotto">
   <button type="button" class="cruscotto-tab" id="tab-terremoti" data-panel="terremoti" role="tab" aria-selected="true" aria-controls="panel-terremoti" tabindex="0"><i class="bi bi-activity" aria-hidden="true"></i> Terremoti</button>
   <button type="button" class="cruscotto-tab" id="tab-vulcani" data-panel="vulcani" role="tab" aria-selected="false" aria-controls="panel-vulcani" tabindex="-1"><i class="bi bi-triangle" aria-hidden="true"></i> Vulcani</button>

--- a/static/js/laboratorio-meteo.js
+++ b/static/js/laboratorio-meteo.js
@@ -116,17 +116,20 @@
     $('lab-grafico-titolo').textContent = dati.titolo + (dati.sottotitolo ? ' — ' + dati.sottotitolo : '');
     var box = $('lab-grafico');
     box.textContent = '';
-    var svg = (dati.tipo === 'bar') ? svgBarre(dati) : svgLinee(dati);
-    box.appendChild(svg);
+    var r = (dati.tipo === 'bar') ? svgBarre(dati) : svgLinee(dati);
+    box.appendChild(r.svg);
+    montaInterazione(box, r, dati);
     $('lab-grafico-wrap').hidden = false;
     costruisciTabella(dati);
     $('lab-tabella-blocco').hidden = false;
   }
 
   // ---- Scale ----------------------------------------------------------------
-  var W = 820, H = 420, M = { t: 20, r: 20, b: 70, l: 56 };
+  var W = 860, H = 440, M = { t: 30, r: 26, b: 76, l: 60 };
   function plotW() { return W - M.l - M.r; }
   function plotH() { return H - M.t - M.b; }
+  function valido(v) { return !(v === null || v === undefined || isNaN(v)); }
+  function fmtVal(v) { return String(Math.round(v * 10) / 10).replace('.', ','); }
 
   function estremi(serie) {
     var min = Infinity, max = -Infinity;
@@ -155,7 +158,9 @@
     });
     svg.appendChild(el('title', { id: 'lab-svg-title' }, titoloAcc));
     svg.appendChild(el('desc', { id: 'lab-svg-desc' },
-      'Grafico dei dati; gli stessi valori sono nella tabella qui sotto.'));
+      'Grafico dei dati; passa il puntatore o usa le frecce per leggere i valori. Gli stessi dati sono nella tabella qui sotto.'));
+    // rettangolo trasparente che cattura i movimenti del puntatore su tutta l'area
+    svg.appendChild(el('rect', { x: 0, y: 0, width: W, height: H, fill: '#fff', 'fill-opacity': '0', 'pointer-events': 'all' }));
     return svg;
   }
 
@@ -174,35 +179,64 @@
     }, unita));
   }
 
-  function assiX(svg, x) {
-    var n = x.length, passo = Math.max(1, Math.ceil(n / 7));
-    for (var i = 0; i < n; i += passo) {
-      var px = M.l + (n === 1 ? plotW() / 2 : plotW() * i / (n - 1));
-      svg.appendChild(el('text', { x: px, y: H - M.b + 22, 'text-anchor': 'middle', class: 'lab-svg-tick' },
-        fmtData(x[i])));
+  // pxFn = stessa funzione di posizione X del grafico (allinea le etichette ai dati).
+  // ogni = true → un'etichetta per ogni valore (es. ogni anno sotto la sua barra).
+  function assiX(svg, x, pxFn, ogni) {
+    var n = x.length, idxs = [];
+    if (ogni) {
+      for (var k = 0; k < n; k++) idxs.push(k);
+    } else {
+      var passo = Math.max(1, Math.ceil((n - 1) / 7));
+      for (var i = 0; i < n; i += passo) idxs.push(i);
+      if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
     }
+    var ruota = ogni && n > 12;  // diagonale per non sovrapporre quando sono molte
+    idxs.forEach(function (i) {
+      var px = pxFn(i), y = H - M.b + (ruota ? 16 : 22);
+      var attrs = { x: px, y: y, class: 'lab-svg-tick' };
+      if (ruota) {
+        attrs['text-anchor'] = 'end';
+        attrs.transform = 'rotate(-45 ' + px + ' ' + y + ')';
+      } else {
+        attrs['text-anchor'] = i === 0 ? 'start' : (i === n - 1 ? 'end' : 'middle');
+      }
+      svg.appendChild(el('text', attrs, fmtData(x[i])));
+    });
   }
 
   function svgLinee(dati) {
     var svg = baseSvg(dati.titolo);
     var ex = estremi(dati.serie), n = dati.x.length;
     assiY(svg, ex, dati.unita);
-    assiX(svg, dati.x);
+    assiX(svg, dati.x, px, false);
     function px(i) { return M.l + (n === 1 ? plotW() / 2 : plotW() * i / (n - 1)); }
     function py(v) { return M.t + plotH() - plotH() * (v - ex.min) / (ex.max - ex.min); }
     dati.serie.forEach(function (s) {
       var d = '', started = false;
       s.valori.forEach(function (v, i) {
-        if (v === null || v === undefined || isNaN(v)) { started = false; return; }
+        if (!valido(v)) { started = false; return; }
         d += (started ? ' L' : ' M') + px(i) + ' ' + py(v); started = true;
       });
       svg.appendChild(el('path', {
         d: d.trim(), fill: 'none', stroke: s.colore, 'stroke-width': 2.5,
-        'stroke-dasharray': s.tratto === 'dash' ? '7 4' : '0'
+        'stroke-dasharray': s.tratto === 'dash' ? '7 4' : '0', 'pointer-events': 'none'
       }));
+      // punti marcati su ogni valore
+      s.valori.forEach(function (v, i) {
+        if (valido(v)) svg.appendChild(el('circle', { cx: px(i), cy: py(v), r: 2.8, fill: s.colore, 'pointer-events': 'none' }));
+      });
     });
+    // etichette di valore quando i punti sono pochi (niente sovrapposizioni)
+    if (dati.serie.length * n <= 28) {
+      dati.serie.forEach(function (s) {
+        s.valori.forEach(function (v, i) {
+          if (valido(v)) svg.appendChild(el('text', { x: px(i), y: py(v) - 9, 'text-anchor': 'middle', class: 'lab-svg-val', 'pointer-events': 'none' }, fmtVal(v)));
+        });
+      });
+    }
     legenda(svg, dati.serie);
-    return svg;
+    var hover = el('g', { 'pointer-events': 'none' }); svg.appendChild(hover);
+    return { svg: svg, kind: 'line', n: n, px: px, py: py, ex: ex, hover: hover };
   }
 
   function svgBarre(dati) {
@@ -210,17 +244,89 @@
     var s = dati.serie[0], n = dati.x.length;
     var ex = estremi(dati.serie); if (ex.min > 0) ex.min = 0;
     assiY(svg, ex, dati.unita);
-    assiX(svg, dati.x);
+    assiX(svg, dati.x, px, n <= 24);
     var bw = plotW() / n * 0.7;
+    function px(i) { return M.l + plotW() * (i + 0.5) / n; }
     function py(v) { return M.t + plotH() - plotH() * (v - ex.min) / (ex.max - ex.min); }
+    var y0 = py(ex.min < 0 ? 0 : ex.min);
     s.valori.forEach(function (v, i) {
-      if (v === null || v === undefined || isNaN(v)) return;
-      var cx = M.l + plotW() * (i + 0.5) / n;
-      var y = py(v), y0 = py(ex.min < 0 ? 0 : ex.min);
-      svg.appendChild(el('rect', { x: cx - bw / 2, y: Math.min(y, y0), width: bw, height: Math.abs(y0 - y), fill: s.colore }));
+      if (!valido(v)) return;
+      var cx = px(i), y = py(v);
+      svg.appendChild(el('rect', { x: cx - bw / 2, y: Math.min(y, y0), width: bw, height: Math.abs(y0 - y), fill: s.colore, 'pointer-events': 'none' }));
+      // etichetta di valore sopra la barra quando le barre sono poche
+      if (n <= 24) svg.appendChild(el('text', { x: cx, y: Math.min(y, y0) - 5, 'text-anchor': 'middle', class: 'lab-svg-val', 'pointer-events': 'none' }, fmtVal(v)));
     });
     legenda(svg, dati.serie);
-    return svg;
+    var hover = el('g', { 'pointer-events': 'none' }); svg.appendChild(hover);
+    return { svg: svg, kind: 'bar', n: n, px: px, py: py, ex: ex, bw: bw, y0: y0, hover: hover };
+  }
+
+  // ---- Interazione: tooltip (puntatore/tocco) + tastiera ------------------
+  function montaInterazione(box, r, dati) {
+    box.style.position = 'relative';
+    var tip = document.createElement('div');
+    tip.className = 'lab-tip'; tip.hidden = true;
+    tip.setAttribute('role', 'status'); tip.setAttribute('aria-live', 'polite');
+    box.appendChild(tip);
+    var svg = r.svg, n = r.n;
+
+    function idxDaX(clientX) {
+      var rect = svg.getBoundingClientRect();
+      var vx = ((clientX - rect.left) / rect.width) * W;
+      var i = (r.kind === 'bar')
+        ? Math.floor((vx - M.l) / (plotW() / n))
+        : Math.round((vx - M.l) / (n > 1 ? plotW() / (n - 1) : 1));
+      return Math.max(0, Math.min(n - 1, i));
+    }
+
+    function mostra(i, clientX, clientY) {
+      r.hover.textContent = '';
+      var gx = r.px(i);
+      r.hover.appendChild(el('line', { x1: gx, y1: M.t, x2: gx, y2: M.t + plotH(), stroke: '#003366', 'stroke-width': 1, 'stroke-dasharray': '3 3', opacity: '0.55' }));
+      var html = '<strong>' + escapeHtml(fmtData(dati.x[i])) + '</strong>';
+      dati.serie.forEach(function (s) {
+        var v = s.valori[i];
+        var testo = valido(v) ? (fmtVal(v) + ' ' + dati.unita) : 'dato non disponibile';
+        if (valido(v)) {
+          if (r.kind === 'bar') {
+            r.hover.appendChild(el('rect', { x: gx - r.bw / 2, y: Math.min(r.py(v), r.y0), width: r.bw, height: Math.abs(r.y0 - r.py(v)), fill: 'none', stroke: '#ffbe2e', 'stroke-width': 2.5 }));
+          } else {
+            r.hover.appendChild(el('circle', { cx: gx, cy: r.py(v), r: 5, fill: s.colore, stroke: '#fff', 'stroke-width': 2 }));
+          }
+        }
+        html += '<br><span class="lab-tip-pall" style="background:' + s.colore + '"></span>' + escapeHtml(s.nome) + ': <strong>' + escapeHtml(testo) + '</strong>';
+      });
+      tip.innerHTML = html;
+      tip.hidden = false;
+      var brect = box.getBoundingClientRect();
+      var left, top;
+      if (clientX != null) { left = clientX - brect.left + 14; top = clientY - brect.top + 14; }
+      else { var sr = svg.getBoundingClientRect(); left = (gx / W) * sr.width + (sr.left - brect.left) + 14; top = 14; }
+      if (left + tip.offsetWidth > box.clientWidth) left = box.clientWidth - tip.offsetWidth - 6;
+      if (left < 0) left = 6;
+      if (top + tip.offsetHeight > box.clientHeight) top = box.clientHeight - tip.offsetHeight - 6;
+      tip.style.left = left + 'px'; tip.style.top = top + 'px';
+    }
+    function nascondi() { tip.hidden = true; r.hover.textContent = ''; }
+
+    svg.addEventListener('pointermove', function (e) { mostra(idxDaX(e.clientX), e.clientX, e.clientY); });
+    svg.addEventListener('pointerdown', function (e) { mostra(idxDaX(e.clientX), e.clientX, e.clientY); });
+    svg.addEventListener('pointerleave', nascondi);
+
+    // tastiera: frecce per scorrere giorno per giorno
+    var cur = 0;
+    box.tabIndex = 0;
+    box.setAttribute('aria-label', 'Grafico interattivo: usa le frecce sinistra e destra per leggere i valori uno per uno. La tabella sotto contiene tutti i dati.');
+    box.addEventListener('keydown', function (e) {
+      if (e.key === 'ArrowRight') { cur = Math.min(n - 1, cur + 1); }
+      else if (e.key === 'ArrowLeft') { cur = Math.max(0, cur - 1); }
+      else if (e.key === 'Home') { cur = 0; }
+      else if (e.key === 'End') { cur = n - 1; }
+      else if (e.key === 'Escape') { nascondi(); return; }
+      else { return; }
+      e.preventDefault(); mostra(cur, null, null);
+    });
+    box.addEventListener('blur', nascondi);
   }
 
   function legenda(svg, serie) {

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6679,6 +6679,11 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 .ecmwf-valido { display: block; margin-top: .35rem; color: #003366; }
 @media print { .ecmwf-figura img { border-color: #000; } }
 
+/* Cruscotto — richiamo al Laboratorio meteo (box info su una riga) */
+.cruscotto-callout { display: flex; align-items: flex-start; gap: .6rem; background: #e7f0fa; border-left: 4px solid #003366; border-radius: 6px; padding: .7rem 1rem; margin: .25rem 0 1rem; font-size: .95rem; color: #1a2a3a; line-height: 1.5; }
+.cruscotto-callout i { color: #003366; font-size: 1.2rem; line-height: 1.4; flex: 0 0 auto; }
+@media print { .cruscotto-callout { display: none; } }
+
 /* ============================================================
    LABORATORIO METEO v1.0 — costruttore di grafici client-side
    ============================================================ */
@@ -6712,6 +6717,13 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 .lab-svg-tick { font-size: 11px; fill: #5a6678; }
 .lab-svg-axis { font-size: 12px; fill: #003366; font-weight: 600; }
 .lab-svg-legend { font-size: 13px; fill: #1a1a1a; }
+/* etichette di valore sul grafico, con alone bianco per leggibilità su qualsiasi sfondo */
+.lab-svg-val { font-size: 10.5px; fill: #1a2a3a; font-weight: 600; stroke: #fff; stroke-width: 3px; paint-order: stroke fill; }
+.lab-grafico { position: relative; }
+.lab-grafico:focus-visible { outline: 3px solid #ffbe2e; outline-offset: 2px; }
+/* tooltip dati: data + valori della colonna sotto il puntatore */
+.lab-tip { position: absolute; z-index: 5; pointer-events: none; background: #fff; border: 1px solid #003366; border-left: 4px solid #003366; border-radius: 6px; padding: .45rem .65rem; font-size: .9rem; line-height: 1.5; color: #1a2a3a; box-shadow: 0 4px 14px rgba(0,51,102,.22); max-width: 16rem; }
+.lab-tip-pall { display: inline-block; width: .7rem; height: .7rem; border-radius: 50%; margin-right: .35rem; vertical-align: baseline; }
 
 .lab-tabella-blocco { margin-top: 1.5rem; }
 .lab-tabella-azioni { display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }


### PR DESCRIPTION
Dopo il feedback sulla leggibilità: etichette di valore sul grafico quando i punti sono pochi, tooltip interattivo (mouse/tocco/tastiera) che mostra giorno+valore con linea guida e marcatori, punti marcati sulle linee. FIX: le etichette dell'asse X delle barre erano sfalsate rispetto alle barre → ora ogni anno è allineato sotto la sua barra (in diagonale per non sovrapporsi); prima/ultima etichetta non più troncate. Aggiunto box info nel cruscotto che richiama il Laboratorio. Verifica Playwright superata, 0 errori console.