### PR TITLE
116117: link diretti alle schede ufficiali Salute Lazio e Ministero

### DIFF
--- a/content/comunicazioni/2026-06-03-116117-numero-europeo-cure-non-urgenti.md
+++ b/content/comunicazioni/2026-06-03-116117-numero-europeo-cure-non-urgenti.md
@@ -82,5 +82,5 @@ Come Gruppo Comunale di Protezione Civile diffondiamo questa informazione perch�
 
 **Fonti istituzionali:**
 
-- [Regione Lazio – Salute Lazio: il 116117](https://www.salutelazio.it/) — pagina ufficiale del Servizio Sanitario Regionale.
-- [Ministero della Salute – Numero europeo cure non urgenti 116117](https://www.salute.gov.it/) — scheda nazionale del servizio.
+- [Regione Lazio – Salute Lazio: il 116117](https://www.salutelazio.it/notizie-dalla-regione-lazio/-/asset_publisher/gzqRjLEc0ALr/content/id/192321254) — scheda ufficiale del Servizio Sanitario Regionale.
+- [Ministero della Salute – Numero europeo cure non urgenti 116117](https://www.salute.gov.it/new/it/tema/livelli-essenziali-di-assistenza/numero-europeo-cure-non-urgenti-116117/) — scheda nazionale del servizio.


### PR DESCRIPTION
Migliora l'articolo 116117 sostituendo i due link "Fonti istituzionali" dalle homepage alle **schede ufficiali dedicate**:

- Salute Lazio → scheda 116117 del Servizio Sanitario Regionale.
- Ministero della Salute → pagina tema "Numero europeo cure non urgenti 116117".

Nessun'altra modifica. Build Hugo pulita.

https://claude.ai/code/session_01QmeGWfmvJCqKvy2oigpKs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmeGWfmvJCqKvy2oigpKs8)_