### PR TITLE
Fix audit 10/06 + copertura rischi mancanti: 4 nuove pagine operative

### DIFF
--- a/content/comunicazioni/2026-04-17-mostra-terremoti-italia-napoli.md
+++ b/content/comunicazioni/2026-04-17-mostra-terremoti-italia-napoli.md
@@ -8,6 +8,7 @@ autore: "Gruppo Comunale Volontari PC Genzano"
 image: "/images/2026-04-17-mostra-terremoti-italia-napoli.webp"
 image_alt: "Cover dell'articolo: La mostra «Terremoti d'Italia» fa tappa a Napoli: dal 20 aprile al 9 maggio"
 scadenza: 2026-05-09
+archiviato: true
 area: "Napoli"
 allegati: []
 draft: false

--- a/content/comunicazioni/2026-05-08-open-day-antincendio-boschivo-aprilia.md
+++ b/content/comunicazioni/2026-05-08-open-day-antincendio-boschivo-aprilia.md
@@ -8,6 +8,7 @@ autore: "Gruppo Comunale Volontari PC Genzano"
 image: "/images/2026-05-08-open-day-antincendio-boschivo-aprilia.webp"
 image_alt: "Cover dell'articolo: I nostri volontari all'Open Day antincendio boschivo del 9 maggio ad Aprilia"
 scadenza: "2026-05-09"
+archiviato: true
 area: "Aprilia (LT)"
 allegati: []
 draft: false

--- a/content/comunicazioni/2026-05-16-salone-libro-torino-dpc.md
+++ b/content/comunicazioni/2026-05-16-salone-libro-torino-dpc.md
@@ -8,6 +8,7 @@ autore: "Gruppo Comunale Volontari PC Genzano"
 image: "/images/2026-05-16-salone-libro-torino-dpc.webp"
 image_alt: "Cover dell'articolo: Salone del Libro 2026 — la Protezione Civile a Torino con 'Infiniti racconti, una sola storia'"
 scadenza: "2026-05-19"
+archiviato: true
 area: "Torino"
 allegati:
   - titolo: "Programma completo dei 12 talk al padiglione DPC del Salone del Libro 2026"

--- a/content/comunicazioni/2026-05-22-esposizione-grandi-mezzi-soccorso-marino.md
+++ b/content/comunicazioni/2026-05-22-esposizione-grandi-mezzi-soccorso-marino.md
@@ -9,6 +9,7 @@ image: "/images/2026-05-22-esposizione-grandi-mezzi-soccorso-marino.webp"
 image_alt: "Cover dell'articolo: esposizione dei grandi mezzi di soccorso a Marino, presente anche Genzano"
 area: "Marino (RM)"
 scadenza: "2026-05-25"
+archiviato: true
 allegati: []
 draft: false
 ---

--- a/content/comunicazioni/2026-05-22-infiorata-ragazzi-genzano-2026.md
+++ b/content/comunicazioni/2026-05-22-infiorata-ragazzi-genzano-2026.md
@@ -9,6 +9,7 @@ image: "/images/2026-05-22-infiorata-ragazzi-genzano-2026.webp"
 image_alt: "Cover dell'articolo: Infiorata dei Ragazzi 2026, il Gruppo a supporto dell'evento"
 area: "Genzano di Roma"
 scadenza: "2026-06-01"
+archiviato: true
 allegati:
   - titolo: "Ordinanza Polizia Locale n. 71 del 19 maggio 2026 — viabilità Infiorata dei Ragazzi"
     url: "/allegati/2026/ordinanza-71-2026-infiorata-ragazzi-viabilita.pdf"

--- a/content/comunicazioni/2026-05-23-riapertura-via-nemorense-genzano-nemi.md
+++ b/content/comunicazioni/2026-05-23-riapertura-via-nemorense-genzano-nemi.md
@@ -8,6 +8,7 @@ autore: "Gruppo Comunale Volontari PC Genzano"
 image: "/images/2026-05-23-riapertura-via-nemorense-genzano-nemi.webp"
 image_alt: "Cover dell'articolo: Riaperta via Nemorense tra Genzano e Nemi, strada percorribile nei due sensi"
 scadenza: "2026-06-09"
+archiviato: true
 area: "Genzano di Roma — Nemi"
 allegati: []
 social_citazione: "Via Nemorense, tra Genzano e Nemi, è di nuovo percorribile nei due sensi di marcia."

--- a/content/comunicazioni/2026-06-07-caldo-salute-app-bollettini.md
+++ b/content/comunicazioni/2026-06-07-caldo-salute-app-bollettini.md
@@ -1,7 +1,7 @@
 ---
 title: "Caldo e Salute: l'app per i bollettini sulle ondate di calore"
-date: 2026-06-07
-description: "Arriva l'estate: l'app gratuita Caldo e Salute mostra ogni giorno il livello di rischio per il caldo nella tua città, con i bollettini ufficiali del Ministero della Salute."
+date: 2026-06-07T00:01:00+02:00
+description: "L'app gratuita Caldo e Salute mostra ogni giorno il livello di rischio caldo nella tua città, con i bollettini ufficiali del Ministero della Salute."
 badge: "Prevenzione"
 priorita: "normale"
 autore: "Gruppo Comunale Volontari PC Genzano"

--- a/content/comunicazioni/2026-06-07-sicurezza-alimentare-emergenza-scorte.md
+++ b/content/comunicazioni/2026-06-07-sicurezza-alimentare-emergenza-scorte.md
@@ -1,6 +1,6 @@
 ---
 title: "7 giugno: sicurezza alimentare in emergenza"
-date: 2026-06-07
+date: 2026-06-07T00:02:00+02:00
 description: "La Giornata mondiale della sicurezza alimentare tocca un aspetto pratico e spesso trascurato della preparazione: come conservare."
 badge: "Prevenzione"
 priorita: "normale"

--- a/content/conoscere/catalogo-dei-rischi/rischio-chimico-industriale.md
+++ b/content/conoscere/catalogo-dei-rischi/rischio-chimico-industriale.md
@@ -51,6 +51,7 @@ A differenza di altri rischi, qui la regola di autoprotezione può essere **cont
 
 ## Approfondimenti sul nostro sito
 
