### PR TITLE
Dossier: fix responsive mobile sezioni dati con foto di sfondo

### DIFF
--- a/static/css/dossier.css
+++ b/static/css/dossier.css
@@ -693,7 +693,10 @@ html.a11y-pause-anim .dossier-cursorglow { display: none !important; }
   content: ""; position: absolute; inset: 0;
   background: linear-gradient(180deg, rgba(5,8,15,.85), rgba(5,8,15,.72) 45%, rgba(5,8,15,.88));
 }
-.dossier-dati--img .dossier-dati__grid { position: relative; z-index: 1; }
+/* min-width:0 + width:100% — il grid è figlio flex di .dossier-dati--img:
+   senza questo erediterebbe min-width:auto e non collasserebbe a 1 colonna su
+   mobile (le colonne sforavano e venivano tagliate da overflow:hidden). */
+.dossier-dati--img .dossier-dati__grid { position: relative; z-index: 1; min-width: 0; width: 100%; }
 @media (prefers-reduced-motion: reduce) { .dossier-dati--img .dossier-dati__bg { animation: none !important; } }
 html.a11y-pause-anim .dossier-dati--img .dossier-dati__bg { animation: none !important; }
 .dossier-scena[data-align="top"] .dossier-scena__panel li strong { color: var(--ink); }


### PR DESCRIPTION
## Problema

Sui dossier interattivi, le sezioni statistiche con foto di sfondo a tutta pagina (`.dossier-dati--img`) non erano responsive su cellulare: le card delle statistiche restavano affiancate in 3 colonne che sforavano il viewport e venivano tagliate ai lati (visibile solo la colonna centrale).

## Causa

`.dossier-dati--img` è un **flex container** (`display:flex`). Il grid figlio `.dossier-dati__grid` ereditava il `min-width:auto` di default dei flex item, quindi non si restringeva sotto la larghezza minima del contenuto (3 × `minmax(220px,1fr)` ≈ 720px). L'`auto-fit` non collassava a una colonna e `overflow:hidden` tagliava lo sforamento. Le sezioni dati normali (in `display:block`) si impilavano già correttamente.

## Fix

Una riga CSS scoped (`static/css/dossier.css`): `min-width: 0; width: 100%` sul grid dentro `.dossier-dati--img`, così rispetta la larghezza del contenitore e l'`auto-fit` torna a impilare su mobile. Nessun cambiamento su desktop (resta centrato fino a 1180px).

https://claude.ai/code/session_01NDboWj5ru9FS5ivq5AhXsB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDboWj5ru9FS5ivq5AhXsB)_