### PR TITLE
Roadmap benchmark — ondata 5: mappa sede self-hosted (privacy /contatti/)

### DIFF
--- a/content/contatti/_index.md
+++ b/content/contatti/_index.md
@@ -107,7 +107,7 @@ Segui i canali ufficiali per aggiornamenti, allerte e comunicazioni del Gruppo.
 
 ## Mappa della sede
 
-{{< mappa-punto lat="41.7075" lon="12.6895" zoom="16" label="Sede del Gruppo Comunale Volontari di Protezione Civile — Via Sicilia 13-15, Genzano di Roma" >}}
+{{< mappa-punto lat="41.70273" lon="12.69588" zoom="17" label="Sede del Gruppo Comunale Volontari di Protezione Civile — Via Sicilia 13-15, Genzano di Roma" >}}
 
 <p><strong>Sede:</strong> Via Sicilia, 13-15 — 00045 Genzano di Roma (RM).</p>
 

--- a/content/contatti/_index.md
+++ b/content/contatti/_index.md
@@ -107,13 +107,9 @@ Segui i canali ufficiali per aggiornamenti, allerte e comunicazioni del Gruppo.
 
 ## Mappa della sede
 
-<div class="ratio ratio-16x9 mb-4">
-<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2978.5!2d12.6895!3d41.7075!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2zNDHCsDQyJzI3LjAiTiAxMsKwNDEnMjIuMiJF!5e0!3m2!1sit!2sit!4v1" title="Mappa della sede del Gruppo di Protezione Civile" loading="lazy" allowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
-</div>
+{{< mappa-punto lat="41.7075" lon="12.6895" zoom="16" label="Sede del Gruppo Comunale Volontari di Protezione Civile — Via Sicilia 13-15, Genzano di Roma" >}}
 
-<noscript>
-<p><strong>Sede:</strong> Via Sicilia, 13-15 — 00045 Genzano di Roma (RM). La mappa interattiva richiede JavaScript per essere visualizzata.</p>
-</noscript>
+<p><strong>Sede:</strong> Via Sicilia, 13-15 — 00045 Genzano di Roma (RM).</p>
 
 ## Vedi anche
 

--- a/themes/flavour-pcgenzano/layouts/shortcodes/mappa-punto.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/mappa-punto.html
@@ -1,0 +1,31 @@
+{{- /* mappa-punto: mini-mappa Leaflet self-hosted di un singolo punto (es. la sede).
+       Privacy-first: niente Google Maps, solo tile OpenStreetMap + Leaflet self-hosted
+       (static/vendor/leaflet/). Sostituisce gli iframe Google che inviano dati a Google al view.
+       Uso: {{< mappa-punto lat="41.7075" lon="12.6895" zoom="16" label="Sede — Via Sicilia 13-15" >}} */ -}}
+{{- $lat := .Get "lat" -}}
+{{- $lon := .Get "lon" -}}
+{{- $zoom := .Get "zoom" | default "16" -}}
+{{- $label := .Get "label" | default "Sede del Gruppo" -}}
+{{- $leafletCSS := "vendor/leaflet/leaflet.css" | relURL -}}
+{{- $leafletJS  := "vendor/leaflet/leaflet.js"  | relURL -}}
+{{- $id := printf "mappa-punto-%s" (substr (md5 (printf "%s,%s" $lat $lon)) 0 8) -}}
+<link rel="stylesheet" href="{{ $leafletCSS }}" crossorigin="">
+<style>
+.mappa-punto{height:380px;width:100%;border-radius:8px;border:2px solid #003366;box-shadow:0 4px 12px rgba(0,0,0,0.08);background:#eaeaea}
+@media (max-width:575px){.mappa-punto{height:300px}}
+.mappa-punto-credit{font-size:.8rem;color:#6c757d;margin:.4rem 0 0}
+</style>
+<div id="{{ $id }}" class="mappa-punto" role="application" aria-label="Mappa di {{ $label }} (OpenStreetMap)"></div>
+<p class="mappa-punto-credit">Mappa: <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">© OpenStreetMap contributors</a> — Leaflet self-hosted. <a href="https://www.openstreetmap.org/?mlat={{ $lat }}&mlon={{ $lon }}#map={{ $zoom }}/{{ $lat }}/{{ $lon }}" target="_blank" rel="noopener noreferrer">Apri su OpenStreetMap</a></p>
+<script src="{{ $leafletJS }}" crossorigin=""></script>
+<script>
+(function(){
+  var el=document.getElementById({{ $id | jsonify | safeJS }}); if(!el||typeof L==='undefined')return;
+  var lat={{ $lat }}, lon={{ $lon }};
+  var m=L.map(el,{scrollWheelZoom:false}).setView([lat,lon],{{ $zoom }});
+  m.on('focus',function(){m.scrollWheelZoom.enable();});
+  m.on('blur',function(){m.scrollWheelZoom.disable();});
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19,attribution:'© OpenStreetMap'}).addTo(m);
+  L.marker([lat,lon]).addTo(m).bindPopup({{ $label | jsonify | safeJS }}).openPopup();
+})();
+</script>


### PR DESCRIPTION
Ondata 5: mappa sede self-hosted (fix privacy /contatti/).

- Iframe Google Maps (invio dati a Google al view, GDPR) sostituito con shortcode mappa-punto: Leaflet self-hosted + tile OSM, niente terze parti.
- Coordinate sede corrette e verificate via Nominatim/OSM (Via Sicilia 13).

Verificato con Playwright (tile OSM + marker, 0 iframe Google, reverse-geocode = Via Sicilia 13).
