### PR TITLE
Ponte glossario ↔ enciclopedia: indice A-Z in /conoscere/ + 58 rimandi Approfondisci

### DIFF
--- a/content/conoscere/_index.md
+++ b/content/conoscere/_index.md
@@ -5,10 +5,12 @@ layout: "single"
 toc: true
 image: ""
 date: 2026-05-29
-dataUltimaRevisione: "2026-05-29"
+dataUltimaRevisione: "2026-06-07"
 ---
 
 La protezione civile non è solo il numero da chiamare quando succede qualcosa. È un **sistema** che lavora ogni giorno: studia i rischi, prepara il territorio, interviene durante gli eventi e accompagna il ritorno alla normalità. Questa sezione la racconta come una materia, passo dopo passo, perché capirla è il primo modo per esserne parte.
+
+È **l'enciclopedia divulgativa del sito**: se il [Glossario](/glossario/) ti dice in una riga *cosa significa* una parola, qui trovi *come funziona* e *perché*. Cerchi un concetto preciso? Vai subito all'**[indice A-Z dei concetti](#indice-a-z-dei-concetti)**.
 
 <div class="alert alert-info" role="note">
 <p class="mb-0"><i class="bi bi-info-circle me-2" aria-hidden="true"></i><strong>Una guida divulgativa.</strong> Queste pagine spiegano come funziona il sistema di protezione civile a scopo informativo ed educativo. Il Gruppo Comunale Volontari di Protezione Civile di Genzano di Roma <strong>non parla a nome</strong> del Dipartimento della Protezione Civile né della Regione Lazio. In caso di emergenza il riferimento resta sempre il <strong>numero unico 112</strong> e i <strong>canali ufficiali</strong> del Dipartimento e della Regione.</p>
@@ -45,6 +47,36 @@ Sono le quattro fasi del ciclo del rischio. Le trovi spiegate una per una nella 
 - **[Storia della protezione civile italiana](/conoscere/storia-della-protezione-civile/)** — dal Vajont al Codice del 2018, e il ruolo di Giuseppe Zamberletti.
 - **[La scienza del rischio e i Centri di competenza](/conoscere/scienza-del-rischio/)** — come la conoscenza scientifica diventa allerta: la catena dal modello al bollettino.
 - **[La dimensione internazionale](/conoscere/dimensione-internazionale/)** — il Meccanismo europeo di protezione civile, rescEU e il Quadro di Sendai.
+
+## Indice A-Z dei concetti
+
+Cerca il concetto che ti interessa e vai diritto alla pagina che lo spiega. Dove il tema ha anche una pagina operativa («cosa faccio?»), trovi il rimando lì dentro.
+
+- **Agibilità e schede AeDES** — [Dopo l'emergenza](/conoscere/le-quattro-fasi/dopo-l-emergenza/)
+- **Catalogo dei rischi** — [Il catalogo dei rischi](/conoscere/catalogo-dei-rischi/)
+- **Centri di competenza** — [La scienza del rischio](/conoscere/scienza-del-rischio/)
+- **Ciclo del rischio (le quattro fasi)** — [Le quattro fasi](/conoscere/le-quattro-fasi/)
+- **COC e modello di intervento** — [Dal COC alla DiComaC](/conoscere/le-quattro-fasi/modello-di-intervento/)
+- **Dimensione internazionale (Meccanismo UE, rescEU, Sendai)** — [La dimensione internazionale](/conoscere/dimensione-internazionale/)
+- **Incendi boschivi (AIB)** — [Il rischio da incendi boschivi](/conoscere/catalogo-dei-rischi/rischio-incendio/)
+- **IT-alert** — [Telecomunicazioni in emergenza](/conoscere/telecomunicazioni-emergenza/)
+- **Maremoto (tsunami)** — [Il rischio da maremoto](/conoscere/catalogo-dei-rischi/rischio-maremoto/)
+- **Modello del rischio (Pericolosità × Vulnerabilità × Esposizione)** — [La scienza del rischio](/conoscere/scienza-del-rischio/)
+- **Neve e gelo** — [Il rischio da neve e gelo](/conoscere/catalogo-dei-rischi/rischio-neve-gelo/)
+- **Nucleare e radiologico** — [Il rischio nucleare e radiologico](/conoscere/catalogo-dei-rischi/rischio-nucleare-radiologico/)
+- **Prevenzione** — [Prevenzione](/conoscere/le-quattro-fasi/prevenzione/)
+- **Previsione** — [Previsione](/conoscere/le-quattro-fasi/previsione/)
+- **Rete radio di emergenza** — [La Rete Radio nazionale di emergenza](/conoscere/telecomunicazioni-emergenza/rete-zamberletti/)
+- **Rischio chimico-industriale (direttiva Seveso)** — [Il rischio chimico-industriale](/conoscere/catalogo-dei-rischi/rischio-chimico-industriale/)
+- **Rischio idrogeologico (frane, alluvioni)** — [Il rischio idrogeologico](/conoscere/catalogo-dei-rischi/rischio-idrogeologico/)
+- **Rischio sanitario (epidemie, pandemie)** — [Il rischio sanitario](/conoscere/catalogo-dei-rischi/rischio-sanitario/)
+- **Rischio sismico (terremoti)** — [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/)
+- **Servizio Nazionale (chi fa cosa, il Sindaco)** — [Il Servizio Nazionale](/conoscere/servizio-nazionale/)
+- **Siccità (deficit idrico)** — [Il rischio da deficit idrico](/conoscere/catalogo-dei-rischi/rischio-siccita/)
+- **Soccorso e gestione dell'emergenza** — [Soccorso](/conoscere/le-quattro-fasi/soccorso/)
+- **Storia della protezione civile (Vajont, Zamberletti)** — [Storia della protezione civile italiana](/conoscere/storia-della-protezione-civile/)
+- **Superamento dell'emergenza** — [Superamento](/conoscere/le-quattro-fasi/superamento/)
+- **Vulcano Laziale (Colli Albani)** — [Il vulcanismo dei Colli Albani](/conoscere/rischio-vulcanico-colli-albani/)
 
 ## Approfondimenti sul nostro sito
 

--- a/content/glossario/_index.md
+++ b/content/glossario/_index.md
@@ -7,10 +7,14 @@ sitemap:
   changefreq: monthly
 toc: true
 tts: true
-dataUltimaRevisione: "2026-05-21"
+dataUltimaRevisione: "2026-06-07"
 ---
 
 Le sigle della protezione civile possono sembrare difficili. Questo glossario le spiega in modo semplice, con esempi collegati al territorio quando utile.
+
+<div class="alert alert-info" role="note">
+<p class="mb-0"><i class="bi bi-book me-2" aria-hidden="true"></i><strong>Vuoi capire come funziona, non solo cosa significa?</strong> Il glossario dà la definizione breve. Per l'approfondimento vai a <a href="/conoscere/">Conoscere la Protezione Civile</a>, l'enciclopedia divulgativa del sito: il ciclo del rischio, il Servizio Nazionale, i rischi spiegati uno per uno. Diverse voci qui sotto hanno il rimando «Approfondisci».</p>
+</div>
 
 <div id="glossario-strumenti" class="glossario-strumenti"></div>
 <noscript>
@@ -28,12 +32,14 @@ Luogo sicuro dove la popolazione può radunarsi nelle prime fasi di un'emergenza
 
 ### AeDES
 Scheda tecnica usata dopo un terremoto da tecnici abilitati per valutare il danno e l'agibilità degli edifici. Serve a stabilire se un edificio può essere usato, se servono limitazioni o se è inagibile.
+*Approfondisci: [Dopo l'emergenza](/conoscere/le-quattro-fasi/dopo-l-emergenza/).*
 
 ### AGESCI {#agesci}
 Associazione Guide e Scout Cattolici Italiani. Il suo settore di protezione civile è iscritto all'elenco nazionale del volontariato presso il Dipartimento.
 
 ### AIB
 Antincendio Boschivo. Comprende prevenzione, avvistamento, contenimento e spegnimento degli incendi boschivi. Coinvolge Regioni, Vigili del Fuoco, Carabinieri Forestali e volontari formati.
+*Approfondisci: [Il rischio da incendi boschivi](/conoscere/catalogo-dei-rischi/rischio-incendio/).*
 
 ### Allerta
 Comunicazione preventiva emessa dalle autorità quando sono previsti fenomeni che possono causare criticità. Non indica per forza un'emergenza già in corso. I colori sono verde, giallo, arancione e rosso.
@@ -73,6 +79,7 @@ Basic Life Support Defibrillation. Il BLS unito all'uso del defibrillatore (DAE)
 
 ### Build back better {#build-back-better}
 Principio della ricostruzione dopo un disastro: non tornare com'era prima, ma ricostruire più sicuro e resiliente. È uno dei principi del Quadro di Sendai delle Nazioni Unite.
+*Approfondisci: [Dopo l'emergenza](/conoscere/le-quattro-fasi/dopo-l-emergenza/).*
 
 ### Bollettino di criticità idrogeologica e idraulica {#bollettino-di-criticita-idrogeologica-e-idraulica}
 Documento emesso dal Centro Funzionale Regionale. Indica il livello previsto di criticità per rischio idrogeologico, idraulico e temporali nelle diverse zone di allerta.
@@ -105,9 +112,11 @@ Corpo Nazionale Soccorso Alpino e Speleologico. Struttura del Club Alpino Italia
 
 ### COC — Centro Operativo Comunale
 Struttura che il Sindaco attiva per coordinare un'emergenza sul territorio comunale. Riunisce le funzioni necessarie, come tecnica, volontariato, sanità, assistenza alla popolazione, comunicazione e viabilità.
+*Approfondisci: [Il modello di intervento: dal COC alla DiComaC](/conoscere/le-quattro-fasi/modello-di-intervento/).*
 
 ### COI — Centro Operativo Intercomunale
 Struttura di coordinamento tra più Comuni, utile quando un'emergenza riguarda un territorio più ampio del singolo Comune.
+*Approfondisci: [Il modello di intervento: dal COC alla DiComaC](/conoscere/le-quattro-fasi/modello-di-intervento/).*
 
 ### Codice della protezione civile
 Decreto legislativo 2 gennaio 2018, n. 1. È il riferimento principale del Servizio nazionale di protezione civile. Definisce attività, competenze, ruoli e strumenti del sistema.
@@ -226,6 +235,7 @@ Istituto Superiore di Sanità. Ente pubblico di ricerca in materia di salute; in
 
 ### IT-alert
 Sistema nazionale di allarme pubblico. Invia messaggi ai telefoni presenti in un'area interessata da una grave emergenza. Non richiede app, registrazione o connessione internet.
+*Approfondisci: [Telecomunicazioni in emergenza](/conoscere/telecomunicazioni-emergenza/).*
 
 ## L
 
@@ -242,6 +252,7 @@ Misura l'energia rilasciata da un terremoto. Non indica da sola i danni, che dip
 
 ### Maremoto (tsunami) {#maremoto}
 Serie di onde marine provocate dallo spostamento improvviso di una grande massa d'acqua: terremoti sottomarini, frane o eruzioni. In Italia l'allertamento è gestito dal sistema SiAM (INGV, ISPRA, DPC).
+*Approfondisci: [Il rischio da maremoto](/conoscere/catalogo-dei-rischi/rischio-maremoto/).*
 
 ### MCS / Mercalli
 Scala che descrive gli effetti di un terremoto su persone, edifici e ambiente. È diversa dalla magnitudo, che misura l'energia del terremoto.
@@ -332,9 +343,11 @@ Evento sismico avvertito dalle persone o registrato dagli strumenti.
 
 ### Sendai, Quadro di {#sendai}
 Quadro di Sendai 2015-2030: l'accordo mondiale delle Nazioni Unite per ridurre i danni dei disastri. Indica priorità come conoscere il rischio, rafforzare la governance e ricostruire meglio (*build back better*).
+*Approfondisci: [La dimensione internazionale](/conoscere/dimensione-internazionale/).*
 
 ### Seveso (direttiva) {#seveso}
 Normativa europea che impone misure di sicurezza e piani di emergenza agli stabilimenti industriali che trattano grandi quantità di sostanze pericolose. Prende il nome dall'incidente industriale di Seveso del 1976. La versione vigente è la direttiva Seveso III (2012/18/UE), recepita in Italia con il decreto legislativo n. 105 del 2015.
+*Approfondisci: [Il rischio chimico-industriale](/conoscere/catalogo-dei-rischi/rischio-chimico-industriale/).*
 
 ### ShakeMap {#shakemap}
 Mappa che mostra l'intensità di scuotimento del terreno dopo un terremoto, calcolata in pochi minuti da INGV sulla base delle stazioni sismiche.

--- a/content/glossario/_index.md
+++ b/content/glossario/_index.md
@@ -43,6 +43,7 @@ Antincendio Boschivo. Comprende prevenzione, avvistamento, contenimento e spegni
 
 ### Allerta
 Comunicazione preventiva emessa dalle autorità quando sono previsti fenomeni che possono causare criticità. Non indica per forza un'emergenza già in corso. I colori sono verde, giallo, arancione e rosso.
+*Approfondisci: [La scienza del rischio](/conoscere/scienza-del-rischio/).*
 
 ### ANPAS {#anpas}
 Associazione Nazionale Pubbliche Assistenze. Rete nazionale di pubbliche assistenze sanitarie e di protezione civile, partner storica del Dipartimento.
@@ -83,29 +84,37 @@ Principio della ricostruzione dopo un disastro: non tornare com'era prima, ma ri
 
 ### Bollettino di criticità idrogeologica e idraulica {#bollettino-di-criticita-idrogeologica-e-idraulica}
 Documento emesso dal Centro Funzionale Regionale. Indica il livello previsto di criticità per rischio idrogeologico, idraulico e temporali nelle diverse zone di allerta.
+*Approfondisci: [La scienza del rischio](/conoscere/scienza-del-rischio/).*
 
 ### Bradisismo
 Movimento lento del suolo verso l'alto o verso il basso, collegato a fenomeni vulcanici. È noto, per esempio, nell'area dei Campi Flegrei.
+*Approfondisci: [Il vulcanismo dei Colli Albani](/conoscere/rischio-vulcanico-colli-albani/).*
 
 ## C
 
 ### Capo Dipartimento {#capo-dipartimento}
 Massima autorità tecnico-operativa del Servizio nazionale, alle dipendenze della Presidenza del Consiglio. Coordina la risposta alle emergenze di rilievo nazionale.
+*Approfondisci: [Il Servizio Nazionale](/conoscere/servizio-nazionale/).*
 
 ### CCS {#ccs}
 Centro Coordinamento Soccorsi. Centro provinciale dei soccorsi attivato dalla Prefettura: coordina forze dell'ordine, sanità, Vigili del Fuoco e volontariato.
+*Approfondisci: [Il modello di intervento](/conoscere/le-quattro-fasi/modello-di-intervento/).*
 
 ### Cell Broadcast {#cell-broadcast}
 Tecnologia che invia un messaggio a tutti i cellulari collegati alle antenne di una zona, senza usare la rubrica. È la base tecnica di IT-alert.
+*Approfondisci: [Telecomunicazioni in emergenza](/conoscere/telecomunicazioni-emergenza/).*
 
 ### Censimento dei danni {#censimento-dei-danni}
 Rilevazione tecnica dopo un evento, di norma con scheda AeDES per i terremoti, per quantificare i danni e attivare i contributi di ricostruzione.
+*Approfondisci: [Dopo l'emergenza](/conoscere/le-quattro-fasi/dopo-l-emergenza/).*
 
 ### Centro Funzionale Regionale (CFR)
 Struttura regionale che analizza previsioni e dati di monitoraggio e pubblica i bollettini di criticità. Per il Lazio, Genzano di Roma rientra nella **Zona F — Bacini Costieri Sud**.
+*Approfondisci: [La scienza del rischio](/conoscere/scienza-del-rischio/).*
 
 ### CNR {#cnr}
 Consiglio Nazionale delle Ricerche. Maggiore ente pubblico di ricerca italiano; per la protezione civile fornisce conoscenze scientifiche sui rischi naturali (frane via CNR-IRPI).
+*Approfondisci: [La scienza del rischio](/conoscere/scienza-del-rischio/).*
 
 ### CNSAS {#cnsas}
 Corpo Nazionale Soccorso Alpino e Speleologico. Struttura del Club Alpino Italiano (CAI) specializzata nel soccorso in montagna, in grotta e negli ambienti impervi. È una struttura operativa del Servizio nazionale di protezione civile.
@@ -120,15 +129,18 @@ Struttura di coordinamento tra più Comuni, utile quando un'emergenza riguarda u
 
 ### Codice della protezione civile
 Decreto legislativo 2 gennaio 2018, n. 1. È il riferimento principale del Servizio nazionale di protezione civile. Definisce attività, competenze, ruoli e strumenti del sistema.
+*Approfondisci: [Il Servizio Nazionale](/conoscere/servizio-nazionale/).*
 
 ### COM {#com}
 Centro Operativo Misto. Struttura intercomunale che coordina i soccorsi tra più Comuni colpiti dalla stessa emergenza, sotto il CCS provinciale.
+*Approfondisci: [Il modello di intervento](/conoscere/le-quattro-fasi/modello-di-intervento/).*
 
 ### Colonna mobile
 Insieme organizzato di personale, mezzi e attrezzature che può essere inviato in un territorio colpito da emergenza.
 
 ### COR {#cor}
 Centro Operativo Regionale (sala operativa regionale). Per il Lazio attiva i COC dei Comuni colpiti e coordina la colonna mobile regionale.
+*Approfondisci: [Il modello di intervento](/conoscere/le-quattro-fasi/modello-di-intervento/).*
 
 ### Copernicus EMS
 Servizio europeo di gestione delle emergenze. Fornisce mappe satellitari e prodotti cartografici a supporto di grandi emergenze, come alluvioni, incendi e terremoti.
@@ -143,6 +155,7 @@ Defibrillatore Automatico Esterno. Apparecchio salvavita che riconosce un arrest
 
 ### DICOMAC
 Direzione di Comando e Controllo. Struttura di coordinamento nazionale attivata nelle emergenze di rilievo nazionale.
+*Approfondisci: [Il modello di intervento](/conoscere/le-quattro-fasi/modello-di-intervento/).*
 
 ### Direttiva PCM {#direttiva-pcm}
 Atto di indirizzo del Presidente del Consiglio. Per la protezione civile la più rilevante è la Direttiva 30 aprile 2021 sul Servizio nazionale.
@@ -166,18 +179,22 @@ Documento di Valutazione dei Rischi. È previsto dalla normativa sulla sicurezza
 
 ### Emergenza
 Situazione in cui un evento è in corso o imminente e richiede interventi immediati. È diversa dall'allerta, che segnala una possibile criticità prevista.
+*Approfondisci: [Soccorso e gestione dell'emergenza](/conoscere/le-quattro-fasi/soccorso/).*
 
 ### Epicentro e ipocentro {#epicentro-e-ipocentro}
 L'ipocentro è il punto in profondità dove si genera il terremoto; l'epicentro è il punto in superficie sulla sua verticale, di norma l'area di maggiore danno.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ### ERCC {#ercc}
 Emergency Response Coordination Centre (Centro di coordinamento della risposta alle emergenze). Centro della Commissione europea che coordina 24 ore su 24 gli aiuti tra i Paesi durante le grandi emergenze, nell'ambito del Meccanismo unionale di protezione civile.
+*Approfondisci: [La dimensione internazionale](/conoscere/dimensione-internazionale/).*
 
 ### Esercitazione
 Attività simulata usata per verificare piani, procedure, comunicazioni e capacità operative.
 
 ### Esposizione {#esposizione}
 Quantità e valore di persone, edifici e beni presenti in un'area a rischio. Insieme a pericolosità e vulnerabilità è una delle tre componenti del rischio.
+*Approfondisci: [La scienza del rischio](/conoscere/scienza-del-rischio/).*
 
 ### ETS {#ets}
 Ente del Terzo Settore. Categoria giuridica che raggruppa associazioni, OdV, fondazioni e imprese sociali con finalità civiche e di utilità sociale.
@@ -189,6 +206,7 @@ Allontanamento ordinato da un'area a rischio verso un luogo più sicuro, secondo
 
 ### Faglia
 Frattura nella crosta terrestre lungo cui possono avvenire movimenti e terremoti.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ### FEMA
 Federal Emergency Management Agency. È l'agenzia federale statunitense per la gestione delle emergenze.
@@ -208,27 +226,33 @@ Bande di frequenza radio: HF a lunga portata (centinaia o migliaia di km), VHF e
 
 ### IFFI
 Inventario dei Fenomeni Franosi in Italia. È una banca dati nazionale, gestita da ISPRA, che raccoglie informazioni sulle frane censite.
+*Approfondisci: [Il rischio idrogeologico](/conoscere/catalogo-dei-rischi/rischio-idrogeologico/).*
 
 ### Incidente rilevante (stabilimenti RIR) {#incidente-rilevante}
 Evento (incendio, esplosione, rilascio di sostanze tossiche) che in uno stabilimento industriale può creare grave pericolo per persone e ambiente. Gli stabilimenti che superano le soglie di legge sono detti «a rischio di incidente rilevante» (RIR) e seguono la direttiva Seveso.
+*Approfondisci: [Il rischio chimico-industriale](/conoscere/catalogo-dei-rischi/rischio-chimico-industriale/).*
 
 ### INAIL {#inail}
 Istituto Nazionale per l'Assicurazione contro gli Infortuni sul Lavoro. Ente pubblico che assicura i lavoratori contro infortuni e malattie professionali; garantisce la copertura anche ai volontari di protezione civile nelle attività autorizzate.
 
 ### INGV
 Istituto Nazionale di Geofisica e Vulcanologia. Monitora terremoti, vulcani e maremoti ed è una fonte istituzionale per i dati sismici in Italia.
+*Approfondisci: [La scienza del rischio](/conoscere/scienza-del-rischio/).*
 
 ### Intensità sismica {#intensita-sismica}
 Misura degli effetti di un terremoto su persone, edifici e ambiente, valutata osservando i danni. Diversa dalla magnitudo, che misura l'energia. Vedi anche **MCS / Mercalli**.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ### Io non rischio {#io-non-rischio}
 Campagna nazionale del Dipartimento e di ANPAS per la riduzione del rischio: ogni anno i volontari informano i cittadini in piazza su terremoti, alluvioni, incendi e maremoti.
 
 ### ISIN {#isin}
 Ispettorato nazionale per la sicurezza nucleare e la radioprotezione. È l'autorità che vigila su impianti, sorgenti e trasporti di materiale radioattivo in Italia. Istituito con il decreto legislativo n. 45 del 2014.
+*Approfondisci: [Il rischio nucleare e radiologico](/conoscere/catalogo-dei-rischi/rischio-nucleare-radiologico/).*
 
 ### ISPRA {#ispra}
 Istituto Superiore per la Protezione e la Ricerca Ambientale. Gestisce dati nazionali su frane, alluvioni, costa e suolo; pubblica la piattaforma IdroGEO.
+*Approfondisci: [La scienza del rischio](/conoscere/scienza-del-rischio/).*
 
 ### ISS {#iss}
 Istituto Superiore di Sanità. Ente pubblico di ricerca in materia di salute; in emergenza fornisce dati e raccomandazioni alle istituzioni sanitarie.
@@ -244,11 +268,13 @@ Legge 9 gennaio 2004, n. 4. Riguarda l'accessibilità degli strumenti informatic
 
 ### Legge Zamberletti
 Legge 24 febbraio 1992, n. 225. Ha istituito il Servizio nazionale della protezione civile. Oggi il riferimento principale è il D.Lgs. 1/2018.
+*Approfondisci: [Storia della protezione civile italiana](/conoscere/storia-della-protezione-civile/).*
 
 ## M
 
 ### Magnitudo
 Misura l'energia rilasciata da un terremoto. Non indica da sola i danni, che dipendono anche da distanza, profondità, tipo di terreno, edifici e vulnerabilità.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ### Maremoto (tsunami) {#maremoto}
 Serie di onde marine provocate dallo spostamento improvviso di una grande massa d'acqua: terremoti sottomarini, frane o eruzioni. In Italia l'allertamento è gestito dal sistema SiAM (INGV, ISPRA, DPC).
@@ -256,20 +282,25 @@ Serie di onde marine provocate dallo spostamento improvviso di una grande massa 
 
 ### MCS / Mercalli
 Scala che descrive gli effetti di un terremoto su persone, edifici e ambiente. È diversa dalla magnitudo, che misura l'energia del terremoto.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ### Meccanismo europeo di protezione civile (UCPM) {#meccanismo-europeo}
 Il sistema con cui i Paesi dell'Unione Europea si aiutano nelle grandi emergenze, mettendo in comune mezzi e squadre. La sigla UCPM sta per *Union Civil Protection Mechanism*.
+*Approfondisci: [La dimensione internazionale](/conoscere/dimensione-internazionale/).*
 
 ### Microzonazione sismica {#microzonazione-sismica}
 Studio che descrive, strada per strada, come il terreno risponde a un terremoto: alcune zone amplificano la scossa più di altre. Guida la pianificazione comunale e le norme di costruzione.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ### Mitigazione {#mitigazione}
 Insieme di interventi che riducono gli effetti di un evento dannoso (argini, edifici antisismici). Distinta dalla prevenzione, che mira a evitare l'evento.
+*Approfondisci: [Prevenzione](/conoscere/le-quattro-fasi/prevenzione/).*
 
 ## N
 
 ### NTC {#ntc}
 Norme Tecniche per le Costruzioni (aggiornate nel 2018). Fissano i requisiti antisismici e di sicurezza degli edifici e classificano l'Italia in zone sismiche.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ### NUE 112
 Numero Unico Europeo di Emergenza. È il numero da chiamare per incendio, malore, incidente, reato o altro pericolo immediato. La centrale smista la chiamata al servizio competente.
@@ -289,6 +320,7 @@ Periodo di almeno tre giorni con temperature molto sopra la media stagionale. Au
 
 ### PAI
 Piano di Assetto Idrogeologico. Classifica le aree esposte a pericolosità da frana o alluvione e ha effetti sulla pianificazione territoriale.
+*Approfondisci: [Il rischio idrogeologico](/conoscere/catalogo-dei-rischi/rischio-idrogeologico/).*
 
 ### PCM {#pcm}
 Presidenza del Consiglio dei Ministri. Il DPC è una sua struttura e da essa derivano le direttive che regolano la protezione civile.
@@ -298,6 +330,7 @@ Percorsi per le Competenze Trasversali e l'Orientamento. Sono attività formativ
 
 ### PGRA {#pgra}
 Piano di Gestione del Rischio di Alluvioni. Recepisce la Direttiva europea Alluvioni (2007/60/CE) tramite il D.Lgs. 49/2010 e aggiorna ogni sei anni le mappe e le misure contro le alluvioni.
+*Approfondisci: [Il rischio idrogeologico](/conoscere/catalogo-dei-rischi/rischio-idrogeologico/).*
 
 ### Piano comunale di protezione civile {#piano-di-emergenza-comunale}
 Documento che descrive rischi, aree di emergenza, procedure, ruoli e risorse del Comune. Per Genzano consulta il [Piano di emergenza](/piano-emergenza/) e la [Cartografia](/cartografia/).
@@ -309,6 +342,7 @@ Posto Medico Avanzato. Struttura sanitaria temporanea allestita vicino a un'emer
 
 ### Quiescente
 Detto di un vulcano che non ha eruzioni in corso, ma non è considerato spento. I Colli Albani sono considerati un complesso vulcanico quiescente e sono monitorati dagli enti scientifici competenti.
+*Approfondisci: [Il vulcanismo dei Colli Albani](/conoscere/rischio-vulcanico-colli-albani/).*
 
 ## R
 
@@ -317,12 +351,14 @@ Rianimazione Cardio-Polmonare. Tecnica d'emergenza che combina compressioni tora
 
 ### rescEU {#resceu}
 La riserva europea di mezzi per le emergenze (per esempio aerei antincendio, scorte mediche), parte del Meccanismo europeo di protezione civile. Interviene quando le risorse di un Paese non bastano.
+*Approfondisci: [La dimensione internazionale](/conoscere/dimensione-internazionale/).*
 
 ### Resilienza {#resilienza}
 Capacità di una comunità di assorbire un evento avverso, riorganizzarsi e tornare a funzionare. Si costruisce con prevenzione, formazione e pianificazione.
 
 ### Rischio
 Il rischio dipende da tre fattori: pericolosità, esposizione e vulnerabilità. Ridurre il rischio significa conoscere i pericoli, diminuire la vulnerabilità e adottare comportamenti corretti.
+*Approfondisci: [La scienza del rischio](/conoscere/scienza-del-rischio/).*
 
 ### RSPP
 Responsabile del Servizio di Prevenzione e Protezione. È una figura prevista dalla normativa sulla sicurezza nei luoghi di lavoro e nelle scuole.
@@ -331,15 +367,18 @@ Responsabile del Servizio di Prevenzione e Protezione. È una figura prevista da
 
 ### SAE
 Soluzioni Abitative d'Emergenza. Sono moduli abitativi temporanei usati dopo grandi emergenze per ospitare persone che non possono rientrare in casa.
+*Approfondisci: [Dopo l'emergenza](/conoscere/le-quattro-fasi/dopo-l-emergenza/).*
 
 ### Sala Operativa Protezione Civile Lazio {#sala-operativa-protezione-civile-lazio}
 Sala operativa regionale (numero verde 803 555) per segnalazioni non urgenti. Per le emergenze si chiama il **112**.
 
 ### Sciame sismico {#sciame-sismico}
 Sequenza di molte scosse di magnitudo simile in un'area ristretta, in giorni o settimane. Non indica necessariamente un terremoto maggiore in arrivo.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ### Scossa
 Evento sismico avvertito dalle persone o registrato dagli strumenti.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ### Sendai, Quadro di {#sendai}
 Quadro di Sendai 2015-2030: l'accordo mondiale delle Nazioni Unite per ridurre i danni dei disastri. Indica priorità come conoscere il rischio, rafforzare la governance e ricostruire meglio (*build back better*).
@@ -351,24 +390,31 @@ Normativa europea che impone misure di sicurezza e piani di emergenza agli stabi
 
 ### ShakeMap {#shakemap}
 Mappa che mostra l'intensità di scuotimento del terreno dopo un terremoto, calcolata in pochi minuti da INGV sulla base delle stazioni sismiche.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ### Sistema di allertamento {#sistema-di-allertamento}
 Catena di soggetti (DPC, Centri Funzionali, Comuni) che valutano il rischio e fanno arrivare l'allerta al cittadino. Opera 24 ore su 24, 7 giorni su 7.
+*Approfondisci: [La scienza del rischio](/conoscere/scienza-del-rischio/).*
 
 ### SNPC {#snpc}
 Servizio Nazionale della Protezione Civile. L'insieme di Stato, Regioni, Comuni, enti e volontariato che concorrono alle attività di protezione civile in Italia, coordinati dal Dipartimento (D.Lgs. 1/2018).
+*Approfondisci: [Il Servizio Nazionale](/conoscere/servizio-nazionale/).*
 
 ### Soggetto Attuatore {#soggetto-attuatore}
 Figura nominata nelle ordinanze di emergenza per realizzare interventi specifici (es. la ricostruzione post-sisma). Risponde al Commissario.
+*Approfondisci: [Dopo l'emergenza](/conoscere/le-quattro-fasi/dopo-l-emergenza/).*
 
 ### SOUP {#soup}
 Sala Operativa Unificata Permanente. Sala regionale antincendio boschivo, attiva 24 ore su 24 nei mesi a rischio: coordina avvistamenti, mezzi aerei e squadre AIB.
+*Approfondisci: [Il rischio da incendi boschivi](/conoscere/catalogo-dei-rischi/rischio-incendio/).*
 
 ### Stato di emergenza {#stato-di-emergenza}
 Atto del Consiglio dei Ministri (art. 24 del Codice della protezione civile) che dichiara un'emergenza di rilievo nazionale: sblocca poteri straordinari e ordinanze.
+*Approfondisci: [Dopo l'emergenza](/conoscere/le-quattro-fasi/dopo-l-emergenza/).*
 
 ### Sussidiarietà
 Principio secondo cui le istituzioni favoriscono l'iniziativa dei cittadini, singoli o associati, per attività di interesse generale. È importante anche per il volontariato.
+*Approfondisci: [Il Servizio Nazionale](/conoscere/servizio-nazionale/).*
 
 ## T
 
@@ -377,6 +423,7 @@ Insieme di enti privati senza scopo di lucro che svolgono attività di interesse
 
 ### Tipo di emergenza (A, B, C) {#tipo-emergenza}
 Classificazione delle emergenze (art. 7 del Codice della protezione civile): tipo A gestita dal Comune, tipo B dalla Regione, tipo C di rilievo nazionale.
+*Approfondisci: [Il Servizio Nazionale](/conoscere/servizio-nazionale/).*
 
 ### Triage {#triage}
 Valutazione rapida delle vittime in un'emergenza per stabilire l'ordine di soccorso in base alla gravità clinica, non all'ordine di arrivo.
@@ -391,6 +438,7 @@ Sigla di *Union Civil Protection Mechanism*: è il [Meccanismo europeo di protez
 
 ### USR
 Ufficio Speciale Ricostruzione. Struttura tecnica che segue la ricostruzione dopo grandi emergenze.
+*Approfondisci: [Dopo l'emergenza](/conoscere/le-quattro-fasi/dopo-l-emergenza/).*
 
 ## V
 
@@ -414,6 +462,7 @@ Area omogenea usata dalla Regione per emettere il bollettino di criticità. Genz
 
 ### Zona sismica
 Classificazione del territorio in base alla pericolosità sismica. Serve per applicare le norme tecniche sulle costruzioni e per la pianificazione. Genzano di Roma è in **zona sismica 2B**.
+*Approfondisci: [Il rischio sismico](/conoscere/catalogo-dei-rischi/rischio-sismico/).*
 
 ---
 
@@ -423,6 +472,7 @@ Classificazione del territorio in base alla pericolosità sismica. Serve per app
 
 ## Vedi anche
 
+- [Conoscere la Protezione Civile](/conoscere/) — l'enciclopedia: ogni concetto spiegato per esteso
 - [Rischi e prevenzione](/rischi-prevenzione/) — comportamenti per ogni rischio
 - [FAQ](/faq/) — domande frequenti
 - [Allerte meteo](/allerte-meteo/) — linguaggio dei bollettini regionali


### PR DESCRIPTION
## Cosa fa

Rafforza il **ponte tra il dizionario (`/glossario/`) e l'enciclopedia (`/conoscere/`)** senza creare sezioni nuove né toccare l'infrastruttura dei popover inline. Modello a due livelli reso esplicito al cittadino: il glossario dice *cosa significa* in una riga, `/conoscere/` spiega *come funziona e perché*.

## Modifiche

**`/conoscere/_index.md`**
- Posizionata esplicitamente come «enciclopedia divulgativa del sito»
- Nuovo **indice A-Z dei concetti** (25 voci navigabili) → la landing diventa consultabile come una knowledge base

**`/glossario/_index.md`**
- Callout-ponte in cima verso `/conoscere/`
- **58 voci** con rimando «Approfondisci» alla pagina enciclopedica corrispondente (era 9). Regola coerente: il rimando c'è solo dove `/conoscere/` tratta davvero il concetto
- «Conoscere la Protezione Civile» aggiunto al blocco «Vedi anche»
- `dataUltimaRevisione` aggiornata

## Verifica
- Tutti i link (24 nell'indice A-Z + 16 target distinti dal glossario) risolvono a pagine reali in `content/conoscere/`: nessun link rotto
- Frontmatter valido · modifiche puramente Markdown (nessun layout nuovo)

https://claude.ai/code/session_01N6pXTd1nWnHxrqVnt3uc7S

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6pXTd1nWnHxrqVnt3uc7S)_