### PR TITLE
Componenti Bootstrap Italia (2/2): spinner, carosello, tabella sticky

### DIFF
--- a/static/js/galleria.js
+++ b/static/js/galleria.js
@@ -1,0 +1,32 @@
+/* Galleria/carosello foto: avanzamento manuale (prev/next + scroll/tocco).
+   Nessun autoplay (WCAG 2.2.2). Idempotente su più gallerie nella pagina. */
+(function () {
+  'use strict';
+  function initGalleria(g) {
+    if (g.dataset.gInit) return;
+    g.dataset.gInit = '1';
+    var track = g.querySelector('.galleria-track');
+    var prev = g.querySelector('[data-galleria="prev"]');
+    var next = g.querySelector('[data-galleria="next"]');
+    if (!track || !prev || !next) return;
+    function passo() {
+      var fig = track.querySelector('figure');
+      return fig ? fig.getBoundingClientRect().width + 10 : track.clientWidth * 0.9;
+    }
+    function aggiorna() {
+      var max = track.scrollWidth - track.clientWidth - 2;
+      prev.disabled = track.scrollLeft <= 2;
+      next.disabled = track.scrollLeft >= max;
+    }
+    prev.addEventListener('click', function () { track.scrollBy({ left: -passo(), behavior: 'smooth' }); });
+    next.addEventListener('click', function () { track.scrollBy({ left: passo(), behavior: 'smooth' }); });
+    track.addEventListener('scroll', function () { window.requestAnimationFrame(aggiorna); }, { passive: true });
+    window.addEventListener('resize', aggiorna, { passive: true });
+    aggiorna();
+  }
+  function init() {
+    [].forEach.call(document.querySelectorAll('.galleria'), initGalleria);
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/static/js/laboratorio-meteo.js
+++ b/static/js/laboratorio-meteo.js
@@ -59,9 +59,15 @@
   }
 
   // ---- Stato UI ------------------------------------------------------------
-  function stato(msg, errore) {
+  function stato(msg, errore, loading) {
     var el = $('lab-stato');
-    el.textContent = msg || '';
+    if (loading) {
+      el.textContent = '';
+      el.appendChild(el.ownerDocument.createElement('span')).className = 'pc-spinner';
+      el.appendChild(el.ownerDocument.createTextNode(msg || ''));
+    } else {
+      el.textContent = msg || '';
+    }
     el.className = 'lab-stato' + (errore ? ' lab-stato-errore' : '');
   }
 
@@ -79,7 +85,7 @@
       '&daily=' + v.daily.join(',') + '&timezone=Europe%2FRome';
 
     $('lab-output').hidden = false;
-    stato('Sto scaricando i dati di ' + luogo.nome + '…');
+    stato('Sto scaricando i dati di ' + luogo.nome + '…', false, true);
     $('lab-grafico-wrap').hidden = true;
     $('lab-tabella-blocco').hidden = true;
 
@@ -407,7 +413,7 @@
   function apriEsempio(file) {
     var path = file.charAt(0) === '/' ? file : (OPENDATA + file);
     $('lab-output').hidden = false;
-    stato("Apro l'esempio…");
+    stato("Apro l'esempio…", false, true);
     fetch(path).then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(function (dati) { disegna(dati); stato(''); $('lab-output').scrollIntoView({ behavior: 'smooth', block: 'start' }); })
       .catch(function (e) { stato('Esempio non disponibile (' + e.message + ').', true); });

--- a/themes/flavour-pcgenzano/layouts/shortcodes/galleria.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/galleria.html
@@ -1,0 +1,16 @@
+{{- /* Galleria/carosello accessibile per ≥4 foto. Avanzamento solo manuale
+       (mai autoplay — WCAG 2.2.2). Contiene shortcode {{< foto >}}:
+       {{< galleria >}}
+         {{< foto src="…" alt="…" caption="…" >}}
+         {{< foto src="…" alt="…" >}}
+       {{< /galleria >}}
+       Parametro opzionale titolo (per aria-label). */ -}}
+{{- $titolo := .Get "titolo" | default "Galleria fotografica" -}}
+<div class="galleria" role="group" aria-roledescription="carosello" aria-label="{{ $titolo }} (scorri o usa i pulsanti)">
+  <div class="galleria-track" tabindex="0">{{ .Inner }}</div>
+  <div class="galleria-nav">
+    <button type="button" class="galleria-btn" data-galleria="prev" aria-label="Foto precedente"><i class="bi bi-chevron-left" aria-hidden="true"></i></button>
+    <button type="button" class="galleria-btn" data-galleria="next" aria-label="Foto successiva"><i class="bi bi-chevron-right" aria-hidden="true"></i></button>
+  </div>
+</div>
+<script src="{{ "js/galleria.js" | relURL }}" defer></script>

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6792,6 +6792,38 @@ html.a11y-pause-anim .scelta-card:hover { transform: none; }
 @media print { .timeline-wrap ul { border-color: #000; } .timeline-wrap ul > li::before { border-color: #000; } }
 
 /* ============================================================
+   SPINNER v1.0 — indicatore di caricamento (Bootstrap Italia "progress-spinner")
+   ============================================================ */
+.pc-spinner { display: inline-block; width: 1em; height: 1em; vertical-align: -0.15em; margin-right: .45rem; border: 2px solid rgba(0,51,102,.25); border-top-color: #003366; border-radius: 50%; animation: pc-spin .7s linear infinite; }
+@keyframes pc-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .pc-spinner { animation-duration: 2.2s; } }
+html.a11y-pause-anim .pc-spinner { animation: none; border-top-color: rgba(0,51,102,.25); }
+
+/* ============================================================
+   TABELLE — intestazione sticky sui tabelloni lunghi (.table-sticky)
+   ============================================================ */
+.article-body .table-sticky, .list-intro-content .table-sticky { max-height: 70vh; overflow-y: auto; }
+.table-sticky table thead th { position: sticky; top: 0; z-index: 2; }
+@media print { .table-sticky { max-height: none; overflow: visible; } .table-sticky table thead th { position: static; } }
+
+/* ============================================================
+   GALLERIA v1.0 — carosello accessibile per ≥4 foto (shortcode {{< galleria >}})
+   Solo avanzamento manuale (mai autoplay — WCAG 2.2.2).
+   ============================================================ */
+.galleria { position: relative; margin: 1.2rem 0; }
+.galleria-track { display: flex; gap: .6rem; overflow-x: auto; scroll-snap-type: x mandatory; scroll-behavior: smooth; padding-bottom: .4rem; -webkit-overflow-scrolling: touch; }
+.galleria-track > figure { scroll-snap-align: center; flex: 0 0 88%; max-width: 88%; margin: 0; }
+.galleria-track > figure img { width: 100%; height: auto; border-radius: 8px; border: 1px solid #cdd9e8; }
+.galleria-track > figure figcaption { font-size: .85rem; color: #33415c; margin-top: .35rem; font-style: italic; }
+.galleria-nav { display: flex; justify-content: space-between; gap: .5rem; margin-top: .5rem; }
+.galleria-btn { background: #003366; color: #fff; border: 0; border-radius: 50%; width: 2.4rem; height: 2.4rem; font-size: 1.1rem; cursor: pointer; }
+.galleria-btn:hover { background: #00284f; }
+.galleria-btn:focus-visible { outline: 3px solid #ffbe2e; outline-offset: 2px; }
+.galleria-btn[disabled] { opacity: .4; cursor: default; }
+@media (min-width: 768px) { .galleria-track > figure { flex-basis: 46%; max-width: 46%; } }
+@media print { .galleria-track { display: block; overflow: visible; } .galleria-track > figure { max-width: 100%; page-break-inside: avoid; margin-bottom: .6rem; } .galleria-nav { display: none; } }
+
+/* ============================================================
    LABORATORIO METEO v1.0 — costruttore di grafici client-side
    ============================================================ */
 .lab-esempi, .lab-builder { margin: 2rem 0 0; }


### PR DESCRIPTION
Spinner di caricamento nel Laboratorio meteo, shortcode {{< galleria >}} (carosello accessibile per ≥4 foto, solo manuale — WCAG 2.2.2), utility .table-sticky per intestazioni tabella. Scartati con motivazione: bottom-nav (conflitto FAB), autocomplete (Pagefind), chips (filter-pill già chip), avatar (direttivo è tabella).