### PR TITLE
Indice di pagina con scrollspy site-wide (navscroll Bootstrap Italia)

### DIFF
--- a/static/js/indice-pagina.js
+++ b/static/js/indice-pagina.js
@@ -1,0 +1,52 @@
+/* Indice di pagina: evidenzia la voce della sezione visibile mentre si scorre
+   (scrollspy). Nessuna dipendenza: scroll listener con throttle rAF. */
+(function () {
+  'use strict';
+  var idx = document.querySelector('.page-index');
+  if (!idx) return;
+  var links = [].slice.call(idx.querySelectorAll('a[href^="#"]'));
+  if (!links.length) return;
+
+  var targets = [];
+  links.forEach(function (a) {
+    var id = (a.getAttribute('href') || '').replace(/^#/, '');
+    var el = id && document.getElementById(id);
+    if (el) targets.push({ id: id, el: el, link: a });
+  });
+  if (!targets.length) return;
+
+  var attivo = null;
+  function setActive(id) {
+    if (id === attivo) return;
+    attivo = id;
+    targets.forEach(function (t) {
+      var on = t.id === id;
+      t.link.classList.toggle('active', on);
+      if (on) t.link.setAttribute('aria-current', 'true');
+      else t.link.removeAttribute('aria-current');
+    });
+  }
+
+  var ticking = false;
+  function aggiorna() {
+    ticking = false;
+    var off = 110; // sotto la navbar
+    var cur = targets[0];
+    for (var i = 0; i < targets.length; i++) {
+      if (targets[i].el.getBoundingClientRect().top <= off) cur = targets[i];
+      else break;
+    }
+    // se siamo in fondo alla pagina, attiva l'ultima voce
+    if ((window.innerHeight + window.scrollY) >= (document.body.offsetHeight - 4)) {
+      cur = targets[targets.length - 1];
+    }
+    if (cur) setActive(cur.id);
+  }
+  function onScroll() {
+    if (!ticking) { ticking = true; window.requestAnimationFrame(aggiorna); }
+  }
+
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', onScroll, { passive: true });
+  aggiorna();
+})();

--- a/themes/flavour-pcgenzano/layouts/_default/list.html
+++ b/themes/flavour-pcgenzano/layouts/_default/list.html
@@ -6,25 +6,16 @@
   </div>
 </div>
 <div class="container py-4">
-  <div class="row">
-    <div class="col-lg-8 mx-auto">
-      {{/* ── INDICE DELLA PAGINA (frontmatter: toc: true) ── */}}
-      {{ if .Params.toc }}
-      <div id="indice" class="article-toc mb-4" tabindex="-1" aria-label="Indice della pagina">
-        <details open>
-          <summary class="article-toc-summary">
-            <span class="article-toc-title h6 fw-bold mb-0">
-              <i class="bi bi-list-ul me-1" aria-hidden="true"></i>In questa pagina
-            </span>
-            <i class="bi bi-chevron-down article-toc-chevron ms-auto" aria-hidden="true"></i>
-          </summary>
-          <div class="article-toc-body">
-            {{ .TableOfContents }}
-          </div>
-        </details>
-      </div>
-      {{ end }}
-
+  {{/* ── INDICE DI PAGINA SITE-WIDE (scrollspy) — vedi _default/single.html ──
+       Costruito dagli H2 dell'intro (_index.md). Le card paginate non vi
+       compaiono (i loro H2 sono nel template, non nel .Content). */}}
+  {{ $idxBan := slice "cruscotto" "laboratorio-meteo" "cerca" "emergenza" "lanterna" "mappa-sito" "attribuzioni-pittogrammi" "comunicazioni" }}
+  {{ $banned := false }}{{ range $idxBan }}{{ if eq $.Section . }}{{ $banned = true }}{{ end }}{{ end }}
+  {{ $nh := len .Fragments.Identifiers }}
+  {{ $idx := and (ge $nh 3) (not $banned) (ne .Params.indice false) (ne .Params.toc false) }}
+  <div class="row{{ if $idx }} justify-content-center gx-lg-5{{ end }}">
+    {{ if $idx }}<div class="col-lg-3 col-indice d-print-none">{{ partial "indice-pagina.html" . }}</div>{{ end }}
+    <div class="{{ if $idx }}col-lg-8 col-contenuto-indice{{ else }}col-lg-8 mx-auto{{ end }}">
       {{/* ── BOX UNIFICATO "Leggi questo articolo in altri modi" ──
            Stesso pattern di _default/single.html: box blu istituzionale che
            raggruppa reading-time + TTS + braille + PDF. Uniformato il 16/05/2026

--- a/themes/flavour-pcgenzano/layouts/_default/single.html
+++ b/themes/flavour-pcgenzano/layouts/_default/single.html
@@ -6,8 +6,16 @@
   </div>
 </div>
 <div class="container py-4">
-  <div class="row">
-    <div class="col-lg-8 mx-auto">
+  {{/* ── INDICE DI PAGINA SITE-WIDE (scrollspy) ──
+       Compare automaticamente sulle pagine con ≥3 sezioni H2, tranne le pagine
+       strumento/lite. Opt-out: indice:false o toc:false nel frontmatter. */}}
+  {{ $idxBan := slice "cruscotto" "laboratorio-meteo" "cerca" "emergenza" "lanterna" "mappa-sito" "attribuzioni-pittogrammi" }}
+  {{ $banned := false }}{{ range $idxBan }}{{ if eq $.Section . }}{{ $banned = true }}{{ end }}{{ end }}
+  {{ $nh := len .Fragments.Identifiers }}
+  {{ $idx := and (ge $nh 3) (not $banned) (ne .Params.indice false) (ne .Params.toc false) }}
+  <div class="row{{ if $idx }} justify-content-center gx-lg-5{{ end }}">
+    {{ if $idx }}<div class="col-lg-3 col-indice d-print-none">{{ partial "indice-pagina.html" . }}</div>{{ end }}
+    <div class="{{ if $idx }}col-lg-8 col-contenuto-indice{{ else }}col-lg-8 mx-auto{{ end }}">
       {{ with .Params.subtitle }}<p class="lead">{{ . }}</p>{{ end }}
 
       {{/* ── DATA ULTIMA REVISIONE (pagine istituzionali/legali) ── */}}
@@ -72,22 +80,9 @@
            Specifiche: manuale/parte-25-italiano-l2-versione-facile.md */}}
       {{ partial "versione-facile-toggle.html" . }}
 
