### PR TITLE
Roadmap benchmark — ondata 1: comunicazione del rischio

### DIFF
--- a/content/allerte-meteo/_index.md
+++ b/content/allerte-meteo/_index.md
@@ -102,6 +102,10 @@ Il codice colore dipende dagli effetti attesi, non solo dalla quantità di piogg
 
 ## Significato dei codici colore
 
+{{< callout tipo="avviso" titolo="Verde non vuol dire rischio zero" >}}
+L'assenza di allerta significa che **non sono previsti fenomeni significativi**, non che il rischio sia nullo. La preparazione si fa **prima**, quando il cielo è sereno: tieni pronto il [kit di emergenza](/rischi-prevenzione/kit-emergenza/), conosci le aree di attesa del tuo quartiere e compila il [Piano Familiare](/piano-familiare/). Quando arriva l'allerta è troppo tardi per organizzarsi.
+{{< /callout >}}
+
 ### <span class="badge badge-allerta-verde">VERDE</span> — Nessuna allerta
 
 {{< pittogramma src="/pittogrammi/arasaac/calma.png" alt="Pittogramma: situazione di calma" size="small" inline="true" >}} Non sono previsti fenomeni significativi.

--- a/content/rischi-prevenzione/_index.md
+++ b/content/rischi-prevenzione/_index.md
@@ -31,9 +31,20 @@ Queste pagine aiutano a orientarsi in pochi minuti, anche senza conoscenze tecni
 {{< link-card url="/rischi-prevenzione/dopo-emergenza/" icon="bi-house-check" titolo="Dopo l'emergenza" desc="Rientro sicuro, verifica di gas, luce e acqua, animali e notizie false quando l'evento è passato." >}}
 </div>
 
+## I più cercati
+
+Le quattro schede più consultate per il nostro territorio. Parti da qui se non sai da dove cominciare.
+
+<div class="consulta-rapida">
+{{< link-card url="/rischi-prevenzione/rischio-sismico/" icon="bi-activity" titolo="Rischio sismico" desc="Cosa fare prima, durante e dopo una scossa. Zona sismica 2B, Colli Albani." >}}
+{{< link-card url="/rischi-prevenzione/rischio-idrogeologico/" icon="bi-water" titolo="Rischio idrogeologico" desc="Piogge intense, allagamenti, frane e smottamenti: il rischio più probabile in zona." >}}
+{{< link-card url="/rischi-prevenzione/rischio-incendio/" icon="bi-fire" titolo="Rischio incendio" desc="Incendi boschivi e di interfaccia. Campagna AIB giugno-settembre, Zona 9." >}}
+{{< link-card url="/rischi-prevenzione/ondate-di-calore/" icon="bi-thermometer-sun" titolo="Caldo e ondate di calore" desc="Come proteggere anziani, bambini e persone fragili durante le ondate di calore." >}}
+</div>
+
 ## Principali rischi
 
-Consulta la scheda del rischio che ti interessa.
+Consulta la scheda completa del rischio che ti interessa.
 
 | Rischio | Quando usarla | Pagina |
 |---|---|---|

--- a/content/rischi-prevenzione/blackout.md
+++ b/content/rischi-prevenzione/blackout.md
@@ -13,6 +13,8 @@ howto_dopo: "Riaccendi gli elettrodomestici uno alla volta per evitare sovraccar
 ---
 Un blackout può durare ore. Gli eventi meteorologici estremi, i guasti alla rete e i sovraccarichi ne sono le cause più frequenti. Chi usa apparecchiature elettromedicali è esposto a rischi aggiuntivi: prepararsi in anticipo riduce i danni.
 
+{{< emergenza-ora >}}
+
 ## <i class="bi bi-info-circle-fill text-primary me-2" aria-hidden="true"></i>Perché è rilevante sul nostro territorio {#perche-rilevante}
 A Genzano di Roma la rete di distribuzione attraversa aree boschive e collinari. Durante eventi meteo intensi, alberi e rami caduti sulle linee elettriche causano interruzioni frequenti.
 

--- a/content/rischi-prevenzione/ondate-di-calore.md
+++ b/content/rischi-prevenzione/ondate-di-calore.md
@@ -13,6 +13,8 @@ howto_dopo: "Se qualcuno mostra sintomi di colpo di calore, chiama il 112 immedi
 ---
 Il caldo estremo prolungato mette a rischio la vita, soprattutto degli anziani, dei bambini piccoli e di chi ha patologie croniche. Ogni estate il Ministero della Salute attiva la sorveglianza sulle ondate di calore: seguire i bollettini ufficiali e adottare pochi comportamenti corretti può prevenire conseguenze gravi.
 
