### PR TITLE
Kit di emergenza per le organizzazioni (commerciali, condomìni, associazioni, eventi)

### DIFF
--- a/content/kit-organizzazioni/_index.md
+++ b/content/kit-organizzazioni/_index.md
@@ -1,0 +1,20 @@
+---
+title: "Kit di emergenza per le organizzazioni"
+description: "Schede pratiche di preparazione all'emergenza per attività commerciali, condomìni, associazioni e organizzatori di eventi a Genzano di Roma e nei Castelli Romani."
+layout: "list"
+tts: true
+sitemap:
+  priority: 0.8
+  changefreq: monthly
+dataUltimaRevisione: "2026-06-15"
+---
+
+La preparazione all'emergenza non riguarda solo le famiglie. Anche **un negozio, un condominio, una sede di associazione o un evento pubblico** sono luoghi dove si trovano molte persone, spesso non del posto, che in un'emergenza guardano a chi gestisce lo spazio per sapere cosa fare.
+
+Queste schede aiutano chi ha una responsabilità su un luogo o su un gruppo di persone a **prepararsi prima**, sapere **cosa fare durante** un terremoto, un incendio, un'allerta meteo o un blackout, e **gestire il dopo**. Sono pensate sul modello dei programmi internazionali di preparazione — come *Ready Business* della protezione civile statunitense (FEMA) e *Prepare* del Regno Unito — adattate al territorio di Genzano di Roma e dei Castelli Romani.
+
+Ogni scheda è **gratuita, riutilizzabile e stampabile**. Non sostituisce gli obblighi di legge (per esempio il piano di emergenza dei luoghi di lavoro previsto dal Testo Unico sulla sicurezza, D.Lgs. 81/2008): li affianca con indicazioni pratiche di autoprotezione, in linea con le campagne del Dipartimento della Protezione Civile.
+
+## A chi servono
+
+Scegli la scheda più vicina alla tua situazione. Se gestisci più realtà (per esempio sei amministratore di condominio e titolare di un'attività), puoi usarne più di una.

--- a/content/kit-organizzazioni/associazioni-e-sedi.md
+++ b/content/kit-organizzazioni/associazioni-e-sedi.md
@@ -1,0 +1,68 @@
+---
+title: "Kit di emergenza per associazioni e sedi"
+description: "Come una sede di associazione, un circolo o un luogo di aggregazione si prepara all'emergenza: piano interno, registro presenze, persone fragili."
+layout: "single"
+tts: true
+weight: 3
+sitemap:
+  priority: 0.7
+  changefreq: monthly
+dataUltimaRevisione: "2026-06-15"
+---
+
+Una sede di associazione, un circolo, un oratorio o un centro culturale ospita riunioni, corsi e attività con molte persone, spesso bambini o anziani. Chi apre e gestisce lo spazio ha una **responsabilità verso chi entra**: sapere cosa fare in un'emergenza è parte della cura di quel luogo.
+
+Questa scheda aiuta **referenti e volontari** di una sede a darsi poche regole semplici e condivise. Se nella sede si svolge attività con lavoratori o dipendenti, valgono anche gli obblighi del Testo Unico sulla sicurezza (D.Lgs. 81/2008).
+
+## Perché prepararsi a Genzano
+
+Nei Castelli Romani il rischio sismico e i temporali intensi sono concreti. Una sede affollata da persone che non conoscono i locali ha bisogno di un piano chiaro e di volontari che sappiano cosa fare.
+
+## Cosa fare PRIMA
+
+- **Scrivi un piano interno in una pagina.** Uscite, estintori, chiusura di gas ed elettricità, punto di raccolta all'esterno. Appendilo all'ingresso.
+- **Tieni un registro delle presenze** durante le attività, soprattutto con minori: in emergenza serve sapere quante persone contare al punto di raccolta.
+- **Designa un referente per turno.** Chi apre la sede sa che, in emergenza, guida l'uscita e conta le persone.
+- **Conta le persone fragili presenti.** Bambini, anziani, persone con disabilità: pensa prima a chi le aiuta a uscire.
+- **Prepara un kit minimo.** Torcia, cassetta di primo soccorso, numeri utili su carta, fischietto, radio a batterie.
+- **Tieni libere le vie di fuga** e verifica che le uscite di sicurezza si aprano davvero.
+
+## Cosa fare DURANTE
+
+**Terremoto.** Invita i presenti a ripararsi sotto i tavoli, lontano da finestre, scaffali e oggetti appesi. Non far correre nessuno durante la scossa. Si esce **dopo**, con calma, verso il punto di raccolta.
+
+**Incendio.** Fai uscire tutti subito dall'uscita più vicina. Conta le persone al punto di raccolta usando il registro. Usa l'estintore solo su un principio di incendio e solo se sai farlo. Non usare l'ascensore. Chiama il 112.
+
+**Allerta meteo.** Con allerta arancione o rossa, valuta di sospendere o rinviare le attività, soprattutto quelle con bambini e anziani. Segui i canali ufficiali e il nostro sito.
+
+**Blackout.** Illumina con le torce, mantieni la calma, rassicura i presenti e aiuta i più fragili. Sospendi le attività se l'oscurità si prolunga.
+
+## Cosa fare DOPO
+
+- Verifica che tutti i presenti stiano bene, partendo dai più fragili, e confronta con il registro.
+- Non rientrare in una sede lesionata dal terremoto finché non è dichiarata agibile.
+- Segnala al 112 i pericoli concreti; informa i responsabili dell'edificio dei danni.
+
+{{< cosa-non-fare titolo="Cosa NON fare nella sede" >}}
+- **Non lasciare le uscite di sicurezza chiuse a chiave** durante le attività.
+- **Non ingombrare le vie di fuga** con sedie, tavoli o materiali.
+- **Non far correre i presenti** verso l'uscita durante una scossa.
+- **Non usare l'ascensore** in caso di incendio o terremoto.
+- **Non proseguire le attività** con minori durante un'allerta arancione o rossa.
+{{< /cosa-non-fare >}}
+
+## Per approfondire
+
+**Sul nostro sito:**
+
+- [Piano familiare](/piano-familiare/) — il metodo, applicabile a una squadra di volontari.
+- [Rischi e prevenzione](/rischi-prevenzione/) — le schede per ogni rischio.
+- [Diventa volontario](/diventa-volontario/) — se la tua associazione vuole fare rete con la Protezione Civile.
+- [Numeri utili](/numeri-utili/).
+
+**Fonti istituzionali:**
+
+- [Dipartimento della Protezione Civile — Io non rischio](https://www.protezionecivile.gov.it/) — buone pratiche di autoprotezione.
+- [Vigili del Fuoco](https://www.vigilfuoco.it/) — sicurezza antincendio nei luoghi affollati.
+
+{{< chi-chiamare >}}

--- a/content/kit-organizzazioni/attivita-commerciali.md
+++ b/content/kit-organizzazioni/attivita-commerciali.md
@@ -1,0 +1,69 @@
+---
+title: "Kit di emergenza per le attività commerciali"
+description: "Come preparare un negozio, un bar o un ristorante a terremoto, incendio, allerta meteo e blackout: piano, kit, clienti e dipendenti."
+layout: "single"
+tts: true
+weight: 1
+sitemap:
+  priority: 0.7
+  changefreq: monthly
+dataUltimaRevisione: "2026-06-15"
+---
+
+Un negozio, un bar o un ristorante accolgono ogni giorno persone che non conoscono i locali: non sanno dove sono le uscite, dove si chiude il gas, dove ci si raccoglie. In un'emergenza, **chi gestisce l'attività diventa il punto di riferimento** per clienti e dipendenti. Bastano poche cose preparate prima per fare la differenza.
+
+Questa scheda riguarda l'autoprotezione. Se hai dipendenti, hai anche **obblighi di legge** sulla sicurezza del lavoro (Testo Unico, D.Lgs. 81/2008): valutazione dei rischi, piano di emergenza ed evacuazione, addetti formati all'antincendio e al primo soccorso. Le indicazioni qui sotto affiancano quegli obblighi, non li sostituiscono.
+
+## Perché prepararsi a Genzano
+
+Genzano di Roma è nei Castelli Romani, un'area con rischio sismico, temporali intensi e fragilità idrogeologica sui versanti. Un'attività ben preparata protegge le persone, riduce i danni e riapre prima.
+
+## Cosa fare PRIMA
+
+- **Scrivi un piano in una pagina.** Dove sono le uscite, dove si chiudono gas ed elettricità, dove si trova l'estintore, qual è il punto di raccolta fuori dal locale. Tienilo visibile al personale.
+- **Forma chi lavora con te.** Anche solo dieci minuti: mostra a ogni nuovo collaboratore le uscite, gli estintori e il punto di raccolta.
+- **Prepara un kit minimo.** Torcia con batterie cariche, cassetta di primo soccorso, copia cartacea dei numeri utili, fischietto, una radio a batterie. Controllalo ogni sei mesi.
+- **Tieni libere le vie di fuga.** Niente scatoloni, espositori o sedie davanti alle uscite di sicurezza.
+- **Salva i contatti importanti.** Proprietario dei locali, tecnici di gas ed elettricità, assicurazione. In un foglio, non solo nel telefono.
+- **Conosci i tuoi clienti fragili.** Se hai clienti abituali anziani o con disabilità, pensa in anticipo a come aiutarli a uscire.
+
+## Cosa fare DURANTE
+
+**Terremoto.** Non far correre nessuno verso l'uscita durante la scossa: cadute e calca feriscono più del terremoto. Invita clienti e personale a ripararsi sotto i tavoli, lontano da vetrine, scaffali e bottiglie. Si esce **dopo** la scossa, con calma.
+
+**Incendio.** Fai uscire tutti subito dall'uscita più vicina e sicura. Usa l'estintore solo su un principio di incendio e solo se sai farlo. Non usare l'ascensore. Chiama il 112. Raggiungi il punto di raccolta e conta le persone.
+
+**Allerta meteo o allagamento.** Se è prevista allerta arancione o rossa, valuta di chiudere o di non aprire. Stacca le attrezzature elettriche se l'acqua entra. Non far scendere nessuno in scantinati o magazzini interrati.
+
+**Blackout.** Mantieni la calma e illumina con le torce, mai con fiamme libere. Apri la cassa manualmente se serve. Aiuta i clienti a uscire in sicurezza se l'attività resta al buio a lungo.
+
+## Cosa fare DOPO
+
+- Verifica che clienti e personale stiano bene prima di pensare ai danni.
+- Non rientrare in un edificio lesionato dal terremoto finché non è dichiarato agibile.
+- Fotografa i danni per l'assicurazione prima di rimuovere nulla.
+- Segnala pericoli concreti (fughe di gas, crolli, cavi scoperti) al 112.
+
+{{< cosa-non-fare titolo="Cosa NON fare nell'attività" >}}
+- **Non bloccare le uscite di sicurezza** con merce, espositori o arredi.
+- **Non mandare i clienti di corsa verso la porta** durante una scossa.
+- **Non usare l'ascensore** in caso di incendio o terremoto.
+- **Non usare candele o fiamme** durante un blackout, soprattutto se sospetti una fuga di gas.
+- **Non rientrare** in un locale lesionato per recuperare merce o registratori di cassa.
+{{< /cosa-non-fare >}}
+
+## Per approfondire
+
+**Sul nostro sito:**
+
+- [Piano familiare](/piano-familiare/) — lo stesso metodo, adattabile alla tua squadra.
+- [Kit di emergenza](/rischi-prevenzione/kit-emergenza/) — cosa mettere nel kit minimo.
+- [Rischi e prevenzione](/rischi-prevenzione/) — schede dettagliate per terremoto, incendio, temporali, blackout.
+- [Numeri utili](/numeri-utili/) — i numeri da tenere in cassa.
+
+**Fonti istituzionali:**
+
+- [Vigili del Fuoco](https://www.vigilfuoco.it/) — prevenzione incendi nei luoghi di lavoro.
+- [Dipartimento della Protezione Civile — Io non rischio](https://www.protezionecivile.gov.it/) — buone pratiche di autoprotezione.
+
+{{< chi-chiamare >}}

--- a/content/kit-organizzazioni/condominio.md
+++ b/content/kit-organizzazioni/condominio.md
@@ -1,0 +1,68 @@
+---
+title: "Kit di emergenza per il condominio"
+description: "Come un condominio si prepara a terremoto, incendio, allagamento e blackout: punto di raccolta, persone fragili ai piani, gas e ascensori."
+layout: "single"
+tts: true
+weight: 2
+sitemap:
+  priority: 0.7
+  changefreq: monthly
+dataUltimaRevisione: "2026-06-15"
+---
+
+In un condominio vivono decine di persone che spesso non si conoscono e non sanno chi, tra i vicini, ha bisogno di aiuto. In un'emergenza — un terremoto, un incendio, un allagamento — **organizzarsi prima tra residenti** salva tempo e protegge i più fragili. Non serve un esperto: bastano accordi semplici e condivisi.
+
+Questa scheda è pensata per **amministratori e residenti**. L'amministratore può promuovere queste misure e portarle in assemblea; ogni residente può fare la sua parte anche da solo.
+
+## Perché prepararsi a Genzano
+
+I Castelli Romani sono zona a rischio sismico, con temporali intensi e fragilità dei versanti. In un edificio con più piani, le scale, gli ascensori, il gas e le persone fragili ai piani alti richiedono un minimo di organizzazione condivisa.
+
+## Cosa fare PRIMA
+
+- **Scegli un punto di raccolta.** Uno spazio aperto vicino all'edificio, lontano da cose che possono cadere (cornicioni, alberi, linee elettriche). Comunicalo a tutti i residenti.
+- **Fai una mappa delle fragilità.** Sapere, con discrezione e rispetto della privacy, chi tra i vicini è anziano, ha disabilità, usa apparecchi elettromedicali o vive solo. In emergenza, qualcuno passa a controllarli.
+- **Conosci i punti di chiusura.** Dove si chiudono il gas e l'acqua dell'edificio, dove si stacca la corrente delle parti comuni. Segnalali con un'etichetta.
+- **Tieni libere scale e uscite.** Niente biciclette, scope o scatoloni sui pianerottoli e davanti alle uscite.
+- **Prepara la bacheca dell'emergenza.** Un foglio nell'androne con i numeri utili, il punto di raccolta e i comportamenti di base. Aggiornalo una volta all'anno.
+- **Verifica gli estintori comuni**, se presenti, e la loro manutenzione.
+
+## Cosa fare DURANTE
+
+**Terremoto.** Durante la scossa, ognuno si ripara dentro casa, sotto un tavolo o accanto a un muro portante, lontano da finestre e mobili alti. **Non si scende per le scale durante la scossa** e **non si usa l'ascensore**. Si esce verso il punto di raccolta solo dopo, con calma.
+
+**Incendio in un appartamento.** Chi è nell'appartamento esce e chiude la porta dietro di sé per rallentare le fiamme. Si avvisano i vicini e si chiama il 112. **Non si usa l'ascensore.** Se il fumo blocca le scale, ci si chiude in una stanza con la porta sigillata da panni bagnati e ci si fa vedere dalla finestra.
+
+**Allagamento.** Non scendere in cantine, garage e locali interrati che si stanno allagando: la corrente d'acqua e il rischio elettrico sono mortali. Stacca la corrente delle parti comuni allagate solo se puoi farlo in sicurezza.
+
+**Blackout.** Illumina con le torce, mai con candele se sospetti fughe di gas. Controlla i vicini fragili, soprattutto chi dipende da apparecchi elettromedicali, e aiutali a contattare i soccorsi se serve.
+
+## Cosa fare DOPO
+
+- Verificate tra vicini che stiano tutti bene, a partire dalle persone fragili.
+- Non rientrate in un edificio lesionato dal terremoto finché non è dichiarato agibile dai tecnici.
+- Segnalate all'amministratore i danni alle parti comuni; segnalate al 112 i pericoli concreti (fughe di gas, crolli, cavi scoperti).
+
+{{< cosa-non-fare titolo="Cosa NON fare in condominio" >}}
+- **Non usare l'ascensore** durante terremoto, incendio o blackout.
+- **Non scendere per le scale durante la scossa**: ci si ripara e si esce dopo.
+- **Non entrare in cantine e garage allagati.**
+- **Non ingombrare scale, pianerottoli e uscite** con oggetti personali.
+- **Non rientrare** in un edificio lesionato senza il via libera dei tecnici.
+{{< /cosa-non-fare >}}
+
+## Per approfondire
+
+**Sul nostro sito:**
+
+- [Piano familiare](/piano-familiare/) — il piano del singolo nucleo, complementare a quello condominiale.
+- [Rischio sismico](/rischi-prevenzione/rischio-sismico/) e [rischio idrogeologico](/rischi-prevenzione/rischio-idrogeologico/).
+- [Aree di attesa](/aree-attesa/) — dove andare se il punto di raccolta condominiale non basta.
+- [Numeri utili](/numeri-utili/).
+
+**Fonti istituzionali:**
+
+- [Dipartimento della Protezione Civile — Io non rischio](https://www.protezionecivile.gov.it/) — autoprotezione sismica e alluvione.
+- [Vigili del Fuoco](https://www.vigilfuoco.it/) — comportamenti in caso di incendio negli edifici.
+
+{{< chi-chiamare >}}

--- a/content/kit-organizzazioni/organizzatori-di-eventi.md
+++ b/content/kit-organizzazioni/organizzatori-di-eventi.md
@@ -1,0 +1,75 @@
+---
+title: "Kit di emergenza per gli organizzatori di eventi"
+description: "Come prepara la sicurezza chi organizza una sagra, una festa o una manifestazione: piano, vie di fuga, soccorso, e cosa può e non può fare il volontariato di PC."
+layout: "single"
+tts: true
+weight: 4
+sitemap:
+  priority: 0.7
+  changefreq: monthly
+dataUltimaRevisione: "2026-06-15"
+---
+
+Chi organizza una sagra, una festa patronale, un concerto o una manifestazione pubblica si assume la responsabilità della **sicurezza delle persone che partecipano**. La preparazione non è un adempimento formale: in caso di calca, maltempo improvviso o malore, un'organizzazione pianificata in anticipo salva vite.
+
+Questa scheda è un promemoria operativo per gli organizzatori. **Non sostituisce** il piano di *safety* e *security* richiesto per le manifestazioni pubbliche. Quel piano è definito dalla circolare del Ministero dell'Interno del 7 giugno 2017 (la cosiddetta "circolare Gabrielli") e dalle indicazioni successive. Per costruirlo devi confrontarti con il Comune, la Polizia Locale, le Forze dell'Ordine, i Vigili del Fuoco e il 118.
+
+## Cosa prepara l'organizzatore
+
+- **Un piano di sicurezza scritto**, proporzionato alla dimensione dell'evento: capienza massima, vie di accesso e di fuga, punti di raccolta, posizione dei presìdi sanitari e antincendio.
+- **Vie di fuga libere e segnalate**, mai bloccate da banchi, palchi o transenne.
+- **Un presidio sanitario** dimensionato al pubblico atteso, in collegamento con il 118.
+- **Un piano per il maltempo**: cosa fare se arriva un temporale, dove far riparare le persone, quando sospendere. Tieni d'occhio le [allerte meteo del Centro Funzionale Regionale Lazio](/allerte-meteo/).
+- **Comunicazione chiara al pubblico**: annunci, cartelli, indicazioni su uscite e punti di raccolta.
+- **Coordinamento preventivo** con Comune, Polizia Locale, Forze dell'Ordine, Vigili del Fuoco e 118: chi fa cosa, e con quali contatti, va deciso prima dell'evento.
+
+## Cosa fare DURANTE
+
+- Tieni sempre **libere e visibili le uscite**.
+- In caso di **maltempo improvviso**, attiva il piano deciso prima: invita il pubblico a riparare nelle aree individuate o sospendi l'evento. Non aspettare che la situazione peggiori.
+- In caso di **malore o incidente**, attiva subito il presidio sanitario e chiama il 112.
+- In caso di **principio di incendio o crollo**, fai allontanare il pubblico verso i punti di raccolta e chiama il 112.
+- Mantieni il **collegamento radio** con i referenti dei vari punti dell'evento.
+
+## Cosa fare DOPO
+
+- Verifica che non ci siano persone in difficoltà nelle aree dell'evento.
+- Segnala al 112 i pericoli concreti.
+- Annota cosa ha funzionato e cosa no, per migliorare l'organizzazione la volta successiva.
+
+## Il ruolo del volontariato di Protezione Civile
+
+Se il Comune attiva il Gruppo Comunale Volontari di Protezione Civile a supporto di una manifestazione, il volontariato può svolgere **solo** i compiti previsti dalla normativa:
+
+- informazione alla popolazione su percorsi, accessi e limitazioni decise dalle autorità;
+- presidio delle aree pedonali dedicate, dei punti di raccolta e delle vie di fuga;
+- comunicazione al pubblico, supporto logistico, primo soccorso in collegamento con il 118;
+- monitoraggio meteo, collegamento radio, assistenza alle persone fragili.
+
+> Il volontariato di Protezione Civile **non può svolgere regolazione del traffico, servizi di polizia stradale né utilizzare palette dirigitraffico**: sono compiti di competenza esclusiva delle Forze dell'Ordine e della Polizia Locale, come stabilito dagli articoli 11 e 12 del Codice della Strada (D.Lgs. 285/1992) e ribadito dalla [Circolare del Dipartimento della Protezione Civile del 6 agosto 2018](https://www.protezionecivile.gov.it/it/normativa/circolare-del-6-agosto-2018-manifestazioni-pubbliche-precisazioni-sullattivazione-e-limpiego-del-volontariato-di-protezione-civile/).
+
+L'attivazione del Gruppo avviene **su mandato del Comune**, non su richiesta diretta dell'organizzatore.
+
+{{< cosa-non-fare titolo="Cosa NON fare in un evento pubblico" >}}
+- **Non bloccare le vie di fuga** con palchi, banchi o transenne.
+- **Non superare la capienza massima** prevista per l'area.
+- **Non affidare la regolazione del traffico ai volontari di Protezione Civile**: è compito delle Forze dell'Ordine e della Polizia Locale.
+- **Non rinviare le decisioni sul maltempo** all'ultimo momento: il piano si attiva per tempo.
+- **Non lasciare il pubblico senza informazioni** su uscite e punti di raccolta.
+{{< /cosa-non-fare >}}
+
+## Per approfondire
+
+**Sul nostro sito:**
+
+- [Allerte meteo](/allerte-meteo/) — come leggere i livelli di allerta prima e durante l'evento.
+- [Rischi e prevenzione](/rischi-prevenzione/) — temporali, vento forte, ondate di calore.
+- [Numeri utili](/numeri-utili/) — 112, 803 555 e tutti i recapiti di emergenza.
+- [Contatti](/contatti/) — per coordinare con il Gruppo tramite il Comune.
+
+**Fonti istituzionali:**
+
+- [Circolare DPC del 6 agosto 2018 — Manifestazioni pubbliche](https://www.protezionecivile.gov.it/it/normativa/circolare-del-6-agosto-2018-manifestazioni-pubbliche-precisazioni-sullattivazione-e-limpiego-del-volontariato-di-protezione-civile/).
+- [Ministero dell'Interno](https://www.interno.gov.it/) — indicazioni su safety e security delle manifestazioni pubbliche.
+
+{{< chi-chiamare >}}

--- a/hugo.toml
+++ b/hugo.toml
@@ -86,7 +86,7 @@ enableGitInfo = true
   url = "/"
   weight = 1
 
-# --- Dropdown: Per il Cittadino (7 voci) ---
+# --- Dropdown: Per il Cittadino (9 voci) ---
 [[menus.main]]
   name = "Per il Cittadino"
   identifier = "per-il-cittadino"
@@ -138,11 +138,21 @@ enableGitInfo = true
   parent = "per-il-cittadino"
   weight = 7
 
+# Aggiunta giugno 2026: schede di preparazione all'emergenza per chi
+# gestisce un luogo o un gruppo di persone (negozio, condominio,
+# associazione, evento). Parallele ai kit-calamita (rivolti alle persone),
+# ma rivolte all'organizzazione-come-entità.
+[[menus.main]]
+  name = "Kit per le organizzazioni"
+  url = "/kit-organizzazioni/"
+  parent = "per-il-cittadino"
+  weight = 8
+
 [[menus.main]]
   name = "Cruscotto del territorio"
   url = "/cruscotto/"
   parent = "per-il-cittadino"
-  weight = 8
+  weight = 9
 
 # --- Dropdown: Per le scuole (7 voci didattiche) ---
 # (rinominato da "Educazione e Inclusione" a maggio 2026 — splittato per

--- a/static/app-shared/site-chrome.js
+++ b/static/app-shared/site-chrome.js
@@ -75,7 +75,7 @@
                  * apre un'issue settimanale se trova drift.
                  */
                 '<li class="nav-item" role="none"><a class="nav-link" href="' + SITE_URL + '/" role="menuitem"><span>Home</span></a></li>' +
-                /* Dropdown: Per il Cittadino (7 voci, +Kit pronti maggio 2026) */
+                /* Dropdown: Per il Cittadino (9 voci, +Kit organizzazioni giugno 2026) */
                 '<li class="nav-item dropdown" role="none">' +
                   '<a class="nav-link dropdown-toggle" href="#" id="navDropdown-per-il-cittadino" role="menuitem" data-bs-toggle="dropdown" aria-expanded="false">' +
                     '<span>Per il Cittadino</span>' +
@@ -89,6 +89,7 @@
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/numeri-utili/" role="menuitem"><span>Numeri Utili</span></a></li>' +
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/piano-familiare/" role="menuitem"><span>Piano Familiare</span></a></li>' +
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/formazione/kit-calamita/" role="menuitem"><span>Kit pronti per situazioni vulnerabili</span></a></li>' +
+                    '<li role="none"><a class="list-item" href="' + SITE_URL + '/kit-organizzazioni/" role="menuitem"><span>Kit per le organizzazioni</span></a></li>' +
                     '<li role="none"><a class="list-item" href="' + SITE_URL + '/cruscotto/" role="menuitem"><span>Cruscotto del territorio</span></a></li>' +
                   '</ul></div></div>' +
                 '</li>' +


### PR DESCRIPTION
## Cosa aggiunge

Nuova famiglia di schede di preparazione all'emergenza rivolte all'**organizzazione-come-entità**, parallela ai `kit-calamita` (che sono rivolti alle *persone* vulnerabili). Colma il vuoto "toolkit per organizzazioni" rilevato dall'audit esterno del 15/06/2026, sul modello *Ready Business* (FEMA) e *Prepare* (UK) adattato ai Castelli Romani.

Sezione `/kit-organizzazioni/`:
- **Hub** (`_index.md`) — auto-elenca le 4 schede.
- **Attività commerciali** — negozi/bar/ristoranti: clienti+dipendenti, vie di fuga, kit, terremoto/incendio/allerta/blackout.
- **Condominio** — amministratore+residenti: punto di raccolta, fragili ai piani, gas/ascensori.
- **Associazioni e sedi** — referenti+volontari: piano interno, registro presenze, fragili.
- **Organizzatori di eventi** — responsabilità di sicurezza dell'organizzatore.

## Conformità

- **Gate Circolare DPC 6/8/2018** (scheda eventi): nessun compito di viabilità/regolazione traffico/palette attribuito al volontariato; disclaimer normativo con link e artt. 11-12 C.d.S. Validato dall'agent `pc-article-reviewer` (conforme + 3 ritocchi AGID).
- Struttura uniforme PRIMA/DURANTE/DOPO + `cosa-non-fare` + `chi-chiamare` (coerenza WCAG 3.2.3/3.2.4).
- Fonti istituzionali citate (D.Lgs. 81/2008, VVF, DPC, circolare Gabrielli 7/6/2017); nessun dato inventato.
- Voce di menu "Kit per le organizzazioni" sotto **Per il Cittadino**, sincronizzata in `hugo.toml` **e** `site-chrome.js` (rule 04b § sincronizzazione).

## Verifica

- Build Hugo pulita (exit 0). Le 5 pagine rendono, l'hub auto-elenca le schede, la voce di menu compare in home.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8ydnYzsg2Yfyba1nkwtoj)_