-      {{/* ── INDICE DELLA PAGINA (frontmatter: toc: true) ── */}}
-      {{ if .Params.toc }}
-      <div id="indice" class="article-toc mb-4" tabindex="-1" aria-label="Indice della pagina">
-        <details open>
-          <summary class="article-toc-summary">
-            <span class="article-toc-title h6 fw-bold mb-0">
-              <i class="bi bi-list-ul me-1" aria-hidden="true"></i>In questa pagina
-            </span>
-            <i class="bi bi-chevron-down article-toc-chevron ms-auto" aria-hidden="true"></i>
-          </summary>
-          <div class="article-toc-body">
-            {{ .TableOfContents }}
-          </div>
-        </details>
-      </div>
-      {{ end }}
+      {{/* L'indice della pagina è ora gestito site-wide come colonna sticky
+           con scrollspy (vedi partial indice-pagina.html, innestato in cima a
+           questo template). Il vecchio TOC in <details> è stato rimosso. */}}
 
       {{/* ── TEMPO DI LETTURA + PULSANTE TTS + GLOSSARIO INLINE ── */}}
       {{/* Opt-out: TTS e glossario attivi di default su tutte le pagine,

--- a/themes/flavour-pcgenzano/layouts/partials/indice-pagina.html
+++ b/themes/flavour-pcgenzano/layouts/partials/indice-pagina.html
@@ -1,0 +1,16 @@
+{{/* Indice di pagina con scrollspy (Bootstrap Italia "navscroll" semplificato).
+     L'elenco è prodotto da .TableOfContents (H2/H3, ordine del documento).
+     Sticky su desktop, accordion collassabile su mobile. Evidenzia la sezione
+     corrente mentre si scorre (static/js/indice-pagina.js, che aggiunge .active
+     ai link). Render solo se il chiamante ha verificato la soglia di heading
+     (len .Fragments.Identifiers ≥ 3 — vedi single.html / list.html). */}}
+<details class="page-index" id="indice" open>
+  <summary class="page-index-summary">
+    <span class="page-index-title"><i class="bi bi-list-ul me-1" aria-hidden="true"></i>In questa pagina</span>
+    <i class="bi bi-chevron-down page-index-chevron" aria-hidden="true"></i>
+  </summary>
+  <nav class="page-index-nav" aria-label="Indice della pagina">
+    {{ .TableOfContents }}
+  </nav>
+</details>
+<script src="{{ "js/indice-pagina.js" | relURL }}" defer></script>

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6724,6 +6724,39 @@ html.a11y-pause-anim .scelta-card:hover { transform: none; }
 }
 
 /* ============================================================
+   INDICE DI PAGINA v1.0 — navscroll con scrollspy (sticky desktop)
+   ============================================================ */
+.page-index { margin: 0 0 1.5rem; border: 1px solid #dbe4ef; border-radius: 8px; background: #f8fafd; padding: .4rem .6rem; }
+.page-index-summary { display: flex; align-items: center; gap: .5rem; cursor: pointer; padding: .35rem .4rem; list-style: none; font-weight: 700; color: #003366; }
+.page-index-summary::-webkit-details-marker { display: none; }
+.page-index-title { font-size: .95rem; }
+.page-index-chevron { margin-left: auto; transition: transform .2s; }
+.page-index[open] .page-index-chevron { transform: rotate(180deg); }
+.page-index-nav { margin-top: .3rem; }
+/* la lista è prodotta da .TableOfContents: <nav id="TableOfContents"><ul>… */
+.page-index-nav ul { list-style: none; margin: 0; padding: 0; border-left: 2px solid #dbe4ef; }
+.page-index-nav ul ul { border-left: 0; padding-left: .7rem; }
+.page-index-nav a { display: block; padding: .3rem .8rem; margin-left: -2px; border-left: 3px solid transparent; color: #33415c; text-decoration: none; font-size: .92rem; line-height: 1.35; }
+.page-index-nav ul ul a { font-size: .86rem; color: #5a6678; padding-top: .2rem; padding-bottom: .2rem; }
+.page-index-nav a:hover { color: #003366; background: #eef3fa; }
+.page-index-nav a.active { color: #003366; font-weight: 700; border-left-color: #003366; background: #eef3fa; }
+.page-index-nav a:focus-visible { outline: 3px solid #ffbe2e; outline-offset: -2px; }
+/* offset per le ancore sotto la navbar fissa */
+.article-body h2[id], .article-body h3[id], .list-intro-content h2[id], .list-intro-content h3[id] { scroll-margin-top: 100px; }
+
+@media (min-width: 992px) {
+  .col-indice { order: 1; }
+  .col-contenuto-indice { order: 2; }
+  .page-index { position: sticky; top: 90px; max-height: calc(100vh - 110px); overflow-y: auto; margin-bottom: 0; }
+  .page-index-summary { cursor: default; }
+  .page-index-chevron { display: none; }
+  /* su desktop la lista è sempre visibile anche se l'utente l'ha chiusa */
+  .page-index .page-index-nav { display: block !important; }
+}
+@media (prefers-reduced-motion: reduce) { .page-index-chevron { transition: none; } }
+@media print { .page-index { display: none; } }
+
+/* ============================================================
    LABORATORIO METEO v1.0 — costruttore di grafici client-side
    ============================================================ */
 .lab-esempi, .lab-builder { margin: 2rem 0 0; }


### PR DESCRIPTION
Espansione site-wide (senza pilota) del primo componente consigliato: indice 'In questa pagina' su tutte le pagine con ≥3 heading. Desktop: colonna sticky a sinistra con scrollspy (evidenzia la sezione corrente). Mobile: accordion collassabile in cima. Costruito da .TableOfContents; gate su len .Fragments.Identifiers ≥3; opt-out indice:false/toc:false; escluse pagine-strumento. Rimosso vecchio TOC in <details>. Verifica Playwright: sezione+articolo+mobile+scrollspy, 0 errori console. NB: niente Telegram (nessun nuovo articolo).