### PR TITLE
Sincronizza documentazione e assistente con le novità dell'audit

### DIFF
--- a/MANUALE-SITO.md
+++ b/MANUALE-SITO.md
@@ -94,6 +94,24 @@ Se non sai in quale Parte cercare:
 
 ## 📜 Changelog
 
+> **3.2 (2026-06-15) — Audit esterno: 3 interventi**
+> Recepiti i punti azionabili di un audit esterno del sito:
+> - **Guard anti-dato-stantio** sullo stato allerta: lo shortcode
+>   `allerta-stato-attuale` avvisa se `ultimo_controllo` della fonte supera
+>   12 ore (build-time Hugo + mini-script client-side per HTML congelato),
+>   invece di lasciar credere fresco uno stato anche verde.
+> - **Kit per le organizzazioni** (`/kit-organizzazioni/`): hub + 4 schede
+>   (attività commerciali, condominio, associazioni e sedi, organizzatori di
+>   eventi) sul modello Ready Business/Prepare. La scheda eventi rispetta il
+>   gate Circolare DPC 6/8/2018 (nessuna viabilità al volontariato). Voce di
+>   menu sotto *Per il Cittadino*, in mappa-sito e assistente.
+> - **Allerta: cosa significa a Genzano** (`/allerte-meteo/cosa-significa-a-genzano/`):
+>   per ogni colore, cosa significa sul territorio, zone più delicate, cosa fa
+>   il cittadino e cosa fa il Comune con il Gruppo. Fonti dal sito; aree
+>   puntuali rimandate a IdroGEO/PAI (NO INVENZIONI).
+> Dettagli nel `README.md` (sezioni dedicate). Resta da rigenerare a parte il
+> deck di presentazione (`scripts/genera-presentazione.py`, richiede LibreOffice).
+
 > **3.1 (2026-05-02) — Lettura accessibile per fasce deboli**
 > Cinque strumenti integrati per anziani, dislessici, italiano L2, bambini in
 > lettura lenta, persone in stress da emergenza:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ Materiali **rilasciati gratuitamente**, liberi e riutilizzabili da altri Comuni/
 
 Specifiche complete in [`manuale/parte-20-kit-calamita-categorie-vulnerabili.md`](manuale/parte-20-kit-calamita-categorie-vulnerabili.md).
 
+### Kit per le organizzazioni (`/kit-organizzazioni/`)
+
+Famiglia di schede di preparazione all'emergenza (giugno 2026) rivolte all'**organizzazione-come-entità**, parallela ai Kit Calamità (che sono rivolti alle *persone*). Sul modello *Ready Business* (FEMA) e *Prepare* (UK), adattate ai Castelli Romani. Colma il punto "toolkit per organizzazioni" emerso da un audit esterno del sito.
+
+Hub `/kit-organizzazioni/` (auto-elenca le schede) + 4 schede AGID a struttura uniforme PRIMA/DURANTE/DOPO + `{{< cosa-non-fare >}}` + `{{< chi-chiamare >}}`:
+
+| Scheda | Target |
+|---|---|
+| Attività commerciali | negozi, bar, ristoranti: clienti+dipendenti, vie di fuga, kit, 4 scenari |
+| Condominio | amministratore+residenti: punto di raccolta, fragili ai piani, gas/ascensori |
+| Associazioni e sedi | referenti+volontari: piano interno, registro presenze, fragili |
+| Organizzatori di eventi | sicurezza dell'organizzatore + **gate Circolare DPC 6/8/2018** (nessuna viabilità al volontariato) |
+
+Voce di menu **"Kit per le organizzazioni"** sotto *Per il Cittadino* (`hugo.toml` + `site-chrome.js`), presente in mappa-sito e assistente virtuale.
+
+### Allerta meteo: cosa significa a Genzano (`/allerte-meteo/cosa-significa-a-genzano/`)
+
+Pagina (giugno 2026) che traduce ogni colore di allerta sul territorio reale: per ciascun livello (verde/giallo/arancione/rosso) una tabella con **cosa significa a Genzano**, **zone più delicate**, **cosa fai tu**, **cosa fa il Comune con il Gruppo**. Fonti dal sito (Zona di allerta F — Bacini Costieri Sud, morfologia cratere/lago di Nemi, `codici_colore.yaml`, logica COC); le aree puntuali rimandano a IdroGEO/ISPRA e PAI (NO INVENZIONI). Cross-link da `/allerte-meteo/` e `/cosa-succede-quando-scatta-allerta/`.
+
+### Guard anti-dato-stantio sullo stato allerta
+
+Lo shortcode `allerta-stato-attuale` (in `/allerte-meteo/` e `/cruscotto/`) mostra un avviso neutro se `ultimo_controllo` della fonte supera **12 ore**, invece di lasciar credere fresco uno stato (anche verde) potenzialmente fermo. Doppio livello: controllo a build-time (Hugo) + mini-script client-side che rivaluta sull'orologio del visitatore (HTML congelato a deploy bloccato).
+
 ### Feed RSS pubblici (`/feed-rss/`)
 
 Hugo genera **39 feed RSS** automaticamente, uno per sezione del sito (homepage, comunicazioni, allerte, rischi, formazione, glossario, standard ISO, ecc.). Tutti i feed sono live su Aruba (`https://www.protezionecivilegenzano.it/<sezione>/index.xml`) e auto-discoverable via `<link rel="alternate" type="application/rss+xml">` nell'`<head>` di ogni pagina.

