### PR TITLE
Mappe terremoti: etichetta Genzano non copre gli eventi (cliccabili + auto-flip + fade)

### DIFF
--- a/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/dashboard-terremoti.html
@@ -129,7 +129,19 @@
     map.on('blur',  function(){ map.scrollWheelZoom.disable(); });
     L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
       subdomains:'abcd', maxZoom:12, attribution:'© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> © <a href="https://carto.com/attributions">CARTO</a>' }).addTo(map);
-    L.marker(GENZANO, { icon: L.divIcon({className:'dash-stella', html:'<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#003366" stroke="#fff" stroke-width="1.4"/></svg>', iconSize:[22,22], iconAnchor:[11,11]}) }).bindTooltip('Genzano di Roma',{permanent:true,direction:'right',offset:[10,0],className:'dash-stella-label'}).bindPopup('<strong>Genzano di Roma</strong>').addTo(map);
+    var genzMk = L.marker(GENZANO, { icon: L.divIcon({className:'dash-stella', html:'<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#003366" stroke="#fff" stroke-width="1.4"/></svg>', iconSize:[22,22], iconAnchor:[11,11]}) }).bindPopup('<strong>Genzano di Roma</strong>').addTo(map);
+    // Etichetta "Genzano di Roma": non copre mai gli eventi (si sposta sul lato meno affollato),
+    // non intercetta i click (pointer-events:none via CSS) e sbiadisce al passaggio del mouse.
+    var GENZ_ETI='Genzano di Roma';
+    function genzOff(d){return d==='right'?[12,0]:d==='left'?[-12,0]:d==='top'?[0,-12]:[0,12];}
+    function genzBind(dir){ genzMk.unbindTooltip(); genzMk.bindTooltip(GENZ_ETI,{permanent:true,direction:dir,offset:genzOff(dir),className:'dash-stella-label'}); }
+    function genzPts(){ var a=[]; (eventi||[]).forEach(function(e){ try{a.push(map.latLngToContainerPoint([e.lat,e.lon]));}catch(_){} }); return a; }
+    function genzOverlap(dir,pts,mr){ genzBind(dir); var tt=genzMk.getTooltip(),el=tt&&tt.getElement(); if(!el)return 0; var b=el.getBoundingClientRect(),x0=b.left-mr.left-6,y0=b.top-mr.top-6,x1=b.right-mr.left+6,y1=b.bottom-mr.top+6,n=0; pts.forEach(function(p){if(p.x>=x0&&p.x<=x1&&p.y>=y0&&p.y<=y1)n++;}); return n; }
+    function posizionaEtichettaGenzano(){ if(!genzMk||!map)return; try{ var pts=genzPts(),mr=map.getContainer().getBoundingClientRect(),dirs=['right','left','top','bottom'],best='right',bn=Infinity; dirs.forEach(function(d){var n=genzOverlap(d,pts,mr); if(n<bn){bn=n;best=d;}}); genzBind(best);}catch(_){ genzBind('right'); } }
+    genzBind('right');
+    map.on('zoomend moveend', posizionaEtichettaGenzano);
+    map.on('mousemove', function(me){ var tt=genzMk.getTooltip(),el=tt&&tt.getElement(); if(!el)return; var mr=map.getContainer().getBoundingClientRect(),b=el.getBoundingClientRect(),x=me.containerPoint.x,y=me.containerPoint.y; el.classList.toggle('is-faded', x>=b.left-mr.left-4&&x<=b.right-mr.left+4&&y>=b.top-mr.top-4&&y<=b.bottom-mr.top+4); });
+    map.on('mouseout', function(){ var tt=genzMk.getTooltip(),el=tt&&tt.getElement(); if(el)el.classList.remove('is-faded'); });
     markers = L.layerGroup().addTo(map);
 
     // Stato ordinamento tabella (default: tempo desc come INGV)
@@ -254,6 +266,7 @@
           cm.addTo(markers); markerById[i]=cm;
         } catch(err) { /* aggira eventuali corner case Leaflet residui */ }
       });
