### PR TITLE
Schede allerta per colore tarate su Genzano (verde/giallo/arancione/rosso)

### DIFF
--- a/content/allerte-meteo/_index.md
+++ b/content/allerte-meteo/_index.md
@@ -102,6 +102,10 @@ Il codice colore dipende dagli effetti attesi, non solo dalla quantità di piogg
 
 ## Significato dei codici colore
 
+{{< callout tipo="info" titolo="Cosa cambia colore per colore qui a Genzano" >}}
+Per ogni livello — verde, giallo, arancione, rosso — abbiamo preparato una scheda che spiega **cosa significa concretamente a Genzano**, quali zone sono più delicate e cosa fa il Comune con il Gruppo: [Allerta meteo: cosa significa a Genzano, colore per colore](/allerte-meteo/cosa-significa-a-genzano/).
+{{< /callout >}}
+
 {{< callout tipo="avviso" titolo="Verde non vuol dire rischio zero" >}}
 L'assenza di allerta significa che **non sono previsti fenomeni significativi**, non che il rischio sia nullo. La preparazione si fa **prima**, quando il cielo è sereno: tieni pronto il [kit di emergenza](/rischi-prevenzione/kit-emergenza/), conosci le aree di attesa del tuo quartiere e compila il [Piano Familiare](/piano-familiare/). Quando arriva l'allerta è troppo tardi per organizzarsi.
 {{< /callout >}}

