### PR TITLE
Roadmap benchmark — ondata 6: Google News sitemap + CLS foto

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -483,7 +483,7 @@ enableGitInfo = true
 
 # Impostazioni di output
 [outputs]
-home = ["HTML", "RSS", "JSON", "BUILDINFO"]
+home = ["HTML", "RSS", "JSON", "BUILDINFO", "NEWSSITEMAP"]
 
 # Formato output per /build-info.js — timestamp della build Hugo
 # usato dalle pagine statiche (giochi, quizpc, formazionepc, ecc.)
@@ -496,6 +496,15 @@ home = ["HTML", "RSS", "JSON", "BUILDINFO"]
   baseName = "build-info"
   isPlainText = true
   notAlternative = true
+
+# Sitemap Google News — solo articoli /comunicazioni/ degli ultimi 2 giorni
+# (requisito Google News). Da inviare in Search Console. Template: index.newssitemap.xml
+[outputFormats.NEWSSITEMAP]
+  mediaType = "application/xml"
+  baseName = "news-sitemap"
+  isPlainText = true
+  notAlternative = true
+  rel = "sitemap"
 
 # Sitemap
 [sitemap]

--- a/themes/flavour-pcgenzano/layouts/index.newssitemap.xml
+++ b/themes/flavour-pcgenzano/layouts/index.newssitemap.xml
@@ -1,0 +1,20 @@
+{{- /* Sitemap Google News: SOLO articoli /comunicazioni/ pubblicati negli ultimi 2 giorni
+   (requisito Google News: niente articoli più vecchi di 48 ore). Gli articoli -facile (A2)
+   sono già esclusi da RegularPages via build.list:never. Da inviare in Search Console. */ -}}
+{{- $soglia := now.AddDate 0 0 -2 -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+{{- range (where (where .Site.RegularPages "Section" "comunicazioni") "Date" "ge" $soglia) }}
+  <url>
+    <loc>{{ .Permalink }}</loc>
+    <news:news>
+      <news:publication>
+        <news:name>Protezione Civile Genzano di Roma</news:name>
+        <news:language>it</news:language>
+      </news:publication>
+      <news:publication_date>{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}</news:publication_date>
+      <news:title>{{ .Title | plainify | htmlEscape }}</news:title>
+    </news:news>
+  </url>
+{{- end }}
+</urlset>

--- a/themes/flavour-pcgenzano/layouts/shortcodes/foto.html
+++ b/themes/flavour-pcgenzano/layouts/shortcodes/foto.html
@@ -23,6 +23,14 @@
 {{- if or (not $src) (not $alt) -}}
   {{- errorf "shortcode foto: parametri 'src' e 'alt' sono obbligatori (chiamato in %s)" .Page.File.Path -}}
 {{- end -}}
+{{- /* width/height reali per riservare lo spazio ed evitare il layout shift (CLS, Core Web Vital).
+       Letti dal file statico con imageConfig, solo per formati raster esistenti (no SVG/mancanti). */ -}}
+{{- $w := 0 }}{{- $h := 0 -}}
+{{- $ext := lower (path.Ext $src) -}}
+{{- $statpath := printf "static%s" $src -}}
+{{- if and (in (slice ".webp" ".jpg" ".jpeg" ".png" ".gif") $ext) (fileExists $statpath) -}}
+  {{- with (imageConfig $statpath) -}}{{- $w = .Width }}{{- $h = .Height -}}{{- end -}}
+{{- end -}}
 <figure class="figure my-4 w-100 text-center">
   <a href="{{ $src | relURL }}"
      target="_blank"
@@ -32,7 +40,7 @@
     <img src="{{ $src | relURL }}"
          alt="{{ $alt }}"
          class="figure-img img-fluid rounded shadow-sm"
-         loading="lazy">
+         {{ if and (gt $w 0) (gt $h 0) }}width="{{ $w }}" height="{{ $h }}" {{ end }}loading="lazy">
   </a>
   {{- with $caption }}
   <figcaption class="figure-caption text-center mt-2">{{ . | markdownify }}</figcaption>


### PR DESCRIPTION
Ondata 6: tecnici SEO + performance.
- Sitemap Google News (/news-sitemap.xml, ultimi 2 giorni) da inviare in Search Console.
- CLS: width/height reali sulle foto inline via imageConfig (89/100). Cover gia a posto.
Build pulita + Playwright.
