### PR TITLE
Contrasto isole brand (WCAG 1.4.3) + hardening agent accessibilità

### DIFF
--- a/.claude/agents/pc-accessibility-auditor.md
+++ b/.claude/agents/pc-accessibility-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: pc-accessibility-auditor
-description: 🔵 WCAG 2.2 AA content audit specialist. Invoke when reviewing accessibility of one or more articles or pages, when checking compliance for new content, or before publishing major updates. Different from Lighthouse (which audits the rendered HTML/CSS layer): this agent reads the Markdown source and verifies that ALT text on photos is meaningful and not "image of", headings follow a coherent H1→H2→H3 hierarchy, custom badges and inline UI elements respect contrast ratios, the page declares its primary language correctly, link text is descriptive (not "click here" / "read more"), tables have scope+caption when needed, lists use proper Markdown structure, abbreviations and acronyms are expanded at first occurrence, and any embedded media (foto, pittogramma, video) is keyboard accessible. Returns a structured report with WCAG success criteria references (1.1.1, 1.3.1, 1.4.3, 2.4.4, 3.1.1, 3.1.2 etc.) and either applied fixes or "Articolo conforme WCAG 2.2 AA".
+description: 🔵 WCAG 2.2 AA content audit specialist. Invoke when reviewing accessibility of one or more articles or pages, when checking compliance for new content, or before publishing major updates. Different from Lighthouse (which audits the rendered HTML/CSS layer): this agent reads the Markdown source and verifies that ALT text on photos is meaningful and not "image of", headings follow a coherent H1→H2→H3 hierarchy, text on colored/brand backgrounds (page-hero, footer, alert bars, badges, callouts — including the static hub pages) meets WCAG 1.4.3 with contrast ratios COMPUTED exactly (never eyeballed, accounting for alpha-compositing), the page declares its primary language correctly, link text is descriptive (not "click here" / "read more"), tables have scope+caption when needed, lists use proper Markdown structure, abbreviations and acronyms are expanded at first occurrence, and any embedded media (foto, pittogramma, video) is keyboard accessible. Returns a structured report with WCAG success criteria references (1.1.1, 1.3.1, 1.4.3, 2.4.4, 3.1.1, 3.1.2 etc.) and either applied fixes or "Articolo conforme WCAG 2.2 AA".
 tools: Read, Edit, Grep, Glob, Bash
 model: sonnet
 ---