--- a/content/allerte-meteo/cosa-significa-a-genzano.md
+++ b/content/allerte-meteo/cosa-significa-a-genzano.md
@@ -1,0 +1,73 @@
+---
+title: "Allerta meteo: cosa significa a Genzano, colore per colore"
+description: "Cosa cambia davvero a Genzano di Roma per ogni livello di allerta — verde, giallo, arancione, rosso: zone più delicate, cosa fai tu, cosa fa il Comune."
+layout: "single"
+tts: true
+sitemap:
+  priority: 0.85
+  changefreq: monthly
+aliases:
+  - /allerte-meteo/livelli-a-genzano/
+dataUltimaRevisione: "2026-06-15"
+---
+
+I codici colore dell'allerta meteo — verde, giallo, arancione, rosso — sono uguali in tutta Italia. Ma **cosa cambia concretamente per chi vive a Genzano** quando il livello sale? Questa pagina traduce ogni colore nel nostro territorio: cosa significa, quali zone sono più delicate, cosa fai tu e cosa fa il Comune con il Gruppo.
+
+Genzano di Roma rientra nella **Zona di allerta F — Bacini Costieri Sud** del sistema regionale. Il livello lo decide il **Centro Funzionale Regionale del Lazio**, non il Gruppo: noi riportiamo il dato e ti aiutiamo a capirlo. Il **colore in tempo reale** è nella barra in cima alla [homepage](/) e nella pagina [Allerte meteo](/allerte-meteo/).
+
+Perché conta il territorio: Genzano sorge sul bordo di un antico cratere del Vulcano Laziale e affaccia sul **lago di Nemi**, in una conca dai **versanti ripidi**. Questa morfologia — pendii acclivi, terreni piroclastici, conche che raccolgono l'acqua — rende il paese sensibile sia alle **frane e agli smottamenti** sui versanti, sia agli **allagamenti** nelle zone basse e lungo i fossi.
+
+## 🟢 Verde — Nessuna criticità
+
+| | |
+|---|---|
+| **Cosa significa a Genzano** | Nessun fenomeno significativo atteso. Situazione ordinaria sul territorio dei Castelli. |
+| **Zone più delicate** | Nessuna in particolare. |
+| **Cosa fai tu** | Vita normale. Resta informato seguendo i canali ufficiali. |
+| **Cosa fa il Comune e il Gruppo** | Monitoraggio ordinario. Il Centro Operativo Comunale (COC) non è attivo. |
+
+## 🟡 Giallo — Criticità ordinaria (attenzione)
+
+| | |
+|---|---|
+| **Cosa significa a Genzano** | Possibili temporali isolati o piogge moderate. Nelle zone basse e lungo i fossi possono verificarsi allagamenti localizzati e ruscellamento. |
+| **Zone più delicate** | Sottopassi, fossi e caditoie, strade in pendenza verso le conche, locali interrati. |
+| **Cosa fai tu** | Attenzione ai sottopassi e ai corsi d'acqua. Non sostare sotto alberi isolati. Tieni d'occhio i bollettini. |
+| **Cosa fa il Comune e il Gruppo** | Il Comune valuta il bollettino. Di norma il COC non si attiva per il solo giallo, ma il Gruppo resta in pre-allerta. |
+
+## 🟠 Arancione — Criticità moderata (preallarme)
+
+| | |
+|---|---|
+| **Cosa significa a Genzano** | Fenomeni diffusi e potenzialmente pericolosi. Rischio di allagamenti rapidi nelle zone basse e lungo i fossi, ruscellamento e possibili smottamenti sui versanti ripidi del cratere e verso il lago di Nemi. |
+| **Zone più delicate** | Versanti del cratere e affaccio sul lago di Nemi, fossi e zone depresse, sottopassi, locali interrati. |
+| **Cosa fai tu** | Limita gli spostamenti allo stretto necessario. Metti in sicurezza i beni nei locali interrati e non scendere in cantine o garage. Controlla i familiari fragili. Tieni pronto il [kit di emergenza](/rischi-prevenzione/kit-emergenza/). |
+| **Cosa fa il Comune e il Gruppo** | Il Comune può attivare il COC. Con il COC attivo, il Gruppo può essere convocato per turni di presidio e supporto. |
+
+## 🔴 Rosso — Criticità elevata (allarme)
+
+| | |
+|---|---|
+| **Cosa significa a Genzano** | Fenomeni molto intensi con elevata probabilità di danni: possibili frane sui versanti, allagamenti estesi nelle zone basse, strade interrotte. |
+| **Zone più delicate** | Tutte quelle dei livelli precedenti, con rischio aggravato: versanti, fossi, zone depresse, sottopassi, piani interrati. |
+| **Cosa fai tu** | Resta in luogo sicuro, ai piani alti. Non uscire se non per un'evacuazione disposta dall'autorità. Non attraversare strade allagate né sottopassi. Segui solo fonti ufficiali e tieni il telefono carico. Se devi evacuare, raggiungi la tua [area di attesa](/aree-attesa/). |
+| **Cosa fa il Comune e il Gruppo** | Il COC è attivo. Il Gruppo opera su turni di presidio e supporto, su mandato del Comune. Possibile attivazione delle aree di attesa. |
+
+## Il tuo indirizzo è in zona a pericolosità?
+
+L'allerta dice cosa può succedere **oggi**; la **pericolosità** dice dove un fenomeno può avvenire in generale, ed è mappata parcella per parcella. Per verificare un indirizzo specifico consulta la piattaforma **[IdroGEO di ISPRA](https://idrogeo.isprambiente.it/)**, il **Piano di Assetto Idrogeologico (PAI)** e la nostra [Cartografia del territorio](/cartografia/).
+
+## Per approfondire
+
+**Sul nostro sito:**
+
+- [Allerte meteo](/allerte-meteo/) — il livello attuale e i dettagli.
+- [Cosa succede quando scatta un'allerta](/cosa-succede-quando-scatta-allerta/) — chi decide il colore e chi attiva il COC.
+- [Aree di attesa](/aree-attesa/) — dove andare in caso di evacuazione.
+- [Rischio idrogeologico](/rischi-prevenzione/rischio-idrogeologico/) — frane e allagamenti nel dettaglio.
+
+**Fonti istituzionali:**
+
+- [Bollettino del Centro Funzionale Regionale Lazio](https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti) — il dato ufficiale in tempo reale.
+
+{{< chi-chiamare >}}

--- a/content/cosa-succede-quando-scatta-allerta/_index.md
+++ b/content/cosa-succede-quando-scatta-allerta/_index.md
@@ -49,6 +49,8 @@ Sul nostro sito la barra in cima alla [homepage](/) mostra **il livello attuale*
 | 🟠 **Arancione** | Criticità moderata | Evita uscite non necessarie nella finestra di allerta. Metti in sicurezza balconi, garage, cantine. Controlla famigliari fragili. |
 | 🔴 **Rosso** | Criticità elevata | Resta in luogo sicuro. Segui solo fonti ufficiali. Non muoverti se non in evacuazione disposta dall'autorità. |
 
+Per il dettaglio sul **nostro territorio** — zone più delicate e azioni per ogni colore — vedi [Allerta meteo: cosa significa a Genzano, colore per colore](/allerte-meteo/cosa-significa-a-genzano/).
+
 {{< callout tipo="avviso" titolo="Gialla non significa «pericolo nullo»" >}}
 È prevista una criticità ordinaria: la maggior parte degli eventi non produce danni, ma alcuni possono. La prudenza è dovuta.
 {{< /callout >}}


### PR DESCRIPTION
## Cosa aggiunge

Nuova pagina **`/allerte-meteo/cosa-significa-a-genzano/`** che traduce ogni colore di allerta sul territorio reale di Genzano. Per ciascun livello (verde, giallo, arancione, rosso) risponde a 4 domande: cosa significa a Genzano, quali zone sono più delicate, cosa fai tu, cosa fa il Comune con il Gruppo. Colma il punto "scheda locale per colore di allerta" dell'audit del 15/06/2026 (modello DPC / Allerta Emilia-Romagna).

## Fonti (tutte già nel repo / sito)

- **Zona di allerta F — Bacini Costieri Sud** e morfologia (cratere del Vulcano Laziale, lago di Nemi, versanti ripidi, fossi) da `rischio-idrogeologico`.
- Significato e comportamenti per livello da `data/codici_colore.yaml`.
- Logica COC e ruolo del Gruppo da `cosa-succede-quando-scatta-allerta`.
- Aree di attesa e cartografia.

**NO INVENZIONI:** le "zone più delicate" sono descritte per tipologia (versanti, fossi, sottopassi, piani interrati), già pubblicate; per le aree puntuali la pagina rimanda a IdroGEO/ISPRA, PAI e Cartografia, senza inventare vie.

## Discoverability

Cross-link aggiunti da `/allerte-meteo/` (callout) e `/cosa-succede-quando-scatta-allerta/` (sotto la tabella dei 4 colori).

## Verifica

Build Hugo pulita (exit 0); pagina resa con i 4 blocchi colore; chiusura con `chi-chiamare` (Gruppo non attivabile direttamente dai cittadini); refuso corretto.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8ydnYzsg2Yfyba1nkwtoj)_