### PR TITLE
Infiorata dei Ragazzi 2026: articolo di ringraziamento ai partecipanti

### DIFF
--- a/content/comunicazioni/2026-05-31-infiorata-ragazzi-grazie-partecipanti.md
+++ b/content/comunicazioni/2026-05-31-infiorata-ragazzi-grazie-partecipanti.md
@@ -1,0 +1,57 @@
+---
+title: "Infiorata dei Ragazzi 2026: grazie a chi l'ha resa bella"
+date: 2026-05-31T00:02:00+02:00
+description: "La 22ª Infiorata dei Ragazzi si è svolta a Genzano il 30 e 31 maggio. Grazie ai ragazzi, alle scuole, alle famiglie, ai visitatori e ai nostri volontari."
+badge: "Attività"
+priorita: "normale"
+autore: "Gruppo Comunale Volontari PC Genzano"
+image: ""
+image_alt: ""
+scadenza: ""
+area: "Genzano di Roma"
+allegati: []
+draft: false
+tts: true
+social_citazione: "Un'Infiorata bella si fa in tanti: i ragazzi che disegnano i fiori, le scuole, le famiglie, i visitatori e chi lavora dietro le quinte."
+social_punti:
+  - "22ª Infiorata dei Ragazzi: Genzano di Roma, 30 e 31 maggio 2026."
+  - "Grazie ai ragazzi, alle scuole, alle famiglie, ai visitatori e ai volontari."
+  - "I nostri volontari hanno garantito presenza, informazione e primo soccorso."
+  - "Sulle nostre maglie c'è Olly's, l'associazione che sosteniamo per i bambini farfalla."
+---
+
+La **22ª Infiorata dei Ragazzi** si è svolta a Genzano di Roma il **30 e 31 maggio 2026**. È la versione dei più giovani della nostra festa più conosciuta. Bambini e ragazzi delle scuole disegnano e compongono i loro quadri di fiori lungo la salita di via Italo Belardi: gli stessi luoghi che a giugno ospitano l'Infiorata del Corpus Domini.
+
+Anche quest'anno il **Gruppo Comunale Volontari di Protezione Civile** era presente per dare una mano. Le due giornate sono andate bene: vogliamo dire **grazie** a tutti.
+
+## Grazie a chi l'ha resa bella
+
+Un'Infiorata non nasce da sola. La fanno **i ragazzi** che hanno disegnato e steso i petali, le **scuole** che li hanno guidati e le **famiglie** che li hanno accompagnati. E i **visitatori** arrivati a Genzano per ammirare i quadri. Grazie a ognuno di voi.
+
+Grazie anche a chi lavora dietro le quinte: il **Comune di Genzano di Roma**, che ha coordinato la manifestazione, e tutte le componenti del sistema di soccorso sul percorso.
+
+## Il nostro servizio durante le due giornate
+
+Durante le due giornate i nostri volontari hanno garantito **presenza e assistenza** lungo il percorso:
+
+- informazione ai visitatori su percorsi e accessi
+- presidio delle aree pedonali e dei punti di accesso
+- primo soccorso in collegamento con il 112
+- collegamento radio con la centrale di coordinamento
+
+Il Gruppo opera sempre **a supporto della Polizia Locale e delle Forze dell'Ordine**, sul mandato del Comune. Il nostro servizio **non comprende la regolazione del traffico né i servizi di polizia stradale**: sono compiti di competenza esclusiva degli organi di polizia, come stabilito dagli **articoli 11 e 12 del Codice della Strada** (D.Lgs. 285/1992) e ribadito dalla [Circolare del 6 agosto 2018 del Dipartimento della Protezione Civile](https://www.protezionecivile.gov.it/it/normativa/circolare-del-6-agosto-2018-manifestazioni-pubbliche-precisazioni-sullattivazione-e-limpiego-del-volontariato-di-protezione-civile/) sulle manifestazioni pubbliche.
+
+## Sulle nostre maglie c'è Olly's
+
+Chi ci ha incontrati lungo la via avrà notato una scritta sulle nostre maglie: **"PROTEZIONE CIVILE per Olly's"**. Olly's è un'associazione vicina al nostro Gruppo, dedicata alle persone con **epidermolisi bollosa**: una malattia rara della pelle. I bambini che ne soffrono sono conosciuti come **"bambini farfalla"**, perché la loro pelle è fragile come le ali di una farfalla.
+
+Indossare il loro nome è il nostro modo di **far conoscere e sostenere la loro causa**.
+
+## Sul nostro sito
+
+- [Infiorata di Genzano 2026](/comunicazioni/2026-05-22-infiorata-genzano-2026/) — programma e indicazioni per l'Infiorata del Corpus Domini (13-15 giugno)
+- [Chi siamo](/chi-siamo/) — il Gruppo Comunale Volontari di Protezione Civile di Genzano
+- [Diventa volontario](/diventa-volontario/) — come dare una mano anche tu
+- [Numeri utili](/numeri-utili/) — chi chiamare in ogni situazione
+
+In caso di emergenza il riferimento per il cittadino resta sempre il **112**. Il Gruppo **non è attivabile direttamente dai cittadini**.


### PR DESCRIPTION
Articolo di ringraziamento per la 22ª Infiorata dei Ragazzi (30-31 maggio 2026).

- Badge **Attività**, data `T00:02` (2° articolo del 31/05).
- Ringraziamento a ragazzi, scuole, famiglie, visitatori, volontari e Comune.
- Sezione **Olly's** (epidermolisi bollosa / "bambini farfalla"), associazione che il Gruppo promuove sulle maglie.
- Disclaimer Circolare DPC 6/8/2018 (niente viabilità attribuita al Gruppo).
- `image: ""` → la cover tipografica col titolo viene generata automaticamente al deploy.

⚠️ **Le 3 foto inline non sono incluse**: la sessione cloud non può caricare file binari (`.webp`). Saranno aggiunte appena disponibile un canale di push adeguato. Le immagini sono già pronte (fascia blu applicata).

https://claude.ai/code/session_016m7ZNwEyVL6gnfWxZbicpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMeUnxTp5nVmGL1tUHoAL3)_