--- a/content/mappa-sito/_index.md
+++ b/content/mappa-sito/_index.md
@@ -160,6 +160,12 @@ In questa pagina trovi **tutte le sezioni del sito** organizzate per tema. Se sa
   <p class="ms-card-desc">Codici colore, sistema di allertamento, widget Windy/Radar DPC/MeteoAM, fonti ufficiali.</p>
   <span class="ms-card-arrow">Apri →</span>
 </a>
+<a class="ms-card ms-emerg" href="/allerte-meteo/cosa-significa-a-genzano/">
+  <div class="ms-card-icon"><i class="bi bi-palette-fill"></i></div>
+  <p class="ms-card-title">Allerta: cosa significa a Genzano</p>
+  <p class="ms-card-desc">Colore per colore (verde/giallo/arancione/rosso): cosa significa sul territorio, zone più delicate, cosa fai tu, cosa fa il Comune con il Gruppo.</p>
+  <span class="ms-card-arrow">Apri →</span>
+</a>
 <a class="ms-card ms-emerg" href="/numeri-utili/">
   <div class="ms-card-icon"><i class="bi bi-telephone-fill"></i></div>
   <p class="ms-card-title">Numeri Utili</p>
@@ -537,6 +543,36 @@ In questa pagina trovi **tutte le sezioni del sito** organizzate per tema. Se sa
   <div class="ms-card-icon"><i class="bi bi-shield-shaded"></i></div>
   <p class="ms-card-title">Kit Volontari PC (auto-cura)</p>
   <p class="ms-card-desc">IFRC Caring + NCTSN STS + WHO mhGAP + ProQOL-5. Auto-valutazione, decompressione.</p>
+</a>
+</div>
+
+<div class="ms-section"><span class="ms-section-icon" style="background:#003366"><i class="bi bi-shop"></i></span><h2>Kit per le organizzazioni</h2></div>
+
+<div class="ms-grid">
+<a class="ms-card ms-tool" href="/kit-organizzazioni/">
+  <div class="ms-card-icon"><i class="bi bi-buildings-fill"></i></div>
+  <p class="ms-card-title">Hub Kit Organizzazioni</p>
+  <p class="ms-card-desc">Schede di preparazione all'emergenza per chi gestisce un luogo o un gruppo di persone. Modello Ready Business/Prepare adattato ai Castelli Romani.</p>
+</a>
+<a class="ms-card ms-tool" href="/kit-organizzazioni/attivita-commerciali/">
+  <div class="ms-card-icon"><i class="bi bi-shop"></i></div>
+  <p class="ms-card-title">Attività commerciali</p>
+  <p class="ms-card-desc">Negozi, bar, ristoranti: clienti e dipendenti, vie di fuga, kit, terremoto/incendio/allerta/blackout.</p>
+</a>
+<a class="ms-card ms-tool" href="/kit-organizzazioni/condominio/">
+  <div class="ms-card-icon"><i class="bi bi-building"></i></div>
+  <p class="ms-card-title">Condominio</p>
+  <p class="ms-card-desc">Amministratore e residenti: punto di raccolta, persone fragili ai piani, gas e ascensori.</p>
+</a>
+<a class="ms-card ms-tool" href="/kit-organizzazioni/associazioni-e-sedi/">
+  <div class="ms-card-icon"><i class="bi bi-people-fill"></i></div>
+  <p class="ms-card-title">Associazioni e sedi</p>
+  <p class="ms-card-desc">Referenti e volontari: piano interno, registro presenze, persone fragili.</p>
+</a>
+<a class="ms-card ms-tool" href="/kit-organizzazioni/organizzatori-di-eventi/">
+  <div class="ms-card-icon"><i class="bi bi-calendar-event-fill"></i></div>
+  <p class="ms-card-title">Organizzatori di eventi</p>
+  <p class="ms-card-desc">Sicurezza di sagre, feste e manifestazioni; cosa può e non può fare il volontariato di PC (Circolare DPC 6/8/2018).</p>
 </a>
 </div>
 

