### PR TITLE
Fix cruscotto: clic sulla riga apre la scheda terremoto (href doppio escape)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
@@ -75,7 +75,7 @@
   (function(){
     if (typeof L === 'undefined') return;
     var FDSN = 'https://webservices.ingv.it/fdsnws/event/1/query';
-    var SCHEDA = {{ "cruscotto/terremoto/" | relURL | jsonify }};
+    var SCHEDA = {{ "cruscotto/terremoto/" | relURL | jsonify | safeJS }};
     var GENZANO = [41.7085, 12.6916];
     var win = 7, minmag = 1.5, zona = 'italia', eventi = [], markers = null, map = null, markerById = {};
     var BBOX = {

--- a/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
@@ -38,7 +38,7 @@
   <div class="dash-sisma-grid">
     <div id="dash-sisma-mappa" role="application" aria-label="Mappa dei terremoti in Italia nel periodo selezionato, con Genzano di Roma evidenziata."></div>
     <div class="dash-sisma-liste">
-      <p class="dash-aria-nota" style="margin:0 0 .5rem"><span id="dash-conteggio">—</span> · clicca un'intestazione per ordinare, una riga per centrarla sulla mappa.</p>
+      <p class="dash-aria-nota" style="margin:0 0 .5rem"><span id="dash-conteggio">—</span> · clicca un'intestazione per ordinare, una riga per aprire la scheda completa del terremoto.</p>
       <div class="table-responsive">
         <table class="dash-sisma-tabella" id="dash-sisma-tabella">
           <caption class="visually-hidden">Elenco dei terremoti rilevati nel periodo e nell'area selezionati, con data, magnitudo, zona, profondità, latitudine e longitudine. Ordinabile per ogni colonna.</caption>
@@ -143,9 +143,11 @@
       document.getElementById('dash-sisma-mappa').scrollIntoView({behavior:'smooth',block:'nearest'});
     }
     document.getElementById('dash-sisma-tbody').addEventListener('click',function(ev){
-      if(ev.target.closest('a')) return; // click su link "scheda" → naviga, non centrare
+      if(ev.target.closest('a')) return; // link interni gestiscono da soli
       var tr=ev.target.closest('tr[data-ev]'); if(!tr)return;
-      vaiAEvento(parseInt(tr.dataset.ev,10));
+      var e=eventi[parseInt(tr.dataset.ev,10)];
+      if(e&&e.id){ window.location.href = SCHEDA+'#'+e.id; return; } // riga intera → scheda evento
+      vaiAEvento(parseInt(tr.dataset.ev,10));             // fallback: centra sulla mappa
     });
 
     // ordinamento via click sulle intestazioni della tabella
@@ -198,7 +200,7 @@
       var html='';
       for(var i=0;i<max;i++){
         var e=arr[i], k=eventi.indexOf(e);
-        html += '<tr data-ev="'+k+'" title="Centra sulla mappa">'+
+        html += '<tr data-ev="'+k+'" title="Apri la scheda completa del terremoto" style="cursor:pointer">'+
                 '<td class="dash-cell-time">'+pad6(e.time)+'</td>'+
                 '<td><span class="dash-mag" style="border-left-color:'+colore(e.mag)+'">M '+e.mag.toFixed(1)+'</span></td>'+
                 '<td class="dash-cell-place">'+(e.id?'<a class="dash-scheda-link" href="'+SCHEDA+'#'+e.id+'" title="Apri la scheda completa di questo terremoto">'+e.place+'</a>':e.place)+'</td>'+


### PR DESCRIPTION
## Problema
Nel cruscotto sismico (`/cruscotto/`) il clic su una riga della tabella terremoti non apriva la scheda di dettaglio dell'evento: la pagina si ricaricava su sé stessa.

## Causa
La costante JS `SCHEDA` in `dashboard-terremoti.html` era generata con `relURL | jsonify` dentro un blocco `<script>`. Hugo applica un secondo escape JS contestuale ai contenuti dentro `<script>`, producendo:

```js
var SCHEDA = "\"/sito-pc-genzano/cruscotto/terremoto/\"";
```

con le virgolette letterali nel valore. L'href risultante `href=""/sito-pc-genzano/...` veniva letto dal parser HTML come href vuoto + path spezzato in attributi.

## Fix
Aggiunto `| safeJS` (stesso pattern già documentato nella rule 04a per i blocchi `<script>`). Verificato dal vivo con Playwright: l'href è ora `/sito-pc-genzano/cruscotto/terremoto/#<id>` e il clic apre la scheda completa con dati INGV.

## Commit inclusi
- Fix href scheda terremoto (doppio escape jsonify/safeJS)
- Riga intera del terremoto cliccabile
