### PR TITLE
Tromba d'aria a Roma: aggiunti schemi SVG di tromba d'aria e downburst

### DIFF
--- a/content/comunicazioni/2026-06-03-tromba-aria-roma-fenomeno-raro-facile.md
+++ b/content/comunicazioni/2026-06-03-tromba-aria-roma-fenomeno-raro-facile.md
@@ -35,6 +35,14 @@ Una **tromba d'aria** è una colonna di aria che **gira** molto veloce. Scende d
 
 C'è anche il **downburst**. È un vento forte che **scende** e va dritto. Non gira. Anche questo rompe gli alberi.
 
+{{< foto src="/images/2026-06-03-schema-tromba-aria.svg"
+         alt="Schema: una colonna di aria scende da una nuvola e diventa stretta come un imbuto. Due frecce curve mostrano che l'aria gira."
+         caption="La tromba d'aria: l'aria **gira** e scende fino a terra." >}}
+
+{{< foto src="/images/2026-06-03-schema-downburst.svg"
+         alt="Schema: frecce dritte scendono dalla nuvola fino a terra e poi si aprono a destra e a sinistra. L'aria non gira."
+         caption="Il downburst: l'aria **scende e si apre**. Non gira." >}}
+
 I due fenomeni sono diversi. Gli esperti studiano i danni e dicono quale è stato.
 
 ## Perché è raro a Roma

--- a/content/comunicazioni/2026-06-03-tromba-aria-roma-fenomeno-raro.md
+++ b/content/comunicazioni/2026-06-03-tromba-aria-roma-fenomeno-raro.md
@@ -35,6 +35,14 @@ Nei racconti di giornata compaiono spesso due parole, usate come sinonimi. In re
 - La **tromba d'aria** (in inglese *tornado*) è una colonna d'aria **in rotazione** che scende da un grande temporale fino a toccare il suolo. Diventa visibile quando il vapore risucchiato condensa e forma il tipico **imbuto**.
 - Il **downburst** è una raffica di vento **discendente** che esce dalla base del temporale e si apre al suolo in linea retta, **senza ruotare**. Può superare i 100 km/h e abbattere alberi su un fronte ampio.
 
+{{< foto src="/images/2026-06-03-schema-tromba-aria.svg"
+         alt="Schema: una colonna d'aria scende da un cumulonembo restringendosi a imbuto fino al suolo; due frecce curve attorno all'imbuto indicano la rotazione dell'aria."
+         caption="La tromba d'aria: una colonna d'aria **in rotazione** che scende dal temporale fino al suolo." >}}
+
+{{< foto src="/images/2026-06-03-schema-downburst.svg"
+         alt="Schema: tre frecce dritte scendono dal cumulonembo verso il suolo e, toccata terra, si aprono verso l'esterno a destra e a sinistra, senza ruotare."
+         caption="Il downburst: aria che **scende e si apre** al suolo in linea retta, senza rotazione." >}}
+
 Entrambi sradicano alberi e scoperchiano tetti, ma lasciano "firme" diverse sul terreno. La **classificazione precisa** spetta agli enti tecnici e ai servizi meteorologici, che analizzano la direzione dei danni.
 
 Durante un temporale forte la pressione cala dove l'aria sale con violenza. Se il calo è marcato, si forma una piccola cella di bassa pressione che può generare venti circolari molto intensi: nei casi peggiori, la tromba d'aria.

--- a/static/images/2026-06-03-schema-downburst.svg
+++ b/static/images/2026-06-03-schema-downburst.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 440" role="img" aria-labelledby="dbTitle dbDesc" font-family="Arial, Helvetica, sans-serif">
+  <title id="dbTitle">Schema di un downburst</title>
+  <desc id="dbDesc">Una corrente d'aria scende in linea retta dal cumulonembo e, raggiunto il suolo, si apre verso l'esterno senza ruotare.</desc>
+  <defs>
+    <marker id="arrDb" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#0369a1"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="600" height="440" rx="12" fill="#eef4fb"/>
+
+  <!-- cumulonembo -->
+  <g fill="#6b7280">
+    <ellipse cx="300" cy="70" rx="150" ry="46"/>
+    <ellipse cx="190" cy="86" rx="80" ry="40"/>
+    <ellipse cx="420" cy="86" rx="86" ry="40"/>
+    <ellipse cx="300" cy="100" rx="170" ry="34"/>
+  </g>
+  <rect x="130" y="100" width="340" height="14" fill="#5b626b"/>
+
+  <!-- aria che scende in linea retta -->
+  <line x1="250" y1="120" x2="250" y2="312" stroke="#0369a1" stroke-width="5" marker-end="url(#arrDb)"/>
+  <line x1="300" y1="120" x2="300" y2="320" stroke="#0369a1" stroke-width="6" marker-end="url(#arrDb)"/>
+  <line x1="350" y1="120" x2="350" y2="312" stroke="#0369a1" stroke-width="5" marker-end="url(#arrDb)"/>
+
+  <!-- a terra l'aria si apre verso l'esterno -->
+  <path d="M292,326 C 230,352 160,352 96,344" fill="none" stroke="#0369a1" stroke-width="5" marker-end="url(#arrDb)"/>
+  <path d="M308,326 C 370,352 440,352 504,344" fill="none" stroke="#0369a1" stroke-width="5" marker-end="url(#arrDb)"/>
+
+  <!-- suolo -->
+  <line x1="40" y1="356" x2="560" y2="356" stroke="#8d6e63" stroke-width="5"/>
+
+  <!-- etichette -->
+  <text x="300" y="392" text-anchor="middle" font-size="28" font-weight="bold" fill="#003366">DOWNBURST</text>
+  <text x="300" y="420" text-anchor="middle" font-size="19" fill="#334155">l'aria scende e si apre: lineare (non ruota)</text>
+</svg>

--- a/static/images/2026-06-03-schema-tromba-aria.svg
+++ b/static/images/2026-06-03-schema-tromba-aria.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 440" role="img" aria-labelledby="trombaTitle trombaDesc" font-family="Arial, Helvetica, sans-serif">
+  <title id="trombaTitle">Schema di una tromba d'aria</title>
+  <desc id="trombaDesc">Una colonna d'aria in rotazione scende da un cumulonembo fino al suolo. Le frecce curve indicano che l'aria gira.</desc>
+  <defs>
+    <marker id="arrTromba" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#003366"/>
+    </marker>
+    <linearGradient id="funnelGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#9aa3ad"/>
+      <stop offset="1" stop-color="#6b7280"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="600" height="440" rx="12" fill="#eef4fb"/>
+
+  <!-- cumulonembo -->
+  <g fill="#6b7280">
+    <ellipse cx="300" cy="70" rx="150" ry="46"/>
+    <ellipse cx="190" cy="86" rx="80" ry="40"/>
+    <ellipse cx="420" cy="86" rx="86" ry="40"/>
+    <ellipse cx="300" cy="100" rx="170" ry="34"/>
+  </g>
+  <rect x="130" y="100" width="340" height="14" fill="#5b626b"/>
+
+  <!-- imbuto in rotazione -->
+  <path d="M250,114 C 268,212 285,292 294,352 L 306,352 C 317,292 334,212 350,114 Z" fill="url(#funnelGrad)"/>
+
+  <!-- frecce di rotazione (l'aria gira) -->
+  <path d="M242,206 A 62,24 0 0 1 358,206" fill="none" stroke="#003366" stroke-width="4" marker-end="url(#arrTromba)"/>
+  <path d="M360,262 A 64,24 0 0 1 240,262" fill="none" stroke="#003366" stroke-width="4" marker-end="url(#arrTromba)"/>
+
+  <!-- suolo + detriti -->
+  <line x1="40" y1="356" x2="560" y2="356" stroke="#8d6e63" stroke-width="5"/>
+  <circle cx="268" cy="350" r="4" fill="#8d6e63"/>
+  <circle cx="338" cy="349" r="4" fill="#8d6e63"/>
+  <circle cx="360" cy="352" r="3" fill="#8d6e63"/>
+
+  <!-- etichette -->
+  <text x="300" y="392" text-anchor="middle" font-size="28" font-weight="bold" fill="#003366">TROMBA D'ARIA</text>
+  <text x="300" y="420" text-anchor="middle" font-size="19" fill="#334155">l'aria gira intorno a un asse (rotazione)</text>
+</svg>


### PR DESCRIPTION
Aggiunge due **schemi SVG originali** all'articolo sulla tromba d'aria, per chiarire la differenza tra i due fenomeni:

- `static/images/2026-06-03-schema-tromba-aria.svg` — colonna d'aria in rotazione (frecce curve).
- `static/images/2026-06-03-schema-downburst.svg` — aria che scende e si apre in linea retta (frecce dritte + divergenza al suolo).

Inseriti inline (`{{< foto >}}`) sia nella versione standard sia nella **versione facile A2** (supporto visivo per lettori A2/L2).

## Note
- Disegni **originali** (nessun problema di copyright, nessun download necessario): risolvono il vincolo per cui le foto dell'evento sono protette.
- Vettoriali, scalabili, con `alt`/`caption` fedeli al contenuto; verifica visiva effettuata (render PNG controllato).
- Scientificamente corretti: tromba d'aria = rotazione; downburst = flusso discendente lineare.
- Build Hugo pulita.

https://claude.ai/code/session_01QmeGWfmvJCqKvy2oigpKs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmeGWfmvJCqKvy2oigpKs8)_