### PR TITLE
Articolo Nemi: scadenza al 15 giugno 2026

### DIFF
--- a/content/comunicazioni/2026-06-09-nemi-chiusura-via-nemorense-demolizione-ponti.md
+++ b/content/comunicazioni/2026-06-09-nemi-chiusura-via-nemorense-demolizione-ponti.md
@@ -7,7 +7,7 @@ priorita: "normale"
 autore: "Gruppo Comunale Volontari PC Genzano"
 image: "/images/2026-06-09-nemi-chiusura-via-nemorense-demolizione-ponti.webp"
 image_alt: "Cover dell'articolo: tra Genzano e Nemi, via Nemorense e via De Sanctis chiuse dal 9 giugno per i lavori sui ponti"
-scadenza: ""
+scadenza: "2026-06-15"
 area: "Genzano di Roma — Nemi"
 allegati: []
 draft: false


### PR DESCRIPTION
Imposta `scadenza: 2026-06-15` sull'articolo della chiusura via Nemorense / via De Sanctis (lavori stimati ~6 giorni dal 9 giugno). Il campo non è visibile finché la data non passa: dopo il 15 giugno l'articolo mostra l'avviso "Comunicazione non più attuale" e viene segnalato dal workflow gestione-scadenze per archiviazione/aggiornamento. Nessuna data di fine lavori pubblicata come certa nel corpo (stima non confermata).

https://claude.ai/code/session_01NDboWj5ru9FS5ivq5AhXsB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDboWj5ru9FS5ivq5AhXsB)_