+{{< emergenza-ora >}}
+
 ## <i class="bi bi-info-circle-fill text-primary me-2" aria-hidden="true"></i>Perché è rilevante sul nostro territorio {#perche-rilevante}
 Genzano di Roma, pur trovandosi in area collinare, è soggetta a ondate di calore intense da giugno ad agosto. Le temperature possono superare i 38-40°C. Gli effetti più gravi colpiscono anziani, bambini piccoli e persone con patologie croniche.
 

--- a/content/rischi-prevenzione/rischio-idrogeologico.md
+++ b/content/rischi-prevenzione/rischio-idrogeologico.md
@@ -15,6 +15,8 @@ howto_dopo: "Non rientrare in casa finché le autorità non lo autorizzano. Non 
 ---
 Il rischio idrogeologico riguarda alluvioni, allagamenti, frane e smottamenti. Piogge intense e persistenti possono innescarli anche in poche ore.
 
+{{< emergenza-ora >}}
+
 ## <i class="bi bi-info-circle-fill text-primary me-2" aria-hidden="true"></i>Perché è rilevante sul nostro territorio {#perche-rilevante}
 Genzano di Roma si trova su un territorio collinare di origine vulcanica, con versanti che possono essere soggetti a frane e smottamenti, soprattutto quando il terreno è saturo d'acqua. Le aree più basse del territorio e le zone lungo i fossi possono essere interessate da allagamenti durante piogge intense. Il rischio aumenta nei periodi autunnali e primaverili.
 

--- a/content/rischi-prevenzione/rischio-incendio.md
+++ b/content/rischi-prevenzione/rischio-incendio.md
@@ -14,6 +14,8 @@ howto_dopo: "Non accedere alla zona percorsa dal fuoco: possono esserci tronchi 
 ---
 L'incendio boschivo divampa in aree vegetate — boschi, macchia mediterranea, terreni incolti — e si propaga rapidamente per effetto del vento, della siccità e della vegetazione secca. Nella grande maggioranza dei casi, comportamenti umani imprudenti o dolosi ne sono la causa.
 
+{{< emergenza-ora >}}
+
 ## <i class="bi bi-info-circle-fill text-primary me-2" aria-hidden="true"></i>Perché è rilevante sul nostro territorio {#perche-rilevante}
 Genzano di Roma è parzialmente compresa nel Parco Regionale dei Castelli Romani, con ampie aree boschive e di macchia mediterranea. Il periodo di massimo rischio va da giugno a settembre: siccità prolungata e venti caldi possono trasformare una piccola fiamma in un incendio devastante. Il nostro Gruppo partecipa attivamente alle campagne antincendio boschivo (AIB).
 

--- a/content/rischi-prevenzione/rischio-sismico.md
+++ b/content/rischi-prevenzione/rischio-sismico.md
@@ -14,6 +14,8 @@ howto_dopo: "Assicurati dello stato di salute delle persone intorno a te. Esci c
 ---
 Il terremoto non si può prevedere. L'unica difesa è prepararsi prima: sapere cosa fare, avere il kit pronto, conoscere le vie di fuga.
 
+{{< emergenza-ora >}}
+
 ## <i class="bi bi-broadcast text-primary me-2" aria-hidden="true"></i>Terremoti recenti in Italia {#terremoti-recenti}
 Mappa e lista degli eventi sismici recenti rilevati dall'**Istituto Nazionale di Geofisica e Vulcanologia (INGV)** — fonte scientifica ufficiale in Italia. La vista mostra tutti i terremoti localizzati sul territorio nazionale; usa il menu interno per filtrare per magnitudo, profondità e periodo.
 

--- a/content/rischi-prevenzione/rischio-vulcanico.md
+++ b/content/rischi-prevenzione/rischio-vulcanico.md
@@ -16,6 +16,8 @@ Il **Vulcano Laziale** dei **Colli Albani** è **quiescente**, non spento. Secon
 
 Questa pagina descrive i fenomeni concreti che il cittadino può incontrare — in particolare le **emissioni di anidride carbonica (CO₂)** — e cosa fare.
 
+{{< emergenza-ora >}}
+
 ## <i class="bi bi-info-circle-fill text-primary me-2" aria-hidden="true"></i>Perché è rilevante sul nostro territorio {#perche-rilevante}
 Il **Vulcano Laziale** ha una storia eruttiva di oltre 600.000 anni. Le sue eruzioni hanno costruito tutto il paesaggio dei Castelli Romani: i rilievi del **Tuscolano-Artemisio**, le caldere di **Albano** e **Nemi** (oggi laghi), la **Faete**, i banchi di tufo su cui sorgono Genzano, Ariccia, Velletri.
 