--- a/themes/flavour-pcgenzano/layouts/assistente/list.html
+++ b/themes/flavour-pcgenzano/layouts/assistente/list.html
@@ -463,7 +463,8 @@
         { text: 'Rischi del territorio (sismico, idro, incendi)', next: 'info_cittadino_rischi' },
         { text: 'Cartografia operativa (aree di attesa)', next: 'info_cittadino_cartografia' },
         { text: 'Numeri utili (112 e altri)', next: 'info_cittadino_numeri' },
-        { text: 'Piano di emergenza familiare', next: 'info_cittadino_piano' }
+        { text: 'Piano di emergenza familiare', next: 'info_cittadino_piano' },
+        { text: 'Kit per le organizzazioni (negozi, condomìni, associazioni, eventi)', next: 'info_cittadino_organizzazioni' }
       ]
     },
     info_cittadino_cosa_fare: {
@@ -480,9 +481,22 @@
       title: 'Allerte meteo e codici colore',
       body: ['La Regione Lazio emette ogni giorno bollettini di allerta con livelli di colore: verde (nessuna), giallo (attenzione), arancione (elevata), rosso (massima). Lo stato attuale per Genzano è sempre visibile in cima alla homepage.'],
       links: [
+        { text: 'Cosa significa ogni colore a Genzano', url: '/allerte-meteo/cosa-significa-a-genzano/' },
         { text: 'Spiegazione codici colore', url: '/allerte-meteo/' },
         { text: 'Stato allerta attuale (homepage)', url: '/' },
         { text: 'Bollettino ufficiale Regione Lazio', url: 'https://protezionecivile.regione.lazio.it/gestione-emergenze/centro-funzionale/bollettini-allertamenti' }
+      ]
+    },
+    info_cittadino_organizzazioni: {
+      kind: 'answer',
+      title: 'Kit per le organizzazioni',
+      body: ['Se gestisci un negozio, un condominio, una sede di associazione o organizzi un evento, queste schede ti aiutano a preparare il tuo luogo e le persone all\'emergenza: piano, vie di fuga, kit, cosa fare per terremoto, incendio, allerta meteo e blackout.'],
+      links: [
+        { text: 'Hub Kit per le organizzazioni', url: '/kit-organizzazioni/' },
+        { text: 'Attività commerciali (negozi, bar, ristoranti)', url: '/kit-organizzazioni/attivita-commerciali/' },
+        { text: 'Condominio', url: '/kit-organizzazioni/condominio/' },
+        { text: 'Associazioni e sedi', url: '/kit-organizzazioni/associazioni-e-sedi/' },
+        { text: 'Organizzatori di eventi', url: '/kit-organizzazioni/organizzatori-di-eventi/' }
       ]
     },
     info_cittadino_rischi: {


### PR DESCRIPTION
## Cosa fa

Propaga (rule 07 — sincronizzazione docs dopo modifiche strutturali) le 3 aggiunte di oggi nei punti di documentazione e scopribilità:

- **README.md** — 3 nuove sezioni: *Kit per le organizzazioni*, *Allerta: cosa significa a Genzano*, *Guard anti-dato-stantio*.
- **MANUALE-SITO.md** — voce changelog **3.2 (2026-06-15)**.
- **content/mappa-sito** — card della pagina allerta per-colore (sezione "Allerte ed emergenze") + nuova sezione "Kit per le organizzazioni" (hub + 4 schede).
- **Assistente virtuale** (`assistente/list.html`) — link alla scheda per-colore nel nodo allerte; nuova voce **"Kit per le organizzazioni"** + nodo risposta nel ramo *Per il cittadino*.

## Verifica

- Build Hugo pulita (exit 0).
- mappa-sito: card nuove rese; assistente: nodo/opzione resi.
- **JS dell'assistente validato** con `node --check` sullo script inline (sintassi OK) — un errore qui non rompe la build ma romperebbe l'assistente a runtime.

## Nota

Resta da rigenerare a parte il **deck di presentazione** (`scripts/genera-presentazione.py`, richiede LibreOffice/venv non disponibili in cloud).

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8ydnYzsg2Yfyba1nkwtoj)_