### PR TITLE
Fix stale Aruba: reset sync-state FTP (upload integrale) + refuso area-volontari

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,13 @@ jobs:
           local-dir: ./public/
           server-dir: /www.protezionecivilegenzano.it/
           dangerous-clean-slate: false
+          # Reset del sync-state per forzare un upload INTEGRALE (09/06/2026):
+          # lo stato FTP precedente era andato in drift e lasciava su Aruba
+          # pagine stantie (chi-siamo 20/4, allerte-meteo 13/5). Un nuovo
+          # state-name fa ri-caricare tutti i file, senza cancellare nulla
+          # (a differenza di dangerous-clean-slate). Da qui in poi gli upload
+          # tornano incrementali contro questo nuovo stato.
+          state-name: .ftp-deploy-sync-state-2026-06-09.json
           timeout: 60000
           log-level: verbose
           exclude: |

--- a/content/area-volontari/_index.md
+++ b/content/area-volontari/_index.md
@@ -34,7 +34,7 @@ Sulla piattaforma i volontari possono:
 - consultare il **calendario turni** e le attivazioni in corso;
 - ricevere **comunicazioni interne** del Capo Gruppo e dei referenti di squadra;
 - scaricare **modulistica operativa** (schede attivazione, verbali, registri radio);
-- aggiornare i **propri dati personali** e i **disponibilità** settimanali;
+- aggiornare i **propri dati personali** e le **disponibilità** settimanali;
 - consultare lo **storico delle attività** svolte.
 
 ## Piattaforma usata


### PR DESCRIPTION
## P0 — File stantii su Aruba (drift sync-state FTP)

Dall'audit live del 9/6: su Aruba convivevano più generazioni di build (chi-siamo 20/4, /allerte-meteo/ 13/5 con un'**allerta gialla inesistente**, diventa-volontario 21/5) mentre home e area-volontari erano fresche del 9/6. Causa: il sync-state di `FTP-Deploy-Action` è andato in drift e lasciava file non ri-caricati.

**Fix:** cambiato `state-name` del deploy FTP → l'azione non trova lo stato vecchio e **ri-carica tutti i file** (upload integrale), **senza cancellare** la cartella `/documenti/` gestita a mano sul server (a differenza di `dangerous-clean-slate`). Dal deploy successivo gli upload tornano incrementali contro il nuovo stato.

## Contenuto

L'audit segnalava anche bug di contenuto, ma il **repo era già corretto** — erano artefatti delle pagine stantie:
- Sindaco: il repo ha già **Fabio Papalia** (live vecchio mostrava Zoccolotti).
- Timeline: il repo dice già **1991 = istituzione del Gruppo**; "1997" nel repo è "Terremoto Umbria-Marche" (l'audit l'ha scambiato per "Fondazione").
- "Vento forte": linkato nel repo; appariva non linkato perché la pagina live (13/5) precede l'articolo (16/5).

**Unico bug reale corretto:** refuso in `area-volontari` → "i disponibilità" → "le disponibilità".

https://claude.ai/code/session_01NDboWj5ru9FS5ivq5AhXsB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDboWj5ru9FS5ivq5AhXsB)_