+- [Rischio chimico-industriale: cosa fare](/rischi-prevenzione/rischio-industriale/) — la pagina operativa con i comportamenti di autoprotezione.
 - [Rischio chimico-industriale: cosa devono sapere i cittadini](/comunicazioni/2026-05-24-rischio-chimico-industriale-cittadini/).
 - [Seveso 1976: cinquant'anni e la direttiva europea](/comunicazioni/2026-07-10-seveso-1976-cinquant-anni-direttiva-europea/).
 - [Le quattro fasi della protezione civile](/conoscere/le-quattro-fasi/) — previsione, prevenzione, gestione, superamento.

--- a/content/conoscere/catalogo-dei-rischi/rischio-incendio.md
+++ b/content/conoscere/catalogo-dei-rischi/rischio-incendio.md
@@ -53,7 +53,7 @@ Significa che la prevenzione dei comportamenti è la prima difesa: ne parliamo a
 
 ## La campagna AIB e la previsione del pericolo
 
-In Italia l'attività di **lotta agli incendi boschivi (AIB)** si concentra nella **campagna estiva**, di norma da giugno a settembre, quando la vegetazione è più secca. È il periodo in cui il volontariato di protezione civile, insieme ai Vigili del Fuoco e alle squadre regionali, intensifica la sorveglianza del territorio. Il nostro Gruppo vi partecipa: lo raccontiamo nelle schede sull'[avvio della campagna AIB nel Lazio](/comunicazioni/2026-06-01-avvio-campagna-aib-lazio-2026/) e sulle [attrezzature e tecniche di attacco](/comunicazioni/2026-04-11-antincendio-boschivo-triangolo-fuoco-attrezzature-tecniche-attacco/).
+In Italia l'attività di **lotta agli incendi boschivi (AIB)** si concentra nella **campagna estiva**, di norma da giugno a settembre, quando la vegetazione è più secca. È il periodo in cui il volontariato di protezione civile, insieme ai Vigili del Fuoco e alle squadre regionali, intensifica la sorveglianza del territorio. Il nostro Gruppo vi partecipa: lo raccontiamo nelle schede sul [primo mese della campagna AIB 2026](/comunicazioni/2026-06-30-bilancio-primo-mese-aib-2026/) e sulle [attrezzature e tecniche di attacco](/comunicazioni/2026-04-11-antincendio-boschivo-triangolo-fuoco-attrezzature-tecniche-attacco/).
 
 Ogni giorno, durante la campagna, il **Centro Funzionale Regionale del Lazio** pubblica il **Bollettino di pericolosità da incendi boschivi**, elaborato con il modello previsionale **RISICO** sviluppato dalla **Fondazione CIMA**. Il bollettino stima il pericolo per ciascuna zona di allerta con quattro livelli — **basso, medio, moderato, elevato** —, ai quali il nostro sito associa i colori verde, giallo, arancione e rosso. Il territorio di **Genzano di Roma rientra nella zona AIB 9** (Castelli Romani). Il nostro sito riporta automaticamente il livello aggiornato nella barra di allerta della homepage e nel [Cruscotto del territorio](/cruscotto/).
 
@@ -76,7 +76,7 @@ Il volontariato di protezione civile, come il nostro Gruppo, contribuisce soprat
 
 - [Rischio incendio: cosa fare](/rischi-prevenzione/rischio-incendio/) — la pagina operativa con i comportamenti di autoprotezione.
 - [Il triangolo del fuoco e la prevenzione](/comunicazioni/2026-04-13-triangolo-del-fuoco-prevenzione-incendi/).
-- [Avvio della campagna AIB nel Lazio](/comunicazioni/2026-06-01-avvio-campagna-aib-lazio-2026/) e [attrezzature e tecniche di attacco](/comunicazioni/2026-04-11-antincendio-boschivo-triangolo-fuoco-attrezzature-tecniche-attacco/).
+- [Primo mese di campagna AIB: il punto al 30 giugno](/comunicazioni/2026-06-30-bilancio-primo-mese-aib-2026/) e [attrezzature e tecniche di attacco](/comunicazioni/2026-04-11-antincendio-boschivo-triangolo-fuoco-attrezzature-tecniche-attacco/).
 - [Le quattro fasi della protezione civile](/conoscere/le-quattro-fasi/) e il [Cruscotto del territorio](/cruscotto/).
 
 ## Per approfondire — fonti istituzionali

--- a/content/conoscere/catalogo-dei-rischi/rischio-maremoto.md
+++ b/content/conoscere/catalogo-dei-rischi/rischio-maremoto.md
@@ -66,6 +66,7 @@ Fonte: INGV — Centro Allerta Tsunami; ISPRA; DPC.
 
 ## Approfondimenti sul nostro sito
 
+- [Maremoto: cosa fare al mare](/rischi-prevenzione/maremoto/) — la pagina operativa con i comportamenti di autoprotezione.
 - [Tōhoku-Fukushima 2011: quando un maremoto innesca emergenze multiple](/comunicazioni/2026-03-11-tohoku-fukushima-2011-tsunami-emergenze-multiple/).
 - [Il rischio sismico in Italia](/conoscere/catalogo-dei-rischi/rischio-sismico/) — i terremoti, prima causa dei maremoti.
 - [Le quattro fasi della protezione civile](/conoscere/le-quattro-fasi/) — previsione, prevenzione, gestione, superamento.

--- a/content/conoscere/catalogo-dei-rischi/rischio-nucleare-radiologico.md
+++ b/content/conoscere/catalogo-dei-rischi/rischio-nucleare-radiologico.md
@@ -50,6 +50,7 @@ Come per il rischio chimico, la regola d'oro è **seguire le indicazioni delle a
 
 ## Approfondimenti sul nostro sito
 
+- [Rischio nucleare e radiologico: cosa fare](/rischi-prevenzione/rischio-nucleare-radiologico/) — la pagina operativa con i comportamenti di autoprotezione.
 - [Tōhoku-Fukushima 2011: quando un maremoto innesca emergenze multiple](/comunicazioni/2026-03-11-tohoku-fukushima-2011-tsunami-emergenze-multiple/).
 - [Il rischio chimico-industriale e la direttiva Seveso](/conoscere/catalogo-dei-rischi/rischio-chimico-industriale/) — l'altro grande rischio antropico.
 - [Le quattro fasi della protezione civile](/conoscere/le-quattro-fasi/).

--- a/content/conoscere/catalogo-dei-rischi/rischio-siccita.md
+++ b/content/conoscere/catalogo-dei-rischi/rischio-siccita.md
@@ -60,6 +60,7 @@ Anche i comportamenti quotidiani contano. Ridurre gli sprechi domestici, segnala
 
 ## Approfondimenti sul nostro sito
 
+- [Siccità e crisi idrica: cosa fare](/rischi-prevenzione/siccita/) — la pagina operativa con i comportamenti di risparmio idrico e autoprotezione.
 - [Giornata mondiale dell'acqua: la rete idrica e la sua sicurezza](/comunicazioni/2026-03-22-giornata-mondiale-acqua-rete-idrica-sicurezza/).
 - [Il catalogo dei rischi](/conoscere/catalogo-dei-rischi/) — tutti i rischi spiegati come materia.
 - [Le quattro fasi della protezione civile](/conoscere/le-quattro-fasi/) — il ciclo del rischio.

--- a/content/mappa-sito/_index.md
+++ b/content/mappa-sito/_index.md
@@ -223,6 +223,26 @@ In questa pagina trovi **tutte le sezioni del sito** organizzate per tema. Se sa
   <p class="ms-card-title">Blackout</p>
   <p class="ms-card-desc">Interruzioni elettriche prolungate, comportamenti, riferimenti.</p>
 </a>
+<a class="ms-card ms-emerg" href="/rischi-prevenzione/siccita/">
+  <div class="ms-card-icon"><i class="bi bi-droplet"></i></div>
+  <p class="ms-card-title">Siccità e crisi idrica</p>
+  <p class="ms-card-desc">Risparmio idrico, ordinanze comunali, sospensioni dell'erogazione e falda dei Colli Albani.</p>
+</a>
+<a class="ms-card ms-emerg" href="/rischi-prevenzione/maremoto/">
+  <div class="ms-card-icon"><i class="bi bi-tsunami"></i></div>
+  <p class="ms-card-title">Maremoto: cosa fare al mare</p>
+  <p class="ms-card-desc">Segnali naturali, allontanamento dalla spiaggia, sistema di allertamento SiAM e IT-alert.</p>
+</a>
+<a class="ms-card ms-emerg" href="/rischi-prevenzione/rischio-industriale/">
+  <div class="ms-card-icon"><i class="bi bi-radioactive"></i></div>
+  <p class="ms-card-title">Rischio chimico-industriale</p>
+  <p class="ms-card-desc">Riparo al chiuso, incidenti con merci pericolose, normativa Seveso e segnali di allarme.</p>
+</a>
+<a class="ms-card ms-emerg" href="/rischi-prevenzione/rischio-nucleare-radiologico/">
+  <div class="ms-card-icon"><i class="bi bi-shield-exclamation"></i></div>
+  <p class="ms-card-title">Rischio nucleare e radiologico</p>
+  <p class="ms-card-desc">Riparo al chiuso, iodoprofilassi solo su indicazione ufficiale, Piano nazionale di emergenza.</p>
+</a>
 <a class="ms-card ms-emerg" href="/rischi-prevenzione/persone-necessita-specifiche/">
   <div class="ms-card-icon"><i class="bi bi-person-arms-up"></i></div>
   <p class="ms-card-title">Persone con esigenze specifiche</p>

--- a/content/rischi-prevenzione/_index.md
+++ b/content/rischi-prevenzione/_index.md
@@ -70,6 +70,10 @@ Consulta la scheda completa del rischio che ti interessa.
 | Incendio | Fumo, fiamme, incendio boschivo o urbano | [Rischio incendio](/rischi-prevenzione/rischio-incendio/) |
 | Caldo intenso | Ondate di calore, fragilità, bambini, anziani e animali | [Caldo e ondate di calore](/rischi-prevenzione/ondate-di-calore/) |
 | Blackout | Mancanza di corrente, dispositivi elettrici, sicurezza domestica | [Blackout](/rischi-prevenzione/blackout/) |
+| Siccità e crisi idrica | Ordinanze sull'uso dell'acqua, risparmio idrico, sospensioni dell'erogazione | [Siccità e crisi idrica](/rischi-prevenzione/siccita/) |
+| Maremoto | Cosa fare al mare se la terra trema o il mare si ritira | [Maremoto: cosa fare al mare](/rischi-prevenzione/maremoto/) |
+| Incidente chimico-industriale | Nube tossica, incidente con merci pericolose, riparo al chiuso | [Rischio chimico-industriale](/rischi-prevenzione/rischio-industriale/) |
+| Emergenza nucleare-radiologica | Riparo al chiuso, iodoprofilassi solo su indicazione ufficiale | [Rischio nucleare e radiologico](/rischi-prevenzione/rischio-nucleare-radiologico/) |
 | Evacuazione | Uscita rapida da casa o scuola, kit, aree di attesa | [Kit di emergenza ed evacuazione](/rischi-prevenzione/kit-emergenza/) |
 
 ## Kit di emergenza essenziale

--- a/content/rischi-prevenzione/maremoto.md
+++ b/content/rischi-prevenzione/maremoto.md
@@ -1,0 +1,79 @@
+---
+title: "Maremoto: Cosa Fare al Mare"
+dataUltimaRevisione: "2026-06-10"
+description: "Genzano non è sul mare, ma il litorale laziale sì: i segnali di un maremoto, le regole di autoprotezione e il sistema di allertamento SiAM."
+tts: true
+lis_section: "maremoto"
+weight: 11
+toc: true
+# Schema.org HowTo — 3 step PRIMA/DURANTE/DOPO per rich result Google.
+howto_prima: "Quando vai al mare, individua subito i percorsi per allontanarti dalla spiaggia e i punti alti raggiungibili a piedi (edifici solidi a più piani, colline). Tieni il telefono carico e attiva la ricezione dei messaggi IT-alert. Osserva la segnaletica sul rischio maremoto, presente in molti comuni costieri. Spiega ai bambini la regola di base: se la terra trema o il mare si ritira, ci si allontana subito dall'acqua."
+howto_durante: "Se avverti un terremoto forte o lungo mentre sei sulla costa, o vedi il mare ritirarsi all'improvviso, non aspettare un avviso ufficiale: allontanati subito dalla spiaggia a piedi e raggiungi un punto alto. Non scendere in spiaggia a guardare. Non usare l'auto se non indispensabile: le strade si bloccano. Ricorda che la prima onda può non essere la più grande e che tra un'onda e l'altra possono passare diversi minuti."
+howto_dopo: "Resta nel punto alto finché le autorità non comunicano il cessato allarme: il pericolo può durare ore. Non tornare sulla spiaggia per recuperare oggetti. Segui solo i canali ufficiali (Protezione Civile, Capitaneria di Porto, Comune). Se qualcuno è ferito o disperso chiama il 112. Non toccare cavi elettrici o detriti instabili portati dall'acqua."
+---
+
+Genzano di Roma non è un comune costiero, ma il litorale laziale è a circa mezz'ora di auto e d'estate molti cittadini lo frequentano ogni settimana. Il maremoto (tsunami) è raro nel Mediterraneo, ma possibile: sapere cosa fare **prima di trovarsi sulla spiaggia** può salvare la vita. Le regole di questa pagina valgono su qualsiasi costa, in Italia e all'estero.
+
+{{< emergenza-ora >}}
+
+## <i class="bi bi-info-circle-fill text-primary me-2" aria-hidden="true"></i>Perché è rilevante anche per noi {#perche-rilevante}
+
+Il Mediterraneo è un mare sismicamente attivo: negli ultimi mille anni le coste italiane sono state colpite da varie decine di maremoti, alcuni distruttivi (Messina 1908, Stromboli 2002). Le coste del Lazio sono considerate a pericolosità più bassa rispetto al Sud Italia, ma **non a pericolosità zero**: un forte terremoto nel Tirreno o nel Mediterraneo occidentale può generare onde che raggiungono anche il nostro litorale.
+
+Per chi vive ai Castelli Romani il rischio non riguarda la casa, ma le abitudini: spiagge di Anzio, Nettuno, Torvaianica e Ostia d'estate, vacanze sulle coste del Sud Italia o all'estero. Per la spiegazione scientifica del fenomeno leggi la pagina materia [Il rischio da maremoto nel Mediterraneo](/conoscere/catalogo-dei-rischi/rischio-maremoto/).
+
+## <i class="bi bi-eye-fill text-primary me-2" aria-hidden="true"></i>Segnali da riconoscere {#segnali}
+
+L'allerta più rapida è quella **naturale**, che percepisci tu stesso:
+
+- **Terremoto forte o lungo** mentre sei sulla costa: è il segnale principale.
+- **Ritiro improvviso del mare**, che lascia in secco un tratto insolitamente ampio di spiaggia o porto.
+- **Rumore anomalo e crescente** proveniente dal mare, simile a un treno.
+
+A questi si aggiunge l'allerta **ufficiale**: il **SiAM** (Sistema di Allertamento nazionale per i Maremoti, gestito da INGV, ISPRA e Dipartimento della Protezione Civile) diffonde i messaggi di allerta, anche tramite [IT-alert](/comunicazioni/2026-05-15-iso-22322-public-warning-it-alert/) sui telefoni presenti nelle zone costiere interessate.
+
+## <i class="bi bi-clipboard-check-fill text-primary me-2" aria-hidden="true"></i>Cosa fare PRIMA {#cosa-fare-prima}
+
+- Quando arrivi in spiaggia, individua i **percorsi di allontanamento** e i punti alti raggiungibili a piedi (edifici solidi a più piani, vie in salita, colline).
+- Osserva la **segnaletica sul rischio maremoto** presente in molti comuni costieri (cartelli con onda stilizzata e frecce di evacuazione).
+- Tieni il telefono carico e **non disattivare IT-alert**.
+- Spiega ai bambini la regola d'oro: **se la terra trema o il mare si ritira, ci si allontana subito dall'acqua**, senza aspettare i genitori che raccolgono gli ombrelloni.
+
+## <i class="bi bi-exclamation-triangle-fill text-primary me-2" aria-hidden="true"></i>Cosa fare DURANTE {#cosa-fare-durante}
+
+- **Allontanati subito dalla spiaggia a piedi** e raggiungi un punto alto: non aspettare un messaggio ufficiale, i minuti contano.
+- Se non puoi allontanarti, sali ai **piani alti di un edificio solido** in cemento armato.
+- **Non scendere verso il mare** per guardare l'onda o fotografarla.
+- Evita l'auto se non indispensabile: le strade costiere si bloccano rapidamente.
+- Aiuta chi è in difficoltà (bambini, anziani, persone con disabilità) solo se puoi farlo senza fermarti nella zona pericolosa.
+
+## <i class="bi bi-arrow-counterclockwise text-primary me-2" aria-hidden="true"></i>Cosa fare DOPO {#cosa-fare-dopo}
+
+- Resta nel punto alto **finché le autorità non comunicano il cessato allarme**: le onde possono susseguirsi per ore e la prima può non essere la più grande.
+- Segui solo i **canali ufficiali**: Protezione Civile, Capitaneria di Porto, Comune costiero.
+- Se ci sono feriti o dispersi chiama il **112**. Per le emergenze in mare il numero della Guardia Costiera è il **1530**.
+- Non toccare cavi elettrici, serbatoi o detriti instabili portati dall'acqua.
+
+{{< cosa-non-fare titolo="Cosa NON fare in caso di maremoto" >}}
+- **Non aspettare la conferma ufficiale** se hai percepito i segnali naturali: allontanati subito.
+- **Non andare verso il mare** per curiosità, per fotografare o per recuperare oggetti.
+- **Non rientrare in spiaggia** dopo la prima onda: possono arrivarne altre più grandi.
+- **Non intasare le linee telefoniche** con chiamate non urgenti: servono ai soccorsi.
+{{< /cosa-non-fare >}}
+
+## <i class="bi bi-link-45deg text-primary me-2" aria-hidden="true"></i>Fonti e approfondimenti {#fonti}
+
+**Sul nostro sito**
+
+- **Approfondisci la materia:** [Il rischio da maremoto nel Mediterraneo](/conoscere/catalogo-dei-rischi/rischio-maremoto/) — come si genera e come funziona il SiAM.
+- [Rischio sismico: cosa fare](/rischi-prevenzione/rischio-sismico/) — i terremoti sono la prima causa dei maremoti.
+- [Tōhoku-Fukushima 2011: quando un maremoto innesca emergenze multiple](/comunicazioni/2026-03-11-tohoku-fukushima-2011-tsunami-emergenze-multiple/).
+- [IT-alert: il sistema di allarme pubblico](/comunicazioni/2026-05-15-iso-22322-public-warning-it-alert/).
+
+**Fonti istituzionali**
+
+- [Dipartimento della Protezione Civile — Rischio maremoto](https://rischi.protezionecivile.gov.it/it/) — comportamenti di autoprotezione e campagna "Io non rischio — maremoto".
+- [INGV — Centro Allerta Tsunami (CAT)](https://www.ingv.it/) — sorveglianza dei terremoti tsunamigenici nel Mediterraneo.
+- [ISPRA](https://www.isprambiente.gov.it/) — monitoraggio del livello del mare.
+
+{{< chi-chiamare >}}

--- a/content/rischi-prevenzione/rischio-industriale.md
+++ b/content/rischi-prevenzione/rischio-industriale.md
@@ -1,0 +1,80 @@
+---
+title: "Rischio Chimico-Industriale: Cosa Fare"
+dataUltimaRevisione: "2026-06-10"
+description: "Incidenti con sostanze pericolose in stabilimenti o durante i trasporti: il riparo al chiuso, i segnali di allarme e le regole della normativa Seveso."
+tts: true
+weight: 12
+toc: true
+# Schema.org HowTo — 3 step PRIMA/DURANTE/DOPO per rich result Google.
+howto_prima: "Informati se vicino a casa, scuola o lavoro ci sono stabilimenti a rischio di incidente rilevante: l'inventario nazionale è pubblicato da ISPRA e i Comuni interessati devono informare la popolazione. Impara a riconoscere i cartelli arancioni sui camion che trasportano merci pericolose. Memorizza la regola base del riparo al chiuso: entrare, chiudere, ascoltare. Tieni in casa nastro adesivo e panni per sigillare porte e finestre, e una radio a pile."
+howto_durante: "Se vedi una nube anomala, senti un odore chimico intenso o le autorità diramano l'allarme, entra nell'edificio chiuso più vicino: nella maggior parte dei casi il riparo al chiuso protegge più della fuga. Chiudi porte e finestre, spegni ventilazione e condizionatori, sigilla gli spifferi. Sali ai piani alti: molti gas pesanti ristagnano in basso. Ascolta radio, IT-alert e canali ufficiali. Esci solo se le autorità dispongono l'evacuazione."
+howto_dopo: "Esci solo dopo il cessato allarme ufficiale. Aera bene tutti i locali. Non consumare frutta e verdura dell'orto né acqua di pozzi privati finché le autorità sanitarie non confermano che è sicuro. Segui le indicazioni di ASL e Comune su eventuali controlli sanitari. Segnala al 112 persone con sintomi da esposizione (irritazioni, difficoltà respiratorie)."
+---
+
+Un incidente chimico-industriale — un incendio, un'esplosione o il rilascio di una sostanza tossica — può avvenire in uno stabilimento, ma anche durante un **trasporto su strada o ferrovia**. È un rischio meno familiare di terremoto o alluvione e con una regola di autoprotezione **controintuitiva**: spesso la cosa giusta non è scappare, ma **chiudersi al chiuso**.
+
+{{< emergenza-ora >}}
+
+## <i class="bi bi-info-circle-fill text-primary me-2" aria-hidden="true"></i>Perché è rilevante sul nostro territorio {#perche-rilevante}
+
+Il territorio di Genzano di Roma non ospita grandi poli chimici, ma il rischio industriale non riguarda solo chi abita accanto a una fabbrica:
+
+- le **merci pericolose viaggiano ogni giorno su strada** (carburanti, GPL, prodotti chimici), anche sulle arterie che attraversano i Castelli Romani come la via Appia: un incidente stradale può trasformarsi in un'emergenza chimica;
+- nel Lazio esistono **stabilimenti soggetti alla normativa Seveso** (D.Lgs. 105/2015), censiti nell'inventario nazionale ISPRA: chi vive o lavora vicino a uno di essi ha **diritto per legge** a essere informato dal Comune sui rischi e sui comportamenti da adottare;
+- anche **depositi di carburante e impianti minori** possono generare incendi ed esplosioni con effetti sull'area circostante.
+
+Per la spiegazione del fenomeno e della normativa leggi la pagina materia [Il rischio chimico-industriale e la direttiva Seveso](/conoscere/catalogo-dei-rischi/rischio-chimico-industriale/).
+
+## <i class="bi bi-eye-fill text-primary me-2" aria-hidden="true"></i>Segnali da riconoscere {#segnali}
+
+- **Nube anomala** (colorata o biancastra) che si alza da uno stabilimento o da un mezzo incidentato.
+- **Odore chimico intenso** e insolito, irritazione a occhi, naso o gola.
+- **Sirene o altoparlanti** delle autorità, messaggio [IT-alert](/comunicazioni/2026-05-15-iso-22322-public-warning-it-alert/) sul telefono.
+- Sui mezzi di trasporto: **pannelli arancioni con codici numerici** indicano merci pericolose. Impara a riconoscerli con la scheda [Cartelli di pericolo delle sostanze pericolose](/comunicazioni/2026-05-24-cartelli-pericolo-sostanze-pericolose-riconoscere-agire/).
+
+## <i class="bi bi-clipboard-check-fill text-primary me-2" aria-hidden="true"></i>Cosa fare PRIMA {#cosa-fare-prima}
+
+- Informati se vicino a casa, scuola o lavoro ci sono **stabilimenti a rischio di incidente rilevante**: l'inventario nazionale è pubblicato da ISPRA e i Comuni interessati hanno l'obbligo di informare la popolazione (Piano di Emergenza Esterna della Prefettura).
+- Memorizza la regola base del **riparo al chiuso**: entrare, chiudere, ascoltare.
+- Tieni in casa **nastro adesivo e panni** per sigillare porte e finestre, e una **radio a pile** nel [kit di emergenza](/rischi-prevenzione/kit-emergenza/).
+- Se assisti a un incidente che coinvolge un mezzo con pannelli arancioni, **mantieni la distanza** e chiama subito il 112 riferendo i numeri del pannello.
+
+## <i class="bi bi-exclamation-triangle-fill text-primary me-2" aria-hidden="true"></i>Cosa fare DURANTE {#cosa-fare-durante}
+
+- **Entra nell'edificio chiuso più vicino**: nella maggior parte dei rilasci tossici il riparo al chiuso protegge più della fuga all'aperto.
+- **Chiudi porte e finestre**, spegni ventilazione, condizionatori e caldaie; sigilla gli spifferi con nastro o panni umidi.
+- **Sali ai piani alti**: molti gas pericolosi sono più pesanti dell'aria e ristagnano in basso (al contrario, in caso di incendio con fumo segui le indicazioni dei soccorritori).
+- **Ascolta i canali ufficiali**: radio, IT-alert, sito e canali del Comune.
+- Se sei in auto vicino al luogo dell'incidente: chiudi i finestrini, spegni la ventilazione e allontanati **perpendicolarmente alla direzione del vento** se le autorità lo indicano.
+- Esci solo se le autorità dispongono l'**evacuazione**.
+
+## <i class="bi bi-arrow-counterclockwise text-primary me-2" aria-hidden="true"></i>Cosa fare DOPO {#cosa-fare-dopo}
+
+- Esci dal riparo **solo dopo il cessato allarme** comunicato dalle autorità.
+- **Aera bene** tutti i locali rimasti chiusi.
+- Non consumare frutta e verdura dell'orto né acqua di **pozzi privati** finché ASL e ARPA non confermano che è sicuro.
+- Se tu o un familiare avete sintomi da esposizione (irritazione agli occhi, tosse, difficoltà respiratorie), chiama il **112** o segui le indicazioni sanitarie ufficiali.
+
+{{< cosa-non-fare titolo="Cosa NON fare durante un'emergenza chimica" >}}
+- **Non avvicinarti** al luogo dell'incidente per curiosità o per fare video.
+- **Non scappare a piedi o in auto attraverso la nube**: il riparo al chiuso è quasi sempre più sicuro.
+- **Non andare a prendere i bambini a scuola** durante l'allarme: la scuola applica il proprio piano di emergenza e portarli fuori li esporrebbe.
+- **Non usare fiamme libere** né creare scintille se sospetti una fuga di gas o vapori infiammabili.
+{{< /cosa-non-fare >}}
+
+## <i class="bi bi-link-45deg text-primary me-2" aria-hidden="true"></i>Fonti e approfondimenti {#fonti}
+
+**Sul nostro sito**
+
+- **Approfondisci la materia:** [Il rischio chimico-industriale e la direttiva Seveso](/conoscere/catalogo-dei-rischi/rischio-chimico-industriale/) — la normativa, i controlli, i piani di emergenza.
+- [Rischio chimico-industriale: cosa devono sapere i cittadini](/comunicazioni/2026-05-24-rischio-chimico-industriale-cittadini/).
+- [Cartelli di pericolo delle sostanze pericolose: riconoscerli e agire](/comunicazioni/2026-05-24-cartelli-pericolo-sostanze-pericolose-riconoscere-agire/).
+- [Kit di emergenza](/rischi-prevenzione/kit-emergenza/) — radio a pile, scorte, materiale per sigillare.
+
+**Fonti istituzionali**
+
+- [Dipartimento della Protezione Civile — Rischio industriale](https://rischi.protezionecivile.gov.it/it/) — comportamenti di autoprotezione.
+- [ISPRA — Rischio industriale](https://www.isprambiente.gov.it/) — inventario nazionale degli stabilimenti a rischio di incidente rilevante.
+- [Ministero dell'Ambiente e della Sicurezza Energetica (MASE)](https://www.mase.gov.it/) — attuazione della direttiva Seveso III.
+
+{{< chi-chiamare >}}

--- a/content/rischi-prevenzione/rischio-nucleare-radiologico.md
+++ b/content/rischi-prevenzione/rischio-nucleare-radiologico.md
@@ -1,0 +1,71 @@
+---
+title: "Rischio Nucleare e Radiologico: Cosa Fare"
+dataUltimaRevisione: "2026-06-10"
+description: "L'Italia non ha centrali attive, ma il rischio radiologico esiste: riparo al chiuso, iodoprofilassi solo su indicazione ufficiale e il Piano nazionale."
+tts: true
+weight: 13
+toc: true
+# Schema.org HowTo — 3 step PRIMA/DURANTE/DOPO per rich result Google.
+howto_prima: "Sappi che in Italia non ci sono centrali nucleari attive: gli scenari riguardano incidenti a impianti esteri, sorgenti radioattive usate in medicina e industria, e i loro trasporti. Non comprare né assumere iodio di tua iniziativa: la iodoprofilassi è utile solo per scenari specifici, su indicazione ufficiale e per le categorie indicate. Tieni in casa una radio a pile e scorte per qualche giorno. Non disattivare IT-alert sul telefono."
+howto_durante: "Segui le indicazioni delle autorità: solo loro conoscono lo scenario reale. Se viene disposto il riparo al chiuso, resta in casa, chiudi porte e finestre, spegni la ventilazione e mettiti possibilmente in un locale interno. Se eri all'aperto, togli i vestiti esterni, chiudili in un sacchetto e fai una doccia. Assumi iodio stabile solo se e quando le autorità sanitarie lo dispongono. Ascolta i canali ufficiali e non diffondere voci non verificate."
+howto_dopo: "Resta al riparo finché le autorità non comunicano il cessato allarme. Segui le indicazioni ufficiali su acqua, alimenti e prodotti dell'orto: eventuali limitazioni vengono comunicate da ISS e autorità sanitarie. Non raccogliere né toccare oggetti metallici sconosciuti trovati per strada o in campagna: se sospetti una sorgente radioattiva abbandonata, allontanati e chiama il 112."
+---
+
+L'Italia non ha centrali nucleari in funzione, eppure un'emergenza radiologica è uno scenario per cui il Paese si prepara: un incidente a un impianto estero, un problema durante un trasporto di materiale radioattivo, una sorgente smarrita. La buona notizia: le regole di autoprotezione sono **poche, semplici e quasi tutte coincidono con il riparo al chiuso**.
+
+{{< emergenza-ora >}}
+
+## <i class="bi bi-info-circle-fill text-primary me-2" aria-hidden="true"></i>Perché è rilevante anche per noi {#perche-rilevante}
+
+Per il territorio di Genzano di Roma non esistono impianti nucleari né scenari locali specifici. Il rischio per il cittadino dei Castelli Romani è quindi **indiretto e a bassa probabilità**, ma reale a scala nazionale:
+
+- un **incidente a una centrale oltre confine** (Francia, Svizzera, Slovenia) potrebbe avere ricadute sull'Italia, gestite dal **Piano nazionale per la gestione delle emergenze radiologiche e nucleari**;
+- **sorgenti radioattive** sono usate ogni giorno in ospedali, industrie e centri di ricerca, e viaggiano su strada;
+- una **sorgente smarrita o abbandonata** (per esempio in un carico di rottami metallici) è lo scenario radiologico più frequente in assoluto.
+
+Per la spiegazione del fenomeno e delle autorità competenti leggi la pagina materia [Il rischio nucleare e radiologico](/conoscere/catalogo-dei-rischi/rischio-nucleare-radiologico/).
+
+## <i class="bi bi-clipboard-check-fill text-primary me-2" aria-hidden="true"></i>Cosa fare PRIMA {#cosa-fare-prima}
+
+- **Non comprare né assumere iodio di tua iniziativa**: la iodoprofilassi protegge solo la tiroide, solo per alcuni scenari, e ha senso solo se disposta dalle autorità sanitarie, per le categorie indicate (soprattutto bambini e giovani). Assunta a caso può fare male.
+- Tieni in casa una **radio a pile** e le scorte del [kit di emergenza](/rischi-prevenzione/kit-emergenza/): le regole del riparo al chiuso sono le stesse di altri rischi.
+- **Non disattivare IT-alert**: è il canale con cui le autorità raggiungono in pochi secondi i telefoni dell'area interessata.
+- Ricorda i tre principi della radioprotezione: **distanza** dalla sorgente, **tempo** di esposizione ridotto, **schermatura** (i muri di casa schermano).
+
+## <i class="bi bi-exclamation-triangle-fill text-primary me-2" aria-hidden="true"></i>Cosa fare DURANTE {#cosa-fare-durante}
+
+- **Segui le indicazioni delle autorità**: è la regola d'oro. Solo loro conoscono l'entità reale dell'evento; le misure (riparo al chiuso, iodoprofilassi, limitazioni alimentari) dipendono dallo scenario.
+- Se viene disposto il **riparo al chiuso**: resta in casa, chiudi porte e finestre, spegni ventilazione e condizionatori, mettiti in un locale possibilmente interno.
+- Se eri all'aperto: **togli i vestiti esterni**, chiudili in un sacchetto di plastica lontano dalle persone e **fai una doccia** con acqua e sapone.
+- Assumi **iodio stabile solo se e quando** le autorità sanitarie lo dispongono ufficialmente.
+- Ascolta i **canali ufficiali** (radio, IT-alert, Protezione Civile) e non rilanciare voci non verificate: nelle emergenze radiologiche la disinformazione corre più veloce della contaminazione.
+
+## <i class="bi bi-arrow-counterclockwise text-primary me-2" aria-hidden="true"></i>Cosa fare DOPO {#cosa-fare-dopo}
+
+- Resta al riparo **finché le autorità non comunicano il cessato allarme**.
+- Segui le indicazioni ufficiali su **acqua, latte, alimenti e prodotti dell'orto**: eventuali limitazioni temporanee vengono comunicate dalle autorità sanitarie.
+- **Non toccare oggetti metallici sconosciuti** trovati per strada, in campagna o tra i rottami: se un oggetto riporta il simbolo del trifoglio radioattivo, o sospetti una sorgente abbandonata, allontanati e chiama il **112**.
+
+{{< cosa-non-fare titolo="Cosa NON fare in un'emergenza radiologica" >}}
+- **Non assumere iodio di tua iniziativa**: senza indicazione ufficiale è inutile o dannoso.
+- **Non metterti in viaggio** per allontanarti se le autorità hanno disposto il riparo al chiuso: all'aperto ti esponi di più.
+- **Non diffondere voci e catene non verificate**: usa solo fonti ufficiali (DPC, ISIN, ISS, Prefettura).
+- **Non maneggiare oggetti sospetti** con il simbolo del trifoglio o provenienti da carichi sconosciuti.
+{{< /cosa-non-fare >}}
+
+## <i class="bi bi-link-45deg text-primary me-2" aria-hidden="true"></i>Fonti e approfondimenti {#fonti}
+
+**Sul nostro sito**
+
+- **Approfondisci la materia:** [Il rischio nucleare e radiologico](/conoscere/catalogo-dei-rischi/rischio-nucleare-radiologico/) — la differenza fra nucleare e radiologico, le autorità, il Piano nazionale.
+- [Tōhoku-Fukushima 2011: quando un maremoto innesca emergenze multiple](/comunicazioni/2026-03-11-tohoku-fukushima-2011-tsunami-emergenze-multiple/).
+- [Rischio chimico-industriale: cosa fare](/rischi-prevenzione/rischio-industriale/) — l'altro rischio antropico, con regole simili.
+- [Kit di emergenza](/rischi-prevenzione/kit-emergenza/).
+
+**Fonti istituzionali**
+
+- [Dipartimento della Protezione Civile — Rischio nucleare e radiologico](https://rischi.protezionecivile.gov.it/it/) — il Piano nazionale e i comportamenti di autoprotezione.
+- [ISIN — Ispettorato nazionale per la sicurezza nucleare e la radioprotezione](https://www.isinucleare.it/) — autorità di regolamentazione e controllo.
+- [Istituto Superiore di Sanità (ISS)](https://www.iss.it/) — radioprotezione della popolazione e iodoprofilassi.
+
+{{< chi-chiamare >}}

--- a/content/rischi-prevenzione/siccita.md
+++ b/content/rischi-prevenzione/siccita.md
@@ -1,0 +1,75 @@
+---
+title: "Siccità e Crisi Idrica: Cosa Fare"
+dataUltimaRevisione: "2026-06-10"
+description: "La siccità è un rischio lento ma concreto anche ai Castelli Romani: come ridurre i consumi, prepararsi alle limitazioni e affrontare una crisi idrica."
+tts: true
+weight: 14
+toc: true
+# Schema.org HowTo — 3 step PRIMA/DURANTE/DOPO per rich result Google.
+howto_prima: "Riduci gli sprechi tutto l'anno: ripara i rubinetti che gocciolano, preferisci la doccia alla vasca, usa lavatrice e lavastoviglie a pieno carico. Installa riduttori di flusso sui rubinetti. Se hai un giardino o un orto, innaffia la sera e valuta la raccolta dell'acqua piovana dove consentito. Segnala al gestore idrico le perdite che vedi in strada. Tieni in casa una scorta minima di acqua potabile come previsto dal kit di emergenza."
+howto_durante: "Durante una crisi idrica rispetta le ordinanze comunali: i divieti tipici riguardano l'irrigazione di giardini, il lavaggio di auto e cortili e il riempimento di piscine private. Riduci i consumi essenziali: docce brevi, riutilizzo dell'acqua di lavaggio delle verdure per le piante. Se l'erogazione viene sospesa a fasce orarie, riempi contenitori puliti per le necessità della giornata e conservali coperti. Per le persone fragili verifica che abbiano acqua a sufficienza."
+howto_dopo: "Quando la crisi rientra, mantieni le buone abitudini: la siccità è ricorrente e la falda si ricarica in anni, non in giorni. Dopo una sospensione prolungata dell'erogazione, fai scorrere l'acqua qualche minuto prima di berla e segui le indicazioni del gestore sulla potabilità. Continua a segnalare le perdite della rete."
+---
+
+La siccità non arriva con un boato: è un **rischio lento**, fatto di mesi con poca pioggia, falde che si abbassano e ordinanze che limitano l'uso dell'acqua. Anche i Castelli Romani la conoscono: la risorsa idrica del nostro territorio è preziosa e va protetta tutto l'anno, non solo quando manca.
+
+{{< emergenza-ora >}}
+
+## <i class="bi bi-info-circle-fill text-primary me-2" aria-hidden="true"></i>Perché è rilevante sul nostro territorio {#perche-rilevante}
+
+I Castelli Romani dipendono in larga parte dalla **falda vulcanica dei Colli Albani**, alimentata solo dalle piogge: anni di precipitazioni scarse e prelievi elevati ne abbassano il livello, come mostra anche il calo storico dei laghi di **Albano** e di **Nemi**, documentato dagli enti di ricerca. Le crisi idriche del 2017 e degli anni successivi hanno interessato anche il Lazio, con misure di contenimento dei consumi.
+
+Con il cambiamento climatico le estati diventano più calde e le piogge più irregolari: gli scenari del CMCC indicano per il Mediterraneo un aumento della frequenza delle siccità. Per la spiegazione scientifica del fenomeno leggi la pagina materia [Il rischio da deficit idrico](/conoscere/catalogo-dei-rischi/rischio-siccita/).
+
+## <i class="bi bi-eye-fill text-primary me-2" aria-hidden="true"></i>Segnali e situazioni tipiche {#segnali}
+
+- **Bollettini degli osservatori**: l'Autorità di Bacino dell'Appennino Centrale classifica la **severità idrica** in quattro livelli (normale, bassa, media, alta).
+- **Ordinanze comunali** di limitazione dell'uso dell'acqua potabile, tipiche dei mesi estivi.
+- **Riduzioni di pressione o sospensioni a fasce orarie** decise dal gestore idrico.
+- Sul territorio: sorgenti e fontanili in secca, livelli dei laghi visibilmente bassi.
+
+## <i class="bi bi-clipboard-check-fill text-primary me-2" aria-hidden="true"></i>Cosa fare PRIMA {#cosa-fare-prima}
+
+- **Ripara le perdite domestiche**: un rubinetto che gocciola spreca migliaia di litri l'anno; lo sciacquone che perde, molti di più.
+- Installa **riduttori di flusso** (frangigetto) su rubinetti e doccia: costano pochi euro e riducono i consumi fino a metà.
+- Usa **lavatrice e lavastoviglie a pieno carico**; preferisci la doccia breve alla vasca.
+- Se hai orto o giardino: **innaffia la sera**, usa pacciamatura, valuta la raccolta dell'acqua piovana dove consentito dai regolamenti.
+- **Segnala al gestore idrico le perdite in strada**: in Italia le reti disperdono in media circa il 30% dell'acqua immessa.
+- Tieni la scorta minima d'acqua del [kit di emergenza](/rischi-prevenzione/kit-emergenza/) (utile anche per blackout e altri eventi).
+
+## <i class="bi bi-exclamation-triangle-fill text-primary me-2" aria-hidden="true"></i>Cosa fare DURANTE {#cosa-fare-durante}
+
+- **Rispetta le ordinanze comunali**: i divieti tipici riguardano irrigazione di giardini, lavaggio di auto e cortili, riempimento di piscine private. Non sono formalità: l'acqua risparmiata serve agli usi potabili.
+- Riduci ulteriormente i consumi: docce più brevi, riutilizzo dell'acqua di lavaggio delle verdure per le piante, chiudi il rubinetto mentre ti lavi i denti.
+- Se l'erogazione è **sospesa a fasce orarie**: riempi contenitori puliti per le necessità della giornata, tienili coperti e al fresco, e usa per bere solo acqua conservata correttamente.
+- **Verifica le persone fragili** del vicinato (anziani soli, persone con disabilità): che abbiano acqua a sufficienza, soprattutto se la crisi idrica coincide con un'[ondata di calore](/rischi-prevenzione/ondate-di-calore/).
+
+## <i class="bi bi-arrow-counterclockwise text-primary me-2" aria-hidden="true"></i>Cosa fare DOPO {#cosa-fare-dopo}
+
+- **Mantieni le buone abitudini** anche quando torna la pioggia: la falda si ricarica in anni, non in giorni, e la siccità è un rischio ricorrente.
+- Dopo una sospensione prolungata dell'erogazione, **fai scorrere l'acqua** qualche minuto prima di usarla per bere e segui le comunicazioni del gestore sulla potabilità.
+- Continua a **segnalare le perdite** della rete: è la misura strutturale più efficace.
+
+{{< cosa-non-fare titolo="Cosa NON fare durante una crisi idrica" >}}
+- **Non ignorare le ordinanze** di limitazione: oltre alle sanzioni, sottraggono acqua potabile a tutti.
+- **Non usare acqua potabile per usi non essenziali** (lavare l'auto, riempire piscine, irrigare prati).
+- **Non bere acqua di pozzi, sorgenti o fontanili non controllati**: la scarsità non la rende sicura.
+- **Non accumulare scorte eccessive** di acqua in bottiglia: crea carenze artificiali; bastano le scorte del kit.
+{{< /cosa-non-fare >}}
+
+## <i class="bi bi-link-45deg text-primary me-2" aria-hidden="true"></i>Fonti e approfondimenti {#fonti}
+
+**Sul nostro sito**
+
+- **Approfondisci la materia:** [Il rischio da deficit idrico (siccità)](/conoscere/catalogo-dei-rischi/rischio-siccita/) — come si misura, le cause, la gestione.
+- [Giornata mondiale dell'acqua: la rete idrica e la sua sicurezza](/comunicazioni/2026-03-22-giornata-mondiale-acqua-rete-idrica-sicurezza/).
+- [Ondate di calore](/rischi-prevenzione/ondate-di-calore/) — il rischio "gemello" delle estati siccitose.
+- [Kit di emergenza](/rischi-prevenzione/kit-emergenza/) — la scorta d'acqua di casa.
+
+**Fonti istituzionali**
+
+- [Autorità di Bacino Distrettuale dell'Appennino Centrale](https://www.autoritadistrettoappenninocentrale.it/) — Osservatorio sugli utilizzi idrici competente per il Lazio.
+- [ISPRA](https://www.isprambiente.gov.it/) — dati su risorse idriche e siccità.
+- [CMCC — Centro Euro-Mediterraneo sui Cambiamenti Climatici](https://www.cmcc.it/) — scenari climatici per il Mediterraneo.
+
+{{< chi-chiamare >}}

--- a/scripts/dizionario-pc.txt
+++ b/scripts/dizionario-pc.txt
@@ -296,3 +296,7 @@ alfabetiere
 epidermolisi
 Olly
 ollyaps
+tsunamigenici
+controintuitiva
+iodoprofilassi
+frangigetto


### PR DESCRIPTION
## Fix dall'audit del 10 giugno 2026

- **Link rotto** in `content/conoscere/catalogo-dei-rischi/rischio-incendio.md` (righe 56 e 79): l'articolo "avvio campagna AIB Lazio 2026" non esiste → retarget al bilancio del primo mese AIB (si attiva automaticamente il 30/06).
- **Ordering articoli stesso giorno**: i due articoli del 2026-06-07 ora hanno orari crescenti `T00:01/T00:02` (script idempotente `fix-ordering-articoli-stesso-giorno.py`).
- **Description >160 char** nell'articolo Caldo e Salute: 172 → 151 caratteri.
- **`archiviato: true`** su 6 articoli con `scadenza:` passata (mostra Napoli, open day Aprilia, Salone Torino, mezzi Marino, Infiorata ragazzi, riapertura Nemorense).

## Copertura rischi mancanti — 4 nuove pagine operative

Nuove pagine in `/rischi-prevenzione/` con lo schema fisso della rule 06 (PRIMA/DURANTE/DOPO + `cosa-non-fare` + `chi-chiamare` + frontmatter HowTo per Schema.org):

| Pagina | Note |
|---|---|
| `rischio-industriale` | NaTech/Seveso: riparo al chiuso, pannelli arancioni merci pericolose, D.Lgs. 105/2015 |
| `maremoto` | Per chi frequenta il litorale laziale: segnali naturali, SiAM, IT-alert. `lis_section: maremoto` |
| `rischio-nucleare-radiologico` | Piano nazionale, iodoprofilassi solo su indicazione ufficiale |
| `siccita` | Falda dei Colli Albani, ordinanze comunali, risparmio idrico |

**Cross-link** (rule 07): tabella "Principali rischi" dell'hub, 4 card in mappa-sito (icone verificate nel font Bootstrap Icons self-hostato), backlink "pagina operativa" dalle 4 pagine materia del catalogo `/conoscere/catalogo-dei-rischi/`.

**Verifiche**: build Hugo 0.154.0 pulita (exit 0, 4 pagine renderizzate), spell-check hunspell OK (+4 termini tecnici al dizionario), nessun diff su campi `image:`, nessun pattern viabilità vietato (Circolare DPC 6/8/2018).

https://claude.ai/code/session_01GyREwc3e6cWJqcWvWXNPfX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyREwc3e6cWJqcWvWXNPfX)_