--- a/content/rischi-prevenzione/temporali-intensi.md
+++ b/content/rischi-prevenzione/temporali-intensi.md
@@ -14,6 +14,8 @@ howto_dopo: "Presta attenzione a cavi elettrici caduti o danneggiati. Non entrar
 ---
 I temporali intensi portano piogge forti, fulmini, grandine e raffiche di vento improvvise. Si formano in pochi minuti, soprattutto tra maggio e ottobre e durante i cambi di stagione.
 
+{{< emergenza-ora >}}
+
 ## <i class="bi bi-lightning-charge-fill text-primary me-2" aria-hidden="true"></i>Fulmini in tempo reale {#fulmini-realtime}
 Mappa dei fulmini rilevati in Europa, aggiornata in tempo reale dalla rete volontaria **Blitzortung / Lightning Maps**. Utile quando è in corso un temporale per capire dove si sta muovendo la cella e quanto è distante.
 

--- a/content/rischi-prevenzione/vento-forte.md
+++ b/content/rischi-prevenzione/vento-forte.md
@@ -14,6 +14,8 @@ howto_dopo: "Segnala al 112 situazioni di pericolo (alberi caduti su strade, cav
 ---
 Il vento forte colpisce spesso i Castelli Romani, soprattutto in autunno e in inverno. Le raffiche violente possono abbattere alberi, rami e tegole, con rischi seri per le persone e i veicoli.
 
+{{< emergenza-ora >}}
+
 ## <i class="bi bi-info-circle-fill text-primary me-2" aria-hidden="true"></i>Perché è rilevante sul nostro territorio {#perche-rilevante}
 Genzano di Roma si trova in un'area collinare esposta ai venti, in particolare durante le perturbazioni atlantiche. La presenza di alberature storiche lungo le strade comunali e nei parchi aumenta il rischio di caduta rami, soprattutto in caso di terreno inzuppato dalle piogge.
 

--- a/data/codici_colore.yaml
+++ b/data/codici_colore.yaml
@@ -21,7 +21,7 @@ codici:
   - livello: "arancione"
     titolo: "Allerta Arancione — Livello di Preallarme"
     colore_bg: "#fd7e14"
-    colore_testo: "#fff"
+    colore_testo: "#000"  # nero su arancione = 8.17:1 (WCAG AA). Bianco su #fd7e14 = 2.57:1 FAIL (rule 03)
     significato: "Criticità moderata. I fenomeni previsti possono essere diffusi e potenzialmente pericolosi."
     cosa_fare: "Limita gli spostamenti allo stretto necessario. Metti in sicurezza beni in locali interrati. Tieni pronto il kit di emergenza. Segui le indicazioni delle autorità."
     icona: "bi-exclamation-triangle-fill"

--- a/themes/flavour-pcgenzano/layouts/shortcodes/emergenza-ora.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/emergenza-ora.html
@@ -1,0 +1,16 @@
+{{- /* emergenza-ora: callout standard "Sei in pericolo adesso?" che intercetta chi è
+       in emergenza anche sulle pagine fredde di prevenzione (pattern FEMA "survivor box").
+       Usa il componente callout NATIVO di Bootstrap Italia (nessun CSS custom).
+       Uso autore: {{< emergenza-ora >}} — nessun parametro. */ -}}
+{{- $sprite := "vendor/bootstrap-italia/svg/sprites.svg" | relURL -}}
+{{- $emerg := "emergenza/" | relURL -}}
+<div class="callout danger" role="note">
+  <div class="callout-inner">
+    <div class="callout-title">
+      <svg class="icon" aria-hidden="true"><use href="{{ $sprite }}#it-error"></use></svg>
+      <span>Sei in pericolo in questo momento?</span>
+    </div>
+    <p>Se c'è un pericolo immediato per le persone — incendio, crollo, allagamento, persona ferita — <strong>chiama subito il <a href="tel:112">112</a></strong>, il numero unico di emergenza. Questa pagina serve a prepararsi <em>prima</em>: non sostituisce la chiamata di soccorso.</p>
+    <p class="mb-0">Hai poca rete? Le informazioni essenziali sono nella <a href="{{ $emerg }}">pagina Emergenza</a>, leggera e veloce.</p>
+  </div>
+</div>


### PR DESCRIPTION
Ondata 1 della roadmap emersa dal benchmark di 26 siti di protezione civile (Italia + mondo).

Pattern best-of-breed applicati:
- Shortcode emergenza-ora (FEMA "survivor box") sulle 8 pagine rischio.
- "Verde non vuol dire rischio zero" su /allerte-meteo/ (JMA).
- "I più cercati" sull hub rischi (Canada) + fix refuso.
- Fix contrasto WCAG arancione in codici_colore.yaml (rule 03).

Verificato: build pulita + Playwright.
