### PR TITLE
Audit § 43b: coerenza allerta home vs /allerte-meteo/ + rule 05 reset sync-state

### DIFF
--- a/.claude/rules/05-github-aruba-deploy.md
+++ b/.claude/rules/05-github-aruba-deploy.md
@@ -215,6 +215,14 @@ Lo script `scripts/auto-cover-mancanti.py` agisce così:
 
 ### Strategia cache-bust raccomandata
 
+> 🔴 **Rimedio decisivo quando il drift è grave o ricorrente (reset del sync-state FTP).** Il cache-bust nei `_index.md` aiuta sui singoli file, ma se su Aruba convivono **più generazioni di build** (es. audit 9 giugno 2026: `/chi-siamo/` ferma al 20/4, `/allerte-meteo/` al 13/5 con allerta gialla inesistente) il problema è che il **sync-state** di `FTP-Deploy-Action` è andato in drift: l'azione "crede" che quei file siano già caricati e li salta per sempre. Il fix che li sana **tutti in un colpo** è cambiare il `state-name` nello step FTP di `deploy.yml`:
+>
+> ```yaml
+> state-name: .ftp-deploy-sync-state-AAAA-MM-GG.json   # nuovo nome → re-upload integrale
+> ```
+>
+> Non trovando lo stato vecchio, l'azione **ri-carica l'intero sito**, **senza cancellare** la cartella `/documenti/` gestita a mano (a differenza di `dangerous-clean-slate: true`, che la distruggerebbe). È auto-curante: lo stato nuovo viene scritto solo a fine upload completo, quindi se un deploy viene interrotto il successivo riprova l'integrale. Dopo la sanatoria gli upload tornano incrementali contro il nuovo stato. Usa questo metodo, non `dangerous-clean-slate`. Il check `audit-sito.yml § 43b` confronta il livello allerta home vs `/allerte-meteo/` e segnala proprio questo sintomo.
+
 Quando modifichi **un partial del chrome** (`navbar.html`, `footer.html`, `slim-header.html`, `utility-bar.html`, `baseof.html`), nello **stesso PR** aggiungi un commento cache-bust nei `_index.md` delle sezioni principali per forzare la rigenerazione "evidente" lato Hugo + il re-upload FTP:
 
 ```markdown

--- a/.github/workflows/audit-sito.yml
+++ b/.github/workflows/audit-sito.yml
@@ -1252,6 +1252,33 @@ jobs:
           fi
 
           # ----------------------------------------------------------------
+          section "43b. Coerenza livello allerta: home vs /allerte-meteo/"
+          # Home e /allerte-meteo/ leggono LO STESSO data/allerta.json al build:
+          # la home lo rende come classe `allerta-bar-<livello>`, la pagina
+          # allerte-meteo come testo "Livello <Livello>" (shortcode
+          # allerta-stato-attuale). Se i due divergono, una delle due pagine è
+          # STANTIA su Aruba — ed è il sintomo peggiore possibile: un'allerta
+          # sbagliata mostrata al cittadino. Check di CONTENUTO, indipendente
+          # dai timestamp (scatta anche se Last-Modified inganna). Aggiunto dopo
+          # l'audit del 9 giugno 2026 (/allerte-meteo/ ferma al 13 maggio con
+          # allerta gialla inesistente mentre la home diceva nessuna allerta).
+          # Cache-bust via query param per scavalcare cache CDN intermedie.
+          CB="?audit=$(date -u +%s)"
+          home_body=$(curl -sL --max-time 10 -H "Cache-Control: no-cache" "https://www.protezionecivilegenzano.it/${CB}" 2>/dev/null)
+          meteo_body=$(curl -sL --max-time 10 -H "Cache-Control: no-cache" "https://www.protezionecivilegenzano.it/allerte-meteo/${CB}" 2>/dev/null)
+          home_lvl=$(echo "$home_body" | grep -oE 'allerta-bar-(verde|giallo|arancione|rosso)' | head -1 | sed 's/allerta-bar-//')
+          meteo_lvl=$(echo "$meteo_body" | grep -oE 'Livello (Verde|Giallo|Arancione|Rosso)' | head -1 | sed 's/Livello //' | tr '[:upper:]' '[:lower:]')
+          if [ -n "$home_lvl" ] && [ -n "$meteo_lvl" ]; then
+            if [ "$home_lvl" != "$meteo_lvl" ]; then
+              err "Livello allerta DIVERGENTE tra home (\`$home_lvl\`) e /allerte-meteo/ (\`$meteo_lvl\`): una delle due pagine è stantia su Aruba. È il sintomo peggiore (allerta sbagliata al cittadino). Forzare un redeploy integrale resettando lo \`state-name\` del deploy FTP — vedi rule 05-github-aruba-deploy.md § \"File stantii su Aruba\"."
+            else
+              ok "Livello allerta coerente tra home e /allerte-meteo/ (\`$home_lvl\`)."
+            fi
+          else
+            warn "Impossibile estrarre il livello allerta per il confronto (home: \`$home_lvl\`, allerte-meteo: \`$meteo_lvl\`) — markup cambiato o pagine irraggiungibili."
+          fi
+
+          # ----------------------------------------------------------------
           section "44. Lunghezza description articoli (≤160 caratteri)"
           # La description alimenta la meta description SEO e og:description.
           # Limite 160 caratteri (rule 02 § "Frontmatter obbligatorio").


### PR DESCRIPTION
Migliorie preventive dopo l'audit del 9/6 (azione #2):

- **`audit-sito.yml` § 43b — coerenza livello allerta home ↔ /allerte-meteo/.** Confronta il livello allerta renderizzato dalla home (`allerta-bar-<livello>`) con quello di `/allerte-meteo/` ("Livello X"): se divergono, una pagina è stantia su Aruba (il sintomo peggiore: allerta sbagliata al cittadino). È un check di **contenuto**, indipendente dai timestamp, con cache-bust via query param per scavalcare le cache CDN.
- **rule 05** — documenta il **reset dello `state-name` FTP** come rimedio decisivo al drift del sync-state (più forte del solo cache-bust dei `_index.md`), senza ricorrere a `dangerous-clean-slate` che cancellerebbe `/documenti/`.

https://claude.ai/code/session_01NDboWj5ru9FS5ivq5AhXsB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDboWj5ru9FS5ivq5AhXsB)_