### PR TITLE
Riapertura via Nemorense: scadenza al 9 giugno (non più attuale)

### DIFF
--- a/content/comunicazioni/2026-05-23-riapertura-via-nemorense-genzano-nemi.md
+++ b/content/comunicazioni/2026-05-23-riapertura-via-nemorense-genzano-nemi.md
@@ -7,7 +7,7 @@ priorita: "normale"
 autore: "Gruppo Comunale Volontari PC Genzano"
 image: "/images/2026-05-23-riapertura-via-nemorense-genzano-nemi.webp"
 image_alt: "Cover dell'articolo: Riaperta via Nemorense tra Genzano e Nemi, strada percorribile nei due sensi"
-scadenza: ""
+scadenza: "2026-06-09"
 area: "Genzano di Roma — Nemi"
 allegati: []
 social_citazione: "Via Nemorense, tra Genzano e Nemi, è di nuovo percorribile nei due sensi di marcia."


### PR DESCRIPTION
Imposta `scadenza: 2026-06-09` sull'articolo "Riaperta via Nemorense" (23 maggio): la strada è di nuovo chiusa dal 9 giugno per i lavori sui ponti, quindi l'avviso di riapertura non è più valido. Essendo la data già passata, l'articolo mostra l'etichetta "Comunicazione non più attuale", a complemento del banner che già rimanda alla nuova chiusura. Il resoconto del 15 aprile (cronaca/Attività) resta senza scadenza per scelta.

https://claude.ai/code/session_01NDboWj5ru9FS5ivq5AhXsB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDboWj5ru9FS5ivq5AhXsB)_