+      try{ posizionaEtichettaGenzano(); }catch(e){}
     }
 
     function carica(retry){

--- a/themes/flavour-pcgenzano/layouts/shortcodes/scheda-terremoto.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/scheda-terremoto.html
@@ -172,8 +172,12 @@
 .eq-download li{background:#f4f7fb;border:1px solid #d6e0ec;border-radius:6px;padding:.55rem .8rem}
 .eq-cosa ul{margin:.5rem 0 1rem;padding-left:1.2rem}
 .eq-cosa li{margin-bottom:.4rem}
-.eq-stella-label{background:#003366;color:#fff;border:1px solid #fff;border-radius:4px;font-weight:600;font-size:.78rem;padding:2px 7px;box-shadow:0 1px 3px rgba(0,0,0,.35)}
-.eq-stella-label::before{border-right-color:#003366}
+.eq-stella-label{background:#003366;color:#fff;border:1px solid #fff;border-radius:4px;font-weight:600;font-size:.78rem;padding:2px 7px;box-shadow:0 1px 3px rgba(0,0,0,.35);pointer-events:none;transition:opacity .15s ease}
+.eq-stella-label.is-faded{opacity:.12}
+.eq-stella-label.leaflet-tooltip-right::before{border-right-color:#003366}
+.eq-stella-label.leaflet-tooltip-left::before{border-left-color:#003366}
+.eq-stella-label.leaflet-tooltip-top::before{border-top-color:#003366}
+.eq-stella-label.leaflet-tooltip-bottom::before{border-bottom-color:#003366}
 @media print{.eq-tablist{display:none}.eq-panel[hidden]{display:block!important}#eq-mappa{display:none}}
 </style>
 
@@ -243,8 +247,20 @@
     L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',{subdomains:'abcd',maxZoom:12,attribution:'© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> © <a href="https://carto.com/attributions">CARTO</a>'}).addTo(map);
     var r=Math.max(8,(ev.mag+1)*3);
     L.circleMarker([ev.lat,ev.lon],{radius:r,color:'#333',weight:1,fillColor:magColor(ev.mag),fillOpacity:.8}).addTo(map).bindPopup('<strong>M '+ev.mag.toFixed(1)+'</strong><br>'+ev.place+'<br>prof. '+ev.depth+' km');
-    L.marker(GENZANO,{icon:L.divIcon({className:'eq-stella',html:'<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#003366" stroke="#fff" stroke-width="1.4"/></svg>',iconSize:[22,22],iconAnchor:[11,11]})}).addTo(map).bindTooltip('Genzano di Roma',{permanent:true,direction:'right',offset:[10,0],className:'eq-stella-label'}).bindPopup('<strong>Genzano di Roma</strong>');
+    var gMk=L.marker(GENZANO,{icon:L.divIcon({className:'eq-stella',html:'<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 26 26" aria-hidden="true"><path d="M13 1l3.4 7.6L24 9.3l-5.8 5 1.8 7.9L13 18.4 5.9 22.2l1.8-7.9L2 9.3l7.6-.7z" fill="#003366" stroke="#fff" stroke-width="1.4"/></svg>',iconSize:[22,22],iconAnchor:[11,11]})}).addTo(map).bindPopup('<strong>Genzano di Roma</strong>');
     try{map.fitBounds(L.latLngBounds([ [ev.lat,ev.lon], GENZANO ]).pad(0.4));}catch(e){}
+    // Etichetta "Genzano di Roma": non copre mai l'epicentro (si sposta sul lato libero),
+    // non intercetta i click (pointer-events:none via CSS) e sbiadisce al passaggio del mouse.
+    var ETI='Genzano di Roma';
+    function offFor(d){return d==='right'?[12,0]:d==='left'?[-12,0]:d==='top'?[0,-12]:[0,12];}
+    function bindGenzLabel(dir){ gMk.unbindTooltip(); gMk.bindTooltip(ETI,{permanent:true,direction:dir,offset:offFor(dir),className:'eq-stella-label'}); }
+    function ptsEventi(){ try{return [map.latLngToContainerPoint([ev.lat,ev.lon])];}catch(_){return [];} }
+    function overlapN(dir,pts,mr){ bindGenzLabel(dir); var tt=gMk.getTooltip(),el=tt&&tt.getElement(); if(!el)return 0; var b=el.getBoundingClientRect(),x0=b.left-mr.left-6,y0=b.top-mr.top-6,x1=b.right-mr.left+6,y1=b.bottom-mr.top+6,n=0; pts.forEach(function(p){if(p.x>=x0&&p.x<=x1&&p.y>=y0&&p.y<=y1)n++;}); return n; }
+    function posizionaEtichetta(){ if(!gMk)return; try{ var pts=ptsEventi(),mr=map.getContainer().getBoundingClientRect(),dirs=['right','left','top','bottom'],best='right',bn=Infinity; dirs.forEach(function(d){var n=overlapN(d,pts,mr); if(n<bn){bn=n;best=d;}}); bindGenzLabel(best);}catch(_){ bindGenzLabel('right'); } }
+    posizionaEtichetta();
+    map.on('zoomend moveend', posizionaEtichetta);
+    map.on('mousemove', function(me){ var tt=gMk.getTooltip(),el=tt&&tt.getElement(); if(!el)return; var mr=map.getContainer().getBoundingClientRect(),b=el.getBoundingClientRect(),x=me.containerPoint.x,y=me.containerPoint.y; el.classList.toggle('is-faded', x>=b.left-mr.left-4&&x<=b.right-mr.left+4&&y>=b.top-mr.top-4&&y<=b.bottom-mr.top+4); });
+    map.on('mouseout', function(){ var tt=gMk.getTooltip(),el=tt&&tt.getElement(); if(el)el.classList.remove('is-faded'); });
     mapDrawn=true;
     setTimeout(function(){map.invalidateSize();},120);
   }

--- a/themes/flavour-pcgenzano/static/css/custom.css
+++ b/themes/flavour-pcgenzano/static/css/custom.css
@@ -6679,8 +6679,12 @@ html.a11y-pause-anim .consulta-rapida .cr-card:hover { transform: none; }
 .dash-incendi-box { margin-bottom: .4rem; }
 #dash-incendi-mappa, #dash-sat-mappa, #dash-cams-mappa { height: 520px; border-radius: 8px; border: 2px solid #003366; background: #0b1622; }
 .dash-stella { background: transparent; border: 0; }
-.dash-stella-label { background: #003366; color: #fff; border: 1px solid #fff; border-radius: 4px; font-weight: 600; font-size: .78rem; padding: 2px 7px; box-shadow: 0 1px 3px rgba(0,0,0,.35); }
-.dash-stella-label::before { border-right-color: #003366; }
+.dash-stella-label { background: #003366; color: #fff; border: 1px solid #fff; border-radius: 4px; font-weight: 600; font-size: .78rem; padding: 2px 7px; box-shadow: 0 1px 3px rgba(0,0,0,.35); pointer-events: none; transition: opacity .15s ease; }
+.dash-stella-label.is-faded { opacity: .12; }
+.dash-stella-label.leaflet-tooltip-right::before { border-right-color: #003366; }
+.dash-stella-label.leaflet-tooltip-left::before { border-left-color: #003366; }
+.dash-stella-label.leaflet-tooltip-top::before { border-top-color: #003366; }
+.dash-stella-label.leaflet-tooltip-bottom::before { border-bottom-color: #003366; }
 @media (max-width: 768px) { #dash-incendi-mappa, #dash-sat-mappa, #dash-cams-mappa { height: 420px; } }
 /* Cruscotto — scheda Vulcani (solo indicatori) */
 .dash-vulcani .dash-sisma-kpi { margin-bottom: .6rem; }


### PR DESCRIPTION
Etichetta "Genzano di Roma" sulle mappe terremoti: non copre piu gli eventi e li lascia cliccabili.

- pointer-events:none: gli eventi sotto restano sempre cliccabili.
- Auto-posizionamento sul lato meno affollato (right/left/top/bottom), ricalcolato a ogni render/zoom/spostamento.
- Sbiadisce al passaggio del mouse per vedere e cliccare l evento sottostante.

Verificato dal vivo con Playwright su cruscotto (104 eventi, 0 sovrapposizioni) e scheda.
