### PR TITLE
Mappe terremoti: etichetta Genzano di Roma accanto alla stella

### DIFF
--- a/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
@@ -129,7 +129,7 @@
     map.on('blur',  function(){ map.scrollWheelZoom.disable(); });
     L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
       subdomains:'abcd', maxZoom:12, attribution:'© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> © <a href="https://carto.com/attributions">CARTO</a>' }).addTo(map);
-    L.marker(GENZANO, { icon: L.divIcon({className:'dash-stella', html:'<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#003366" stroke="#fff" stroke-width="1.4"/></svg>', iconSize:[22,22], iconAnchor:[11,11]}) }).bindPopup('<strong>Genzano di Roma</strong>').addTo(map);
+    L.marker(GENZANO, { icon: L.divIcon({className:'dash-stella', html:'<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#003366" stroke="#fff" stroke-width="1.4"/></svg>', iconSize:[22,22], iconAnchor:[11,11]}) }).bindTooltip('Genzano di Roma',{permanent:true,direction:'right',offset:[10,0],className:'dash-stella-label'}).bindPopup('<strong>Genzano di Roma</strong>').addTo(map);
     markers = L.layerGroup().addTo(map);
 
     // Stato ordinamento tabella (default: tempo desc come INGV)

--- a/themes/flavour-pcgenzano/layouts/shortcodes/scheda-terremoto.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/scheda-terremoto.html
@@ -172,6 +172,8 @@
 .eq-download li{background:#f4f7fb;border:1px solid #d6e0ec;border-radius:6px;padding:.55rem .8rem}
 .eq-cosa ul{margin:.5rem 0 1rem;padding-left:1.2rem}
 .eq-cosa li{margin-bottom:.4rem}
+.eq-stella-label{background:#003366;color:#fff;border:1px solid #fff;border-radius:4px;font-weight:600;font-size:.78rem;padding:2px 7px;box-shadow:0 1px 3px rgba(0,0,0,.35)}
+.eq-stella-label::before{border-right-color:#003366}
 @media print{.eq-tablist{display:none}.eq-panel[hidden]{display:block!important}#eq-mappa{display:none}}
 </style>
 
@@ -241,7 +243,7 @@
     L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',{subdomains:'abcd',maxZoom:12,attribution:'© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> © <a href="https://carto.com/attributions">CARTO</a>'}).addTo(map);
     var r=Math.max(8,(ev.mag+1)*3);
     L.circleMarker([ev.lat,ev.lon],{radius:r,color:'#333',weight:1,fillColor:magColor(ev.mag),fillOpacity:.8}).addTo(map).bindPopup('<strong>M '+ev.mag.toFixed(1)+'</strong><br>'+ev.place+'<br>prof. '+ev.depth+' km');
-    L.marker(GENZANO,{icon:L.divIcon({className:'eq-stella',html:'<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#003366" stroke="#fff" stroke-width="1.4"/></svg>',iconSize:[22,22],iconAnchor:[11,11]})}).addTo(map).bindPopup('<strong>Genzano di Roma</strong>');
+    L.marker(GENZANO,{icon:L.divIcon({className:'eq-stella',html:'<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#003366" stroke="#fff" stroke-width="1.4"/></svg>',iconSize:[22,22],iconAnchor:[11,11]})}).addTo(map).bindTooltip('Genzano di Roma',{permanent:true,direction:'right',offset:[10,0],className:'eq-stella-label'}).bindPopup('<strong>Genzano di Roma</strong>');
     try{map.fitBounds(L.latLngBounds([ [ev.lat,ev.lon], GENZANO ]).pad(0.4));}catch(e){}
     mapDrawn=true;
     setTimeout(function(){map.invalidateSize();},120);

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6679,6 +6679,8 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 .dash-incendi-box { margin-bottom: .4rem; }
 #dash-incendi-mappa, #dash-sat-mappa, #dash-cams-mappa { height: 520px; border-radius: 8px; border: 2px solid #003366; background: #0b1622; }
 .dash-stella { background: transparent; border: 0; }
+.dash-stella-label { background: #003366; color: #fff; border: 1px solid #fff; border-radius: 4px; font-weight: 600; font-size: .78rem; padding: 2px 7px; box-shadow: 0 1px 3px rgba(0,0,0,.35); }
+.dash-stella-label::before { border-right-color: #003366; }
 @media (max-width: 768px) { #dash-incendi-mappa, #dash-sat-mappa, #dash-cams-mappa { height: 420px; } }
 /* Cruscotto — scheda Vulcani (solo indicatori) */
 .dash-vulcani .dash-sisma-kpi { margin-bottom: .6rem; }


### PR DESCRIPTION
Aggiunta etichetta permanente "Genzano di Roma" accanto alla stella su entrambe le mappe terremoti: scheda del singolo evento (/cruscotto/terremoto/) e mappa del cruscotto sismico (/cruscotto/). Verificato dal vivo con Playwright su entrambe.
