### PR TITLE
Callout: componente nativo Bootstrap Italia (conformità manuale AGID)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/shortcodes/callout.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/callout.html
@@ -1,11 +1,23 @@
-{{- /* Callout istituzionale (Bootstrap Italia "callout").
-       Uso: {{< callout tipo="info|avviso|pericolo|ok" titolo="…" >}} testo markdown {{< /callout >}}
-       tipo default: info. */ -}}
+{{- /* Callout NATIVO Bootstrap Italia (componente "callout" del design system).
+       API autore invariata: {{< callout tipo="info|avviso|pericolo|ok" titolo="…" >}} testo {{< /callout >}}
+       Mappa sui modificatori nativi BI: note/warning/danger/success. */ -}}
 {{- $tipo := .Get "tipo" | default "info" -}}
 {{- $titolo := .Get "titolo" -}}
-{{- $icone := dict "info" "bi-info-circle" "avviso" "bi-exclamation-triangle" "pericolo" "bi-x-octagon" "ok" "bi-check-circle" -}}
-{{- $icona := index $icone $tipo | default "bi-info-circle" -}}
-<div class="callout callout-{{ $tipo }}" role="note">
-  {{- with $titolo }}<p class="callout-title"><i class="bi {{ $icona }}" aria-hidden="true"></i> {{ . }}</p>{{ end -}}
-  <div class="callout-body">{{ .Inner | markdownify }}</div>
+{{- $map := dict
+      "info"     (dict "cls" "note"    "icon" "it-info-circle")
+      "avviso"   (dict "cls" "warning" "icon" "it-warning-circle")
+      "pericolo" (dict "cls" "danger"  "icon" "it-error")
+      "ok"       (dict "cls" "success" "icon" "it-check-circle") -}}
+{{- $c := index $map $tipo | default (index $map "info") -}}
+{{- $sprite := "vendor/bootstrap-italia/svg/sprites.svg" | relURL -}}
+<div class="callout {{ $c.cls }}" role="note">
+  <div class="callout-inner">
+    {{- with $titolo }}
+    <div class="callout-title">
+      <svg class="icon" aria-hidden="true"><use href="{{ $sprite }}#{{ $c.icon }}"></use></svg>
+      <span>{{ . }}</span>
+    </div>
+    {{- end }}
+    {{ .Inner | markdownify }}
+  </div>
 </div>

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6756,18 +6756,8 @@ html.a11y-pause-anim .scelta-card:hover { transform: none; }
 @media (prefers-reduced-motion: reduce) { .page-index-chevron { transition: none; } }
 @media print { .page-index { display: none; } }
 
-/* ============================================================
-   CALLOUT v1.0 — box nota istituzionale (shortcode {{< callout >}})
-   ============================================================ */
-.callout { border-left: 4px solid; border-radius: 8px; padding: .85rem 1.05rem; margin: 1.1rem 0; background: #f4f7fb; }
-.callout-title { font-weight: 700; margin: 0 0 .35rem; display: flex; align-items: center; gap: .45rem; }
-.callout-body > :first-child { margin-top: 0; }
-.callout-body > :last-child { margin-bottom: 0; }
-.callout-info { border-color: #003366; background: #e7f0fa; } .callout-info .callout-title { color: #003366; }
-.callout-avviso { border-color: #b45309; background: #fdf3e7; } .callout-avviso .callout-title { color: #92400e; }
-.callout-pericolo { border-color: #c1121f; background: #fdeaec; } .callout-pericolo .callout-title { color: #842029; }
-.callout-ok { border-color: #15803d; background: #e9f5ee; } .callout-ok .callout-title { color: #136a34; }
-@media print { .callout { background: #fff; border-color: #000; } }
+/* Callout: si usa il componente NATIVO Bootstrap Italia (.callout .note/.warning/
+   .danger/.success), nessuna CSS custom qui per non collidere col design system. */
 
 /* ============================================================
    PASSI / STEPPER v1.0 — lista ordinata con pallini numerati (shortcode {{< passi >}})


### PR DESCRIPTION
Il callout custom collideva con il componente nativo .callout del bundle Bootstrap Italia. Riscritto col markup nativo BI (.note/.warning/.danger/.success + callout-inner + callout-title con icona sprite) e rimossa la CSS collidente. API autore invariata. Ora è il componente del design system. Verifica Playwright OK.