### PR TITLE
Audio e podcast: sezione 'Quale scegliere?' come due box colorati

### DIFF
--- a/content/audio-e-podcast/_index.md
+++ b/content/audio-e-podcast/_index.md
@@ -4,7 +4,7 @@ description: "Due modi per ascoltare i contenuti della PC di Genzano di Roma: po
 layout: "single"
 toc: false
 tts: true
-dataUltimaRevisione: "2026-05-15"
+dataUltimaRevisione: "2026-05-31"
 sitemap:
   priority: 0.6
   changefreq: monthly
@@ -30,10 +30,22 @@ Utile per chi non sente bene, per chi preferisce ascoltare mentre fa altro, per 
 
 ## Quale scegliere?
 
-- Vuoi **episodi audio strutturati**, da seguire nel tempo, da ascoltare in macchina o durante una camminata? → Il [podcast](/podcast/).
-- Vuoi **ascoltare un singolo articolo** mentre lavori al computer, o aiutare chi non legge bene? → Gli [articoli da ascoltare](/articoli-da-ascoltare/).
+<div class="scelta-audio">
+  <a class="scelta-card scelta-podcast" href="/podcast/">
+    <span class="scelta-icona"><i class="bi bi-broadcast" aria-hidden="true"></i></span>
+    <span class="scelta-titolo">Scegli il podcast</span>
+    <span class="scelta-testo">Vuoi <strong>episodi audio strutturati</strong>, da seguire nel tempo, da ascoltare in macchina o durante una camminata.</span>
+    <span class="scelta-cta">Vai al podcast <i class="bi bi-arrow-right" aria-hidden="true"></i></span>
+  </a>
+  <a class="scelta-card scelta-articoli" href="/articoli-da-ascoltare/">
+    <span class="scelta-icona"><i class="bi bi-volume-up-fill" aria-hidden="true"></i></span>
+    <span class="scelta-titolo">Scegli gli articoli da ascoltare</span>
+    <span class="scelta-testo">Vuoi <strong>ascoltare un singolo articolo</strong> mentre lavori al computer, o aiutare chi non legge bene.</span>
+    <span class="scelta-cta">Vai agli articoli <i class="bi bi-arrow-right" aria-hidden="true"></i></span>
+  </a>
+</div>
 
-Entrambe le opzioni sono **gratuite**, **accessibili** (WCAG 2.2 AA) e **rispettose della privacy**.
+<p class="scelta-garanzie">Le due opzioni sono entrambe <span class="scelta-badge"><i class="bi bi-cash-coin" aria-hidden="true"></i> gratuite</span> <span class="scelta-badge"><i class="bi bi-universal-access" aria-hidden="true"></i> accessibili (WCAG 2.2 AA)</span> <span class="scelta-badge"><i class="bi bi-shield-lock" aria-hidden="true"></i> rispettose della privacy</span></p>
 
 ## Podcast del Sistema nazionale di Protezione Civile
 

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6685,6 +6685,45 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 @media print { .cruscotto-callout { display: none; } }
 
 /* ============================================================
+   SCELTA AUDIO v1.0 — box "Quale scegliere?" (podcast vs articoli)
+   ============================================================ */
+.scelta-audio { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1rem 0 1.2rem; }
+.scelta-card { display: flex; flex-direction: column; align-items: flex-start; gap: .5rem; padding: 1.2rem 1.3rem; border-radius: 10px; border: 1px solid; transition: transform .15s, box-shadow .15s; }
+/* l'intera card è un link: niente sottolineatura sul testo interno (override .article-body a) */
+.article-body a.scelta-card, .article-body a.scelta-card:hover, .article-body a.scelta-card:focus { text-decoration: none; }
+.scelta-card .scelta-cta { text-decoration: none; }
+.scelta-card:hover { transform: translateY(-3px); box-shadow: 0 6px 18px rgba(0,0,0,.14); }
+.scelta-card:focus-visible { outline: 3px solid #ffbe2e; outline-offset: 3px; }
+.scelta-icona { display: inline-flex; align-items: center; justify-content: center; width: 3rem; height: 3rem; border-radius: 50%; font-size: 1.5rem; }
+.scelta-titolo { font-size: 1.15rem; font-weight: 700; line-height: 1.3; }
+.scelta-testo { font-size: .98rem; line-height: 1.55; }
+.scelta-cta { margin-top: auto; font-weight: 600; display: inline-flex; align-items: center; gap: .35rem; }
+.scelta-card:hover .scelta-cta i { transform: translateX(3px); }
+.scelta-cta i { transition: transform .15s; }
+/* Podcast — blu istituzionale */
+.scelta-podcast { background: #e7f0fa; border-color: #b6cce6; }
+.scelta-podcast .scelta-icona { background: #003366; color: #fff; }
+.scelta-podcast .scelta-titolo, .scelta-podcast .scelta-cta { color: #003366; }
+.scelta-podcast .scelta-testo { color: #1a2a3a; }
+/* Articoli da ascoltare — verde prevenzione */
+.scelta-articoli { background: #e9f5ee; border-color: #b6dcc4; }
+.scelta-articoli .scelta-icona { background: #15803d; color: #fff; }
+.scelta-articoli .scelta-titolo, .scelta-articoli .scelta-cta { color: #136a34; }
+.scelta-articoli .scelta-testo { color: #1f3a29; }
+/* garanzie comuni come badge */
+.scelta-garanzie { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem; font-size: .95rem; color: #33415c; }
+.scelta-badge { display: inline-flex; align-items: center; gap: .35rem; background: #f4f7fb; border: 1px solid #cdd9e8; border-radius: 999px; padding: .2rem .7rem; font-weight: 600; color: #003366; }
+.scelta-badge i { font-size: 1rem; }
+@media (max-width: 600px) { .scelta-audio { grid-template-columns: 1fr; } }
+@media (prefers-reduced-motion: reduce) { .scelta-card { transition: none; } .scelta-card:hover .scelta-cta i { transform: none; } }
+html.a11y-pause-anim .scelta-card:hover { transform: none; }
+@media print {
+  .scelta-card { box-shadow: none; border-color: #000; }
+  .scelta-card:hover { transform: none; }
+  .scelta-icona { background: #fff !important; color: #000 !important; border: 1px solid #000; }
+}
+
+/* ============================================================
    LABORATORIO METEO v1.0 — costruttore di grafici client-side
    ============================================================ */
 .lab-esempi, .lab-builder { margin: 2rem 0 0; }


### PR DESCRIPTION
Su richiesta utente: l'elenco puntato podcast vs articoli-da-ascoltare diventa due card colorate affiancate (blu = podcast, verde = articoli), con icona, titolo, 'quando sceglierlo' e CTA; le tre garanzie come badge a pillola. CSS scoped, responsive, accessibile (focus-visible, reduced-motion, stampa). Verifica visiva Playwright OK.