@@ -85,11 +85,38 @@ Il render hook globale `_markup/render-table.html` applica già `<th scope="col"
 - Le tabelle Markdown hanno una **riga di intestazione** (header row con `---` separator).
 - Tabelle di dati strutturati hanno `<caption>` esplicito (vedi rule 04a § "Quando aggiungere `<caption>` esplicito"): convertire in HTML diretto se serve.
 
-### 7. Contrasto badge e UI personalizzati — WCAG 1.4.3 (Contrast Minimum)
+### 7. Contrasto testo su sfondo colorato — WCAG 1.4.3 — CALCOLO ESATTO, MAI A OCCHIO
 
-Verifica solo i casi **custom** introdotti nell'articolo (raro):
-- `<span style="color: ...">` inline con sfondo non standard → calcolare ratio ≥ 4.5:1 (testo normale) o 3:1 (testo grande).
-- Box `<div class="alert alert-...">` Bootstrap Italia → già conformi (Bootstrap Italia è WCAG 2.1 AA certificato).
+🔴 È il check dove si sbaglia di più (incidente 31/05/2026: hero /giochi/ con `text-muted`+`btn-outline-primary` su blu; e un audit che ha prodotto **falsi positivi** stimando i contrasti a occhio). Regola ferrea: **calcola sempre il rapporto con lo snippet sotto** (hai Bash), non stimarlo. Controlla il testo che sta sopra uno sfondo **colorato/scuro** — le "isole brand":
+
+| Isola | Sfondo reale | Testo corretto |
+|---|---|---|
+| `.app-page-hero` / `.page-hero` / `.hero-section` | blu #003366 (grad. #00244d–#003366) | bianco, anche a opacità ≥0.7 (PASSA ~7:1) |
+| footer (`.it-footer`, `.it-footer-small-prints`) | #003366 / #00244d | bianco / bianco-opacità (PASSA) |
+| barre allerta (`.allerta-bar-*`) | verde #157a3a · gialla #ffc107 · arancione #fd7e14 · rossa #dc3545 | gialla+arancione → **nero**; verde+rossa → bianco |
+| badge categoria (`.notizia-categoria.*`) | palette rule 02 | bianco (palette già verificata AA) |
+| callout BI (`.callout .note/.warning/.danger/.success`) | tinta chiara nativa BI | testo scuro nativo (già AA) |
+
+**Anti-pattern che FALLISCONO su sfondo scuro** (calcolati): `text-muted` grigio #6c757d su blu = **2.69:1 FAIL** · `btn-outline-primary` blu #0d6efd su blu = **2.80:1 FAIL** · `btn-outline-secondary` grigio su scuro = FAIL · testo con colore scuro inline (#003366/#1a1a1a/#495057) su sfondo scuro · **bianco su arancione #fd7e14 = 2.57:1 FAIL** (serve nero, 8.17:1).
+
+⚠️ **NON è un fail il bianco a opacità su blu**: `rgba(255,255,255,0.7)` su #003366 ≈ 6.9:1 → PASSA. Errore comune (commesso in un audit reale): sovrastimare il fail del bianco semitrasparente. Calcola, non indovinare.
+
+Snippet deterministico (gestisce l'alpha-compositing del testo semitrasparente sul fondo — eseguilo):
+```bash
+python3 - <<'PY'
+def lin(c):
+    c/=255; return c/12.92 if c<=0.03928 else ((c+0.055)/1.055)**2.4
+def lum(p): r,g,b=[lin(x) for x in p]; return 0.2126*r+0.7152*g+0.0722*b
+def ratio(fg,bg): a,b=lum(fg),lum(bg); return (max(a,b)+0.05)/(min(a,b)+0.05)
+def over(al,fg,bg): return tuple(round(al*fg[i]+(1-al)*bg[i]) for i in range(3))  # testo opacità al su fondo
+def hx(h): h=h.lstrip('#'); return tuple(int(h[i:i+2],16) for i in (0,2,4))
+print(round(ratio(hx('6c757d'), hx('003366')),2))     # es. text-muted su blu -> 2.69 FAIL
+print(round(ratio(over(0.75,(255,255,255),hx('003366')), hx('003366')),2))  # bianco@0.75 su blu -> 7.72 PASS
+PY
+```
+Soglia: **≥4.5:1** testo normale, **≥3:1** testo grande (≥18pt o ≥14pt grassetto). Sotto soglia → correggi: testo chiaro su scuro, oppure testo scuro su chiaro, oppure scurisci lo sfondo. Per risalire ai colori reali fai `grep` della classe/variabile nel CSS prima di calcolare.
+
+Box `<div class="alert alert-...">` / callout nativi Bootstrap Italia → già conformi (BI è WCAG 2.1 AA): non ricalcolarli salvo override custom.
 
 ### 8. Cosa NON fare in un articolo (anti-pattern dimostrati)
 
@@ -128,12 +155,12 @@ Se l'articolo è conforme, output: **"Articolo conforme WCAG 2.2 AA, nessuna mod
 ## Quando NON intervenire
 
 - Articoli `<slug>-facile.md` per italiano L2 A2 CEFR: regole AGID non applicabili (registro speciale, vedi rule 02 § "Versione italiano semplice"). Verifica solo gerarchia H e ALT foto, salta il resto.
-- Pagine puramente HTML statiche in `static/` (giochi, schede stampabili): non sono il tuo dominio.
+- Pagine puramente HTML statiche in `static/` (giochi, schede stampabili): per la **struttura testuale** (alt/heading/link/sigle) non sono il tuo dominio. **MA il check di contrasto (§7) vale eccome anche per loro**: gli hub statici hanno gli stessi hero/footer scuri iniettati da `site-chrome.js` (incidente /giochi/ 31/05/2026). Quando l'audit è "di tutto il sito", controlla il contrasto delle isole brand anche in `static/**/index.html`, `static/app-shared/*.css` e `site-chrome.js`.
 
 ## Limiti riconosciuti
 
 - **Non puoi simulare uno screen reader** completo. I check sono testuali/strutturali. Per validazione finale serve test con NVDA / VoiceOver / TalkBack umano.
-- **Non calcoli contrasti automaticamente** dal CSS: se trovi colori inline custom, segnala e chiedi calcolo manuale (oppure verifica con tool esterno tipo Contrast Checker WebAIM).
+- **Il contrasto lo CALCOLI tu** con lo snippet Python di §7 (hai Bash): non stimarlo a occhio, non delegarlo a tool esterni, non "andare a sensazione". Stimare i contrasti è la causa nota di **falsi positivi** (es. bocciare il bianco-a-opacità su blu, che invece passa) e **falsi negativi**. Risali ai colori reali nel CSS (`grep` classe/variabile) e calcola.
 
 ## Anti-pattern che riconosci da lontano (storia di errori PA evitati)
 

--- a/.claude/agents/pc-deploy-validator.md
+++ b/.claude/agents/pc-deploy-validator.md
@@ -78,6 +78,12 @@ Per ogni file in `git diff --name-only HEAD origin/main -- content/comunicazioni
 20. **Animazioni senza `prefers-reduced-motion`**: cerca `@keyframes` non protette da media query reduce.
 21. **Immagini senza `alt`**: `grep -nE '<img[^>]+>' themes/ | grep -v 'alt='`.
 22. **Selettori CSS con `:has()` senza fallback `.is-X`**: comune problema cross-browser, vedi caso galleria-auto.js.
+22b. **Contrasto su isole brand scure** (WCAG 1.4.3) — anti-pattern testo-scuro-su-sfondo-scuro. Candidati: file con un hero/footer scuro che contengono classi pensate per sfondo chiaro:
+   ```bash
+   grep -rlE 'app-page-hero|page-hero|hero-section|it-footer' static themes/flavour-pcgenzano/layouts --include=*.html 2>/dev/null \
+     | xargs grep -lnE 'text-muted|btn-outline-(primary|secondary)' 2>/dev/null
+   ```
+   Per ogni candidato, **verifica se l'anti-pattern è DENTRO il blocco hero/footer scuro** (non su una card a sfondo chiaro nella stessa pagina) e, se sì, **calcola il contrasto** (snippet Python in `pc-accessibility-auditor` § 7): `text-muted` grigio su blu = 2.69:1 / `btn-outline-primary` blu su blu = 2.80:1 → FAIL. Fix: testo bianco + `btn-light`/`btn-outline-light`. ⚠️ Il bianco a opacità su blu PASSA: non è un fail. Incidente /giochi/ 31/05/2026.
 
 ### F. Performance — WARNING
 

--- a/.claude/rules/03-accessibility.md
+++ b/.claude/rules/03-accessibility.md
@@ -33,6 +33,17 @@ Per ogni modifica a template, layout o contenuto, verifica sempre:
 - Non affidarsi solo al colore per veicolare informazioni critiche (es. stato allerta)
 - Dimensioni testo scalabili (usa rem/em, non px fissi)
 
+#### 🔴 Contrasto testo su sfondo colorato — "isole brand" (WCAG 1.4.3)
+
+Le superfici a **sfondo scuro/colorato** del sito (page-hero/`.app-page-hero` blu #003366, footer #003366/#00244d, barre allerta, badge, callout) vogliono **testo chiaro**. **Vietato** metterci sopra classi pensate per sfondo chiaro:
+
+- **MAI** `text-muted` (grigio #6c757d → 2.69:1 su blu, FAIL), `btn-outline-primary` (blu #0d6efd → 2.80:1, FAIL) o `btn-outline-secondary` su hero/footer scuri. Usa testo bianco e, per i pulsanti, `btn-light`/`btn-outline-light`. Incidente 31/05/2026: hero `/giochi/` con `text-muted`+`btn-outline-primary` su blu.
+- **MAI** bianco su arancione `#fd7e14` (2.57:1, FAIL): l'arancione vuole **testo nero** (8.17:1), come la barra gialla.
+- ⚠️ Il **bianco a opacità** su blu **PASSA** (`rgba(255,255,255,0.7)` ≈ 6.9:1): non è un problema, non "correggerlo".
+- **Calcola sempre** il contrasto (non a occhio: causa di falsi positivi/negativi). Difesa CSS attiva: `.app-page-hero .text-muted` è già forzato a chiaro in `static/app-shared/app-common.css`.
+
+Vale anche per le **pagine HTML statiche** (`static/**/index.html`, hero iniettato da `site-chrome.js`). L'agent `pc-accessibility-auditor` § 7 ha lo snippet di calcolo deterministico.
+
 ### Form e controlli
 - Ogni campo ha una `<label>` associata correttamente
 - Errori descritti testualmente, non solo con colore o icona

--- a/static/app-shared/app-common.css
+++ b/static/app-shared/app-common.css
@@ -51,6 +51,10 @@ body:not(.chrome-loaded) > .app-content {
   margin-top: 0.5rem;
   font-size: 1rem;
 }
+/* Contrasto sul hero scuro (WCAG 1.4.3): testo chiaro, mai grigio/blu su blu.
+   Difensivo: qualunque .text-muted dentro l'hero scuro diventa chiaro. */
+.app-page-hero p, .app-page-hero .small, .app-page-hero .arena-hero-hint { position: relative; z-index: 1; }
+.app-page-hero .text-muted, .app-page-hero .arena-hero-hint { color: rgba(255,255,255,0.85) !important; }
 
 @media (max-width: 768px) {
   .app-page-hero h1 { font-size: 1.4rem; }

--- a/static/giochi/index.html
+++ b/static/giochi/index.html
@@ -28,7 +28,7 @@
         </nav>
         <h1>Arena PC Genzano</h1>
         <p class="lead">Tutti i giochi della sicurezza in un colpo d'occhio. Impara le regole della Protezione Civile divertendoti — i tuoi progressi restano sul tuo dispositivo.</p>
-        <p class="mb-0"><a class="btn btn-outline-primary btn-sm" href="/catalogo-giochi/"><i class="bi bi-info-circle me-1" aria-hidden="true"></i>Vai al catalogo informativo dei giochi</a> <span class="text-muted small ms-2">— una scheda per ogni gioco con fascia d'età, durata, obiettivo didattico e accessibilità</span></p>
+        <p class="mb-0"><a class="btn btn-outline-light btn-sm" href="/catalogo-giochi/"><i class="bi bi-info-circle me-1" aria-hidden="true"></i>Vai al catalogo informativo dei giochi</a> <span class="small ms-2 arena-hero-hint">— una scheda per ogni gioco con fascia d'età, durata, obiettivo didattico e accessibilità</span></p>
       </div>
     </div>
 

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -79,7 +79,7 @@ body { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; 
 .allerta-bar-loading { opacity: 0; }
 .allerta-bar-verde { background: #157a3a !important; color: #fff !important; } /* WCAG AA 5.42:1 (era #28a745 = 3.13:1) */
 .allerta-bar-gialla { background: #ffc107 !important; color: #000 !important; }
-.allerta-bar-arancione { background: #fd7e14 !important; color: #fff !important; }
+.allerta-bar-arancione { background: #fd7e14 !important; color: #000 !important; } /* testo nero: WCAG AA 8.17:1 (bianco era 2.57:1, FAIL) */
 .allerta-bar-rossa { background: #dc3545 !important; color: #fff !important; }
 
 .allerta-bar-gialla,
@@ -93,19 +93,20 @@ body { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; 
 
 .allerta-bar-btn { border-radius: 20px; font-size: 0.78rem; padding: 0.25rem 1rem; font-weight: 600; transition: all var(--pc-transition); }
 .allerta-bar-verde .allerta-bar-btn { color: #fff; border-color: rgba(255,255,255,0.5); }
-.allerta-bar-gialla .allerta-bar-btn { color: #000; border-color: rgba(0,0,0,0.3); }
-.allerta-bar-arancione .allerta-bar-btn,
+.allerta-bar-gialla .allerta-bar-btn,
+.allerta-bar-arancione .allerta-bar-btn { color: #000; border-color: rgba(0,0,0,0.35); }
 .allerta-bar-rossa .allerta-bar-btn { color: #fff; border-color: rgba(255,255,255,0.5); }
 .allerta-bar-verde .allerta-bar-btn:hover,
-.allerta-bar-arancione .allerta-bar-btn:hover,
 .allerta-bar-rossa .allerta-bar-btn:hover { background: rgba(255,255,255,0.2); }
-.allerta-bar-gialla .allerta-bar-btn:hover { background: rgba(0,0,0,0.1); }
+.allerta-bar-gialla .allerta-bar-btn:hover,
+.allerta-bar-arancione .allerta-bar-btn:hover { background: rgba(0,0,0,0.1); }
 .allerta-bar-verde .allerta-bar-btn:focus-visible,
-.allerta-bar-arancione .allerta-bar-btn:focus-visible,
 .allerta-bar-rossa .allerta-bar-btn:focus-visible { outline: 3px solid #fff; outline-offset: 2px; background: rgba(0,0,0,0.25); }
-.allerta-bar-gialla .allerta-bar-btn:focus-visible { outline: 3px solid #000; outline-offset: 2px; background: rgba(0,0,0,0.15); }
+.allerta-bar-gialla .allerta-bar-btn:focus-visible,
+.allerta-bar-arancione .allerta-bar-btn:focus-visible { outline: 3px solid #000; outline-offset: 2px; background: rgba(0,0,0,0.15); }
 .allerta-bar-meta { font-size: 0.78rem; opacity: 0.92; margin-top: 0.3rem; padding-top: 0.3rem; border-top: 1px solid rgba(255,255,255,0.2); line-height: 1.4; }
-.allerta-bar-gialla .allerta-bar-meta { border-top-color: rgba(0,0,0,0.18); }
+.allerta-bar-gialla .allerta-bar-meta,
+.allerta-bar-arancione .allerta-bar-meta { border-top-color: rgba(0,0,0,0.18); }
 .allerta-bar-meta a { color: inherit; text-decoration: underline; text-underline-offset: 2px; }
 .allerta-bar-meta a:hover { opacity: 0.85; }
 .allerta-bar-meta a:focus-visible { outline: 2px solid currentColor; outline-offset: 2px; }


### PR DESCRIPTION
Fix /giochi/ hero (text-muted + btn-outline-primary su blu → bianco + btn-outline-light) + regola difensiva app-page-hero. Allerta-bar arancione: bianco su #fd7e14 (2.57:1) → testo nero (8.17:1). Contrasti CALCOLATI (i 'fail' su bianco-a-opacità erano falsi positivi). Hardening: pc-accessibility-auditor §7 con calcolo deterministico + estensione alle pagine statiche; pc-deploy-validator check 22b; rule 03 sezione contrasto isole brand.