### PR TITLE
Fix: testo bottone 'Tutti i dossier' leggibile

### DIFF
--- a/static/css/dossier.css
+++ b/static/css/dossier.css
@@ -593,7 +593,7 @@ html.a11y-pause-anim .dossier-dati__grid.is-in .dossier-dato__num { background: 
   position: fixed; top: 1rem; left: 1rem; z-index: 70;
   display: inline-flex; align-items: center; gap: .45rem;
   padding: .6rem 1.15rem; border-radius: 999px;
-  background: var(--accent); color: #0a1730; text-decoration: none;
+  background: var(--accent); color: #0a1730 !important; text-decoration: none;
   font-size: .95rem; font-weight: 700; line-height: 1;
   border: 2px solid #fff;
   -webkit-backdrop-filter: blur(8px); backdrop-filter: blur(8px);
@@ -603,7 +603,7 @@ html.a11y-pause-anim .dossier-dati__grid.is-in .dossier-dato__num { background: 
   transition: opacity .3s ease, transform .3s ease, visibility .3s, background .2s;
 }
 .dossier-back.is-visible { opacity: 1; visibility: visible; transform: none; pointer-events: auto; }
-.dossier-back:hover, .dossier-back:focus-visible { background: #0a1730; color: var(--accent); border-color: var(--accent); }
+.dossier-back:hover, .dossier-back:focus-visible { background: #0a1730; color: var(--accent) !important; border-color: var(--accent); }
 .dossier-back:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; opacity: 1; visibility: visible; transform: none; pointer-events: auto; }
 .dossier-back .bi { font-size: 1.05em; }
 @media (max-width: 575.98px) {


### PR DESCRIPTION
Il bottone di ritorno all'hub mostrava testo invisibile (giallo su giallo) a causa della regola generica .dossier a piu specifica. Forzato il colore del testo: scuro su giallo di default, giallo su scuro al hover/focus.