### PR TITLE
Referente web e comunicazione istituzionale + icona Comune

### DIFF
--- a/content/metodo-editoriale/_index.md
+++ b/content/metodo-editoriale/_index.md
@@ -10,6 +10,8 @@ Questa pagina spiega **come lavoriamo**. Vogliamo che ogni cittadino, ma anche o
 
 Il sito è curato dal **Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma**, articolazione del Comune di Genzano di Roma iscritta al RUNTS come Ente del Terzo Settore. Non siamo un'autorità di protezione civile: traduciamo in linguaggio chiaro le indicazioni delle autorità competenti e le adattiamo al nostro territorio, citando sempre la fonte.
 
+Il sito è ideato, realizzato e gestito da **Alessandro Cuollo** (nominativo radio "Alfa 19", indicativo radioamatoriale **IU0QVW**), in qualità di **Referente Web e Comunicazione Istituzionale** del Gruppo.
+
 ## Le nostre fonti, in ordine di priorità {#fonti}
 
 Quando le fonti dicono cose diverse, prevale quella di livello superiore.

--- a/content/note-legali/_index.md
+++ b/content/note-legali/_index.md
@@ -2,7 +2,7 @@
 title: "Note Legali"
 description: "Informazioni legali sul sito web della Protezione Civile di Genzano di Roma."
 layout: "single"
-dataUltimaRevisione: "2026-05-29"
+dataUltimaRevisione: "2026-06-02"
 ---
 
 ## Titolarità del sito
@@ -11,9 +11,9 @@ Il presente sito web è di proprietà del **Gruppo Comunale Volontari di Protezi
 
 Iscritto al RUNTS, sezione "Altri Enti del Terzo Settore", con determina n. G14230 del 28/10/2024.
 
-## Referente web del Gruppo
+## Referente web e comunicazione istituzionale
 
-Il sito è ideato, realizzato e gestito da **Alessandro Cuollo** (nominativo radio "Alfa 19", indicativo radioamatoriale **IU0QVW**), in qualità di **Referente Web del Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma**.
+Il sito è ideato, realizzato e gestito da **Alessandro Cuollo** (nominativo radio "Alfa 19", indicativo radioamatoriale **IU0QVW**), in qualità di **Referente Web e Comunicazione Istituzionale del Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma**.
 
 Per segnalazioni di malfunzionamenti, errori nei contenuti o richieste di aggiornamento: [segreteria@protezionecivilegenzano.it](mailto:segreteria@protezionecivilegenzano.it).
 

--- a/content/per-gli-enti/_index.md
+++ b/content/per-gli-enti/_index.md
@@ -34,7 +34,7 @@ Se rappresenti un altro gruppo o un'associazione dei Castelli Romani e vuoi cost
 
 Il Gruppo collabora con il **Coordinamento FE.PI.VOL. — Federazione Pronto Intervento Volontariato ODV**, partecipando alle sue **iniziative** e alle **attività di addestramento**. Far parte di una rete di coordinamento permette ai volontari di formarsi insieme ad altri gruppi, condividere procedure comuni e crescere in capacità operativa.
 
-## <i class="bi bi-calendar-event-fill text-primary me-2" aria-hidden="true"></i>Con il Comune, durante le manifestazioni
+## <i class="bi bi-bank text-primary me-2" aria-hidden="true"></i>Con il Comune, durante le manifestazioni
 
 Su **esplicito mandato del Comune di Genzano di Roma**, supportiamo le manifestazioni pubbliche organizzate dall'Amministrazione (sagre, feste, commemorazioni, eventi culturali e sportivi). Il nostro ruolo è di **supporto alla popolazione**, sempre nei limiti previsti dalla normativa sul volontariato di protezione civile.
 


### PR DESCRIPTION
note-legali: ruolo esteso a Referente Web e Comunicazione Istituzionale (A. Cuollo). metodo-editoriale: credito. per-gli-enti: icona Comune